### PR TITLE
Catch JSONDecodeError

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -25,6 +25,10 @@ Read Config
     [Arguments]  ${file_path}=../config/test_config.json
 
     ${file_data}=    OperatingSystem.Get File    ${file_path}
-    ${source_data}=    Evaluate    json.loads('''${file_data}''')    json
+    TRY
+        ${source_data}=    Evaluate    json.loads('''${file_data}''')    json
+    EXCEPT
+        FAIL    Couldn't parse test config ${file_path}
+    END
 
     RETURN  ${source_data}


### PR DESCRIPTION
Error in the config parsing caused revealing of the file content in logs. 
Adding catching of Error and failing with custom error message will help to avoid revealing of sensetive data