### PR TITLE
Add autotest for Ghaf versioning

### DIFF
--- a/Robot-Framework/lib/output_parser.py
+++ b/Robot-Framework/lib/output_parser.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
+from datetime import datetime
 
 
 def get_systemctl_status(output):
@@ -42,3 +43,19 @@ def verify_shutdown_status(output):
         return match.group(1), match.group(2)
     else:
         raise Exception("Couldn't parse shutdown status")
+
+def verify_version_format(output):
+    version = output.split('.')
+
+def parse_version(output):
+    versions = output.split(' ')
+    name = versions[1][1:-1] if len(versions) > 1 else None
+    major, minor, date, commit = versions[0].split(".")
+    version = f"{major}.{minor}"
+    return version, date, commit, name
+
+def verify_date_format(date_string):
+    try:
+        datetime.strptime(date_string, '%Y%m%d')
+    except ValueError:
+        raise Exception("Wrong date format in version date field")

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -134,3 +134,22 @@ Create file
     [Arguments]        ${file_name}
     Execute Command    touch ${file_name}  sudo=True  sudo_password=${password}
     SSHLibrary.File Should Exist  ${file_name}
+
+Verify Version Format
+    [Documentation]    Check that ghaf-version contains date of commit in format yyyymmdd, 7 symbols of hash commit
+    ...                and returns the same NixOS version as the command "nixos-version"
+    ${nixos_version}  ${_}       ${_}       ${_}    Get Version    nixos
+    ${ghaf_version}   ${date}    ${commit}  ${_}    Get Version    ghaf
+    Should Be Equal As Strings   ${nixos_version}   ${ghaf_version}
+    Verify Date Format    ${date}
+    Should Match Regexp	  ${commit}   ^[0-9a-f]{7}$
+
+Get Version
+    [Documentation]    Get version of NixOS or Ghaf system, Examples:
+    ...     "ghaf-version"    output: 23.05.20230628.92414ab            parse result: 23.05, 20230628, 92414ab
+    ...     "nixos-version"   output: 23.05.20230625.35130d4 (Stoat)    parse result: 23.05, 20230625, 35130d4, Stoat
+    [Arguments]  ${whose}
+    ${output}   ${rc}    Execute Command   ${whose}-version   return_rc=True
+    Should Be Equal As Integers     ${rc}   0   Couldn't get ghaf version, command return code
+    ${version}  ${date}  ${commit}  ${name}     Parse Version   ${output}
+    [Return]    ${version}  ${date}  ${commit}  ${name}

--- a/Robot-Framework/test-suites/boot_test.robot
+++ b/Robot-Framework/test-suites/boot_test.robot
@@ -17,8 +17,8 @@ ${IS_AVAILABLE}          False
 *** Test Cases ***
 
 Verify booting after restart by power
-    [Tags]    boot  plug
     [Documentation]    Restart device by power and verify systemctl status is running
+    [Tags]             boot  plug
     Reboot Device
     Check If Device Is Up
     IF    ${IS_AVAILABLE} == False
@@ -32,6 +32,13 @@ Verify booting after restart by power
     ELSE IF  "${CONNECTION_TYPE}" == "serial"
         Verify Systemctl status via serial
     END
+
+Test version format
+    [Documentation]    Test getting version of the system including NixOS version, date and hash of commit
+    [Tags]             bat   SP-T59
+    [Setup]     Connect
+    Verify Version Format
+    [Teardown]  Close All Connections
 
 
 *** Keywords ***


### PR DESCRIPTION
Check that ghaf-version contains the date of commit in format yyyymmdd, 7 symbols of hash commit and returns the same NixOS version as the command "nixos-version"


Signed-off-by: Mariia Azbeleva <mariia.azbeleva@unikie.com>