### PR TITLE
Flake and ghaf-robot wrapper script for running the Robot Framework test suites on Nix/NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,21 @@
 
 Jenkinsfiles, Robot framework suites, libraries and requirements for running tests to ghaf-project nixOS with real HW.
 
+## Nix Flake usage
+
+### Basic test running
+
+To enter a shell which has the `ghaf-robot` wrapper for running the Robot
+Framework, run `nix shell`.
+
+Alternatively, you can build the package with `nix build` and the wrapper will
+appear at `result/bin/ghaf-robot`.
+
+### Devshell
+
+To enter a devshell, where you can run `robot` (instead of the wrapper) and all
+the Python dependencies are available, run `nix develop`.
+
 ## drcontrol.py
 
 For more information, see [drcontrol-README.md](./drcontrol/drcontrol-README.md).

--- a/Robot-Framework/default.nix
+++ b/Robot-Framework/default.nix
@@ -1,0 +1,1 @@
+{hello}: hello

--- a/Robot-Framework/default.nix
+++ b/Robot-Framework/default.nix
@@ -1,1 +1,0 @@
-{hello}: hello

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1692134936,
+        "narHash": "sha256-Z68O969cioC6I3k/AFBxsuEwpJwt4l9fzwuAMUhCCs0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "bfd953b2c6de4f550f75461bcc5768b6f966be10",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
       packages = rec {
         ghaf-robot = pkgs.callPackage ./Robot-Framework {};
         robotframework-seriallibrary = pkgs.python3Packages.callPackage ./pkgs/robotframework-seriallibrary { };
+        robotframework-advancedlogging = pkgs.python3Packages.callPackage ./pkgs/robotframework-advancedlogging { };
         pkcs7 = pkgs.python3Packages.callPackage ./pkgs/pkcs7 { }; # Requirement of PyP100
         PyP100 = pkgs.python3Packages.callPackage ./pkgs/PyP100 { inherit pkcs7; };
         default = ghaf-robot;
@@ -34,6 +35,7 @@
             with ps; [
               robotframework
               self.packages.${system}.robotframework-seriallibrary
+              self.packages.${system}.robotframework-advancedlogging
               self.packages.${system}.PyP100
               robotframework-sshlibrary
               pyserial

--- a/flake.nix
+++ b/flake.nix
@@ -19,9 +19,12 @@
     flake-utils.lib.eachSystem systems (system: let
       pkgs = nixpkgs.legacyPackages.${system};
     in {
-        packages.ghaf-robot = pkgs.callPackage ./Robot-Framework {};
-        packages.robotframework-seriallibrary = pkgs.python3Packages.callPackage ./pkgs/robotframework-seriallibrary {
-        packages.default = self.packages.${system}.ghaf-robot;
+      packages = rec {
+        ghaf-robot = pkgs.callPackage ./Robot-Framework {};
+        robotframework-seriallibrary = pkgs.python3Packages.callPackage ./pkgs/robotframework-seriallibrary { };
+        pkcs7 = pkgs.python3Packages.callPackage ./pkgs/pkcs7 { }; # Requirement of PyP100
+        PyP100 = pkgs.python3Packages.callPackage ./pkgs/PyP100 { inherit pkcs7; };
+        default = ghaf-robot;
       };
 
       # Development shell
@@ -31,6 +34,7 @@
             with ps; [
               robotframework
               self.packages.${system}.robotframework-seriallibrary
+              self.packages.${system}.PyP100
               robotframework-sshlibrary
               pyserial
             ]))

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "A flake for for running Robot Framework tests";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }: let
+    systems = with flake-utils.lib.system; [
+      x86_64-linux
+      aarch64-linux
+    ];
+  in
+    flake-utils.lib.eachSystem systems (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      packages.ghaf-robot = pkgs.callPackage ./Robot-Framework {};
+      packages.default = self.packages.${system}.ghaf-robot;
+
+      # Development shell
+      devShell = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          (python3.withPackages (ps:
+            with ps; [
+              robotframework
+              robotframework-sshlibrary
+              pyserial
+            ]))
+        ];
+      };
+
+      # Allows formatting files with `nix fmt`
+      formatter = pkgs.alejandra;
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,10 @@
     flake-utils.lib.eachSystem systems (system: let
       pkgs = nixpkgs.legacyPackages.${system};
     in {
-      packages.ghaf-robot = pkgs.callPackage ./Robot-Framework {};
-      packages.default = self.packages.${system}.ghaf-robot;
+        packages.ghaf-robot = pkgs.callPackage ./Robot-Framework {};
+        packages.robotframework-seriallibrary = pkgs.python3Packages.callPackage ./pkgs/robotframework-seriallibrary {
+        packages.default = self.packages.${system}.ghaf-robot;
+      };
 
       # Development shell
       devShell = pkgs.mkShell {
@@ -28,6 +30,7 @@
           (python3.withPackages (ps:
             with ps; [
               robotframework
+              self.packages.${system}.robotframework-seriallibrary
               robotframework-sshlibrary
               pyserial
             ]))

--- a/flake.nix
+++ b/flake.nix
@@ -20,11 +20,15 @@
       pkgs = nixpkgs.legacyPackages.${system};
     in {
       packages = rec {
-        ghaf-robot = pkgs.callPackage ./Robot-Framework {};
-        robotframework-seriallibrary = pkgs.python3Packages.callPackage ./pkgs/robotframework-seriallibrary { };
-        robotframework-advancedlogging = pkgs.python3Packages.callPackage ./pkgs/robotframework-advancedlogging { };
-        pkcs7 = pkgs.python3Packages.callPackage ./pkgs/pkcs7 { }; # Requirement of PyP100
-        PyP100 = pkgs.python3Packages.callPackage ./pkgs/PyP100 { inherit pkcs7; };
+        ghaf-robot = pkgs.callPackage ./pkgs/ghaf-robot {
+          PyP100 = self.packages.${system}.PyP100;
+          robotframework-advancedlogging = self.packages.${system}.robotframework-advancedlogging;
+          robotframework-seriallibrary = self.packages.${system}.robotframework-seriallibrary;
+        };
+        robotframework-seriallibrary = pkgs.python3Packages.callPackage ./pkgs/robotframework-seriallibrary {};
+        robotframework-advancedlogging = pkgs.python3Packages.callPackage ./pkgs/robotframework-advancedlogging {};
+        pkcs7 = pkgs.python3Packages.callPackage ./pkgs/pkcs7 {}; # Requirement of PyP100
+        PyP100 = pkgs.python3Packages.callPackage ./pkgs/PyP100 {inherit pkcs7;};
         default = ghaf-robot;
       };
 

--- a/pkgs/PyP100/default.nix
+++ b/pkgs/PyP100/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   pycryptodome,
   pkcs7,
-  requests
+  requests,
 }:
 buildPythonPackage rec {
   version = "0.1.2";

--- a/pkgs/PyP100/default.nix
+++ b/pkgs/PyP100/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pycryptodome,
+  pkcs7,
+  requests
+}:
+buildPythonPackage rec {
+  version = "0.1.2";
+  pname = "PyP100";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "fishbigger";
+    repo = "TapoP100";
+    rev = "43f51a03ab7a647f81682f7b39ceb2afdd04d3a1";
+    sha256 = "sha256-aMrjoh4n5Ygu1hT8BYW2Zez4s33FZqoscN9O2Uga4Ls=";
+  };
+
+  # unit tests are impure
+  # doCheck = false;
+
+  propagatedBuildInputs = [
+    pycryptodome
+    pkcs7
+    requests
+  ];
+
+  meta = with lib; {
+    description = "A library for controlling the Tp-link Tapo P100/P105/P110 plugs and L530/L510E bulbs.";
+    homepage = "https://github.com/fishbigger/TapoP100";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/ghaf-robot/default.nix
+++ b/pkgs/ghaf-robot/default.nix
@@ -1,0 +1,29 @@
+{
+  PyP100,
+  python3,
+  robotframework-advancedlogging,
+  robotframework-seriallibrary,
+  stdenv,
+  writeShellApplication,
+}:
+writeShellApplication {
+  name = "ghaf-robot";
+  runtimeInputs = [
+    (python3.withPackages (ps: [
+      # These are taken from nixpkgs
+      ps.robotframework
+      ps.robotframework-sshlibrary
+      ps.pyserial
+
+      # These are taken from this flake
+      robotframework-advancedlogging
+      robotframework-seriallibrary
+      PyP100
+    ]))
+  ];
+  text = ''
+    # A shell script which runs Robot Framework in an environment where all the
+    # required dependency Python modules are present.
+    exec robot "$@"
+  '';
+}

--- a/pkgs/pkcs7/default.nix
+++ b/pkgs/pkcs7/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "python package pkcs7 conform for the RFC5652.";
-    homepage = ""https://github.com/jeppeter/pypkcs7;
+    homepage = "https://github.com/jeppeter/pypkcs7";
     license = licenses.mit;
   };
 }

--- a/pkgs/pkcs7/default.nix
+++ b/pkgs/pkcs7/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+}:
+buildPythonPackage rec {
+  version = "0.1.2";
+  pname = "pkcs7";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "jeppeter";
+    repo = "pypkcs7";
+    rev = "f8ec81ef4dc7ef061cb15e35b869dccc544e6ddc";
+    sha256 = "sha256-MAta84Z0q/C5AUU+tNAPQuqPFLgPDbw8J3OCN4g4LB4=";
+  };
+
+  postPatch = ''
+    python make_setup.py
+    # Move sources to folder, where setup.py search for them
+    mv src/pkcs7 pkcs7
+  '';
+
+  # unit tests are impure
+  # doCheck = false;
+
+  meta = with lib; {
+    description = "python package pkcs7 conform for the RFC5652.";
+    homepage = ""https://github.com/jeppeter/pypkcs7;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/robotframework-advancedlogging/default.nix
+++ b/pkgs/robotframework-advancedlogging/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  robotframework 
+  robotframework,
 }:
 buildPythonPackage rec {
   version = "2.0.0";

--- a/pkgs/robotframework-advancedlogging/default.nix
+++ b/pkgs/robotframework-advancedlogging/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  robotframework 
+}:
+buildPythonPackage rec {
+  version = "2.0.0";
+  pname = "robotframework-advancedlogging";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "peterservice-rnd";
+    repo = "robotframework-advancedlogging";
+    rev = "4f982c09804024273f25de946b43a3a72428a296";
+    sha256 = "sha256-eMdlj8zWP7DVh+U6DHJFiPNFyPENrLDWBh0qF2g6dWM=";
+  };
+
+  # unit tests are impure
+  # doCheck = false;
+
+  propagatedBuildInputs = [
+    robotframework
+  ];
+
+  meta = with lib; {
+    description = "RobotFramework Advanced Logging Library.";
+    homepage = "RobotFramework Advanced Logging Library";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/robotframework-seriallibrary/default.nix
+++ b/pkgs/robotframework-seriallibrary/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchpatch2,
+  fetchPypi,
+  robotframework,
+  pyserial,
+  poetry-core
+}:
+buildPythonPackage rec {
+  version = "0.4.3";
+  pname = "robotframework-seriallibrary";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-8gvv5cEQbdjdyp9govGL9ex9Xwb28JoD+ma65Ud35rs";
+  };
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://patch-diff.githubusercontent.com/raw/whosaysni/robotframework-seriallibrary/pull/23.diff";
+      sha256 = "sha256-fuPH+LkCuZBFCWRc1oCsTiqq/i2EsYJwaUh4hrdIJnw=";
+    })
+  ];
+
+  # unit tests are impure
+  # doCheck = false;
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    robotframework
+    pyserial
+  ];
+
+  meta = with lib; {
+    description = "Robot Framework test library for serial connection";
+    homepage = "https://github.com/whosaysni/robotframework-seriallibrary/blob/develop";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/robotframework-seriallibrary/default.nix
+++ b/pkgs/robotframework-seriallibrary/default.nix
@@ -5,7 +5,7 @@
   fetchPypi,
   robotframework,
   pyserial,
-  poetry-core
+  poetry-core,
 }:
 buildPythonPackage rec {
   version = "0.4.3";


### PR DESCRIPTION
This flake provides a wrapper `ghaf-robot` script to run Robot Framework in an environment where all the required dependency Python modules are present. Additionally few required Python library packages are provided, and also devshell environment is provided.