### PR TITLE
Use tapop100 lib for Tapo Plugs HW ver2

### DIFF
--- a/Robot-Framework/lib/PlugLibrary/PlugLibrary.py
+++ b/Robot-Framework/lib/PlugLibrary/PlugLibrary.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 from KasaPlug import KasaPlug
 from TapoP100 import TapoP100
+from TapoP100v2 import TapoP100v2
 from robot.libraries.BuiltIn import BuiltIn
 
 
@@ -13,23 +15,30 @@ from robot.libraries.BuiltIn import BuiltIn
 # * Kasa Plug:
 #   -v PLUG_TYPE:KASAPLUG (needs only SOCKET_IP_ADDRESS)
 #
+# * Tapo Plug Hardware Version 2.0:
+#   -v PLUG_TYPE:TAPOP100v2 (needs only SOCKET_IP_ADDRESS)
+#
 class PlugLibrary:
     def __init__(self, *args, **kwargs):
         self._plug = None
+        self._plug_type = "TAPOP100"
 
     def _get_plug(self):
         if not self._plug:
             # Setting self._plug for the first time
-            plug_type = self._get_plug_type()
-            if plug_type == "TAPOP100":
+            self._plug_type = self._get_plug_type()
+            if self._plug_type == "TAPOP100":
                 self._plug = TapoP100()
-            elif plug_type == "KASAPLUG":
+            elif self._plug_type == "KASAPLUG":
                 self._plug = KasaPlug()
+            elif self._plug_type == "TAPOP100v2":
+                self._plug = TapoP100v2()
+        print(f"plug type: {self._plug_type}")
         return self._plug
 
     # Return TAPOP100 if PLUG_TYPE is not known
     def _get_plug_type(self):
-        allowed_types = ["TAPOP100", "KASAPLUG"]
+        allowed_types = ["TAPOP100", "KASAPLUG", "TAPOP100v2"]
         raw = BuiltIn().get_variable_value("${PLUG_TYPE}")
         if raw in allowed_types:
             return raw
@@ -38,7 +47,13 @@ class PlugLibrary:
             return allowed_types[0]
 
     def turn_plug_on(self):
-        self._get_plug().turn_plug_on()
+        if self._plug_type == "TAPOP100v2":
+            asyncio.run(self._get_plug().turn_plug_on())
+        else:
+            self._get_plug().turn_plug_on()
 
     def turn_plug_off(self):
-        self._get_plug().turn_plug_off()
+        if self._get_plug_type() == "TAPOP100v2":
+            asyncio.run(self._get_plug().turn_plug_off())
+        else:
+            self._get_plug().turn_plug_off()

--- a/Robot-Framework/lib/PlugLibrary/TapoP100v2.py
+++ b/Robot-Framework/lib/PlugLibrary/TapoP100v2.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2022-2023 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+from robot.libraries.BuiltIn import BuiltIn
+from plugp100.api.tapo_client import TapoClient
+from plugp100.common.credentials import AuthCredential
+from plugp100.api.plug_device import PlugDevice
+
+
+class TapoP100v2:
+
+    def __init__(self):
+        self._p100 = None
+
+    async def _get_p100(self):
+        ip_address = BuiltIn().get_variable_value("${SOCKET_IP_ADDRESS}")
+        username = BuiltIn().get_variable_value("${PLUG_USERNAME}")
+        password = BuiltIn().get_variable_value("${PLUG_PASSWORD}")
+        credentials = AuthCredential(username, password)
+
+        tapo_client = TapoClient(credentials, ip_address)
+        await tapo_client.initialize()
+        self._p100 = PlugDevice(tapo_client)
+
+        return self._p100
+
+    async def turn_plug_on(self):
+        p100 = await self._get_p100()
+        await p100.on()
+        print("Smart plug turned ON")
+
+    async def turn_plug_off(self):
+        p100 = await self._get_p100()
+        await p100.off()
+        print("Smart plug turned OFF")


### PR DESCRIPTION
TapoP100 plugs can have different HW versions. Plugs with HW ver 2.0 use the another protocol which is not supported by PyP100 pythin library. So library plugp100 will be used for those plugs. 
PyP100 is still used by default, To use plugp100 it's needed to define variable  **-v PLUG_TYPE:TAPOP100v2** 
plugp100 can be also used for HW ver 1.x.