### PR TITLE
[SP-3141] Remove installing sysbench tool

### DIFF
--- a/Robot-Framework/test-suites/performance/performance.robot
+++ b/Robot-Framework/test-suites/performance/performance.robot
@@ -90,4 +90,3 @@ Memory Write multimple threads test
 Common Setup
     Set Variables   ${DEVICE}
     Connect
-    Install sysbench tool


### PR DESCRIPTION
There is no need to install sysbench because now it is included to ghaf.