### PR TITLE
netvm.robot: Test which checks PCI passthrough devices are visible inside NetVM

### DIFF
--- a/Robot-Framework/resources/virtualization_keywords.resource
+++ b/Robot-Framework/resources/virtualization_keywords.resource
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Settings ***
+Library             SSHLibrary
+Resource            ../config/variables.robot
+Library             BuiltIn
+Library             String
+
+
+*** Keywords ***
+
+Verify microvm PCI device passthrough
+    [Documentation]     Verify that proper PCI devices have been passed through to the VM
+    [Arguments]    ${host_connection}    ${vm_connection}    ${vmname}
+    Switch Connection   ${vm_connection}
+    @{pciids}=    Get list of PCI IDs
+    Switch Connection   ${host_connection}
+    @{pcipassthrus}=    Get microvm PCI passthrough list    vmname=${vmname}
+    FOR    ${pcipass}    IN    @{pcipassthrus}
+        ${pciidpass}=    Get PCI ID from PCI Address    address=${pcipass}
+	Log    Checking if PCI ID has been passed through to VM
+	Should Contain    ${pciids}    ${pciidpass}
+    END
+
+Get list of PCI IDs
+    [Documentation]     Runs lspci and returns VENDORID:DEVICEID pairs
+    ...                 Pre-condition: requires active ssh connection to either
+    ...                                host or one of the VMs, and ability run
+    ...                                lspci in the target.
+    ${cmd}=    Set Variable    lspci -n | cut -d ' ' -f 3
+    ${stdout}    ${stderr}    ${rc}=    Execute Command    ${cmd}    return_stdout=True    return_stderr=True    return_rc=True
+    Should Be Equal As Integers    ${rc}    0
+    @{lines}=    Split To Lines    ${stdout}
+    [return]    @{lines}
+
+Get microvm PCI passthrough list
+    [Documentation]     Returns PCI Addresses, like 0001:01:00.0
+    ...                 Pre-condition: requires active ssh connection to ghaf host
+    [Arguments]    ${vmname}
+    ${cmd}=    Format String    cat /var/lib/microvms/{vmname}/booted/share/microvm/pci-devices    vmname=${vmname}
+    ${stdout}    ${stderr}    ${rc}=    Execute Command    ${cmd}    return_stdout=True    return_stderr=True    return_rc=True
+    Should Be Equal As Integers    ${rc}    0
+    @{lines}=    Split To Lines    ${stdout}
+    [return]    @{lines}
+
+Get PCI ID from PCI Address
+    [Documentation]     Gets VENDORID:DEVICEID pair from sysfs
+    [Arguments]    ${address}
+    ${cmd}=    Set Variable    VENDOR=$(cut -c 3-7 /sys/bus/pci/devices/${address}/vendor) && DEVICE=$(cut -c 3-7 /sys/bus/pci/devices/${address}/device) && echo "$VENDOR:$DEVICE"
+    ${stdout}    ${stderr}    ${rc}=    Execute Command    ${cmd}    return_stdout=True    return_stderr=True    return_rc=True
+    Should Be Equal As Integers    ${rc}    0
+    ${stripped}=    Strip String    ${stdout}
+    [return]    ${stripped}

--- a/Robot-Framework/test-suites/bat-tests/netvm.robot
+++ b/Robot-Framework/test-suites/bat-tests/netvm.robot
@@ -5,6 +5,7 @@
 Documentation       Testing Network VM
 Force Tags          netvm
 Resource            ../../resources/ssh_keywords.resource
+Resource            ../../resources/virtualization_keywords.resource
 Resource            ../../config/variables.robot
 Suite Teardown      Close All Connections
 
@@ -74,6 +75,14 @@ Verify wpa_supplicant.service is running
     ...                 Connect to ghaf host  AND  Connect to netvm via tunnel
     Switch Connection   ${netvm}
     Verify service status   service=wpa_supplicant.service
+
+Verify NetVM PCI device passthrough
+    [Documentation]     Verify that proper PCI devices have been passed through to the NetVM
+    [Tags]              bat   SP-T101  nuc  orin-agx  orin-nx
+    [Setup]             Run Keywords
+    ...                 Connect to ghaf host  AND  Connect to netvm via tunnel
+    Verify microvm PCI device passthrough    host_connection=${ghaf_host}    vm_connection=${netvm}    vmname=${NETVM_NAME}
+    [Teardown]          Run Keywords   Close All Connections
 
 
 *** Keywords ***

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692134936,
-        "narHash": "sha256-Z68O969cioC6I3k/AFBxsuEwpJwt4l9fzwuAMUhCCs0=",
+        "lastModified": 1698696950,
+        "narHash": "sha256-FHFL58t6lMumvWqwundC8fDDDLOIvc+JJBNIAlPjrDY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bfd953b2c6de4f550f75461bcc5768b6f966be10",
+        "rev": "017ef2132a5bda50bd713aeabce8f918502d4ec1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
netvm.robot: Test which checks PCI passthrough devices are visible inside NetVM

Tested on both Orin AGX and NUC. Should also work with Orin NX.

Generic test which reads from microvm's configuration which PCI devices are supposed to be passed through, and then checks are they really visible inside the microvm using `lspci`.