### PR TITLE
Jenkinsfiles: Simplify Orin AGX/NX zstd usage

### DIFF
--- a/Jenkinsfiles/hw_test_set
+++ b/Jenkinsfiles/hw_test_set
@@ -94,11 +94,9 @@ pipeline {
                     println("${params.image}")
                     println("${params.device}")
                     if ("${params.device}" == "orin-nx" || "${params.device}" == "orin-agx") {
-                        // unzip zipped image, remove .zst ending from path and use that for flashing usb drive. Remove unzipped image after flashing.
-                        sh "sudo zstd -d ${zipImagePath}"
-                        unzippedPath = zipImagePath.minus(".zst")
-                        sh "sudo dd if=${unzippedPath} of=/dev/${USBDEVICE} bs=1M status=progress conv=fsync"
-                        sh "sudo rm -rf ${unzippedPath}"
+                        // Use zstd to decompress the image and write directly to the USB drive.
+                        sh "sudo zstd -d ${zipImagePath} -o /dev/${USBDEVICE}"
+                        sh "sync"
                     } else {
                         sh "sudo dd if=${params.image} of=/dev/${USBDEVICE} bs=1M status=progress conv=fsync"
                     }


### PR DESCRIPTION
Instead of writing temporary files first, zstd is now used to directly write the image to disk.