### PR TITLE
[SP-3404] Skip browser test if the tested build doesn't contain apps

### DIFF
--- a/Jenkinsfiles/hw_test_set
+++ b/Jenkinsfiles/hw_test_set
@@ -179,6 +179,7 @@ pipeline {
                           [$class: 'StringParameterValue', name: 'DESCRIPTION', value: "${params.server} buildID: ${params.buildID}"],
                           [$class: 'StringParameterValue', name: 'DEVICE_NAME', value: "${deviceName}"],
                           [$class: 'StringParameterValue', name: 'INCLD_TAG', value: "batAND${params.device}"]
+                          [$class: 'StringParameterValue', name: 'BUILD_ID', value: "${params.buildID}"]
                         ]
                     )
                     // copy report and log

--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -29,6 +29,11 @@ Set Variables
     Set Global Variable  ${GALA_VM}            gala-vm.ghaf
     Set Global Variable  ${ZATHURA_VM}         zathura-vm.ghaf
 
+    IF  ${BUILD_ID} != '${EMPTY}'
+        ${config}=     Read Config  ../config/${BUILD_ID}.json
+        Set Global Variable    ${JOB}    ${config['Job']}
+    END
+
 
 Read Config
     [Arguments]  ${file_path}=../config/test_config.json

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -138,6 +138,9 @@ Find pid by name
 Kill process
     [Arguments]    @{pids}    ${sig}=15
     FOR   ${pid}  IN  @{pids}
+        IF  '${PID}' == '${EMPTY}'
+            BREAK
+        END
         Execute Command    kill -${sig} ${pid}
         FOR    ${i}    IN RANGE   5
             ${ps_exists}=    Is Process Started    ${pid}

--- a/Robot-Framework/test-suites/bat-tests/apps.robot
+++ b/Robot-Framework/test-suites/bat-tests/apps.robot
@@ -9,11 +9,17 @@ Resource            ../../config/variables.robot
 Suite Teardown      Close All Connections
 
 
+*** Variables ***
+@{app_pids}         ${EMPTY}
+
+
 *** Test Cases ***
 
 Start Firefox
     [Documentation]   Start Firefox and verify process started
     [Tags]            bat   SP-T45  nuc  orin-agx
+    [Setup]           Skip If   "${JOB}" == "nvidia-jetson-orin-agx-debug-nodemoapps-from-x86_64.x86_64-linux"
+    ...               Skipped because this build doesn't contain applications
     Connect
     Start Firefox
     Check that the application was started    firefox


### PR DESCRIPTION
RobotFramework will skip browser test if the tested build doesn't contain applications (based on the name of the job):
<img width="545" alt="image" src="https://github.com/tiiuae/ci-test-automation/assets/128357352/5d6c860b-ac40-4adb-b245-ea08fe69f5ad">

Test run commant must contain the number of the tested build _-v BUILD_ID:$BUILD_ID_ (in Jenkins pipline it must be provided by the parent job)
config directory should contain $BUILD_ID.json
with the name of the job, for example:
```
{
"Job": "nvidia-jetson-orin-agx-debug-nodemoapps-from-x86_64.x86_64-linux"
}
```
