### PR TITLE
[SP-3721] Get IP address via serial

### DIFF
--- a/Robot-Framework/lib/output_parser.py
+++ b/Robot-Framework/lib/output_parser.py
@@ -141,7 +141,7 @@ def parse_iperf_output(output):
     }
 
 
-def get_wifi_ip_from_ifconfig(output, if_name):
+def get_ip_from_ifconfig(output, if_name):
     pattern = if_name + r'.*?\n.*?inet (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'
     match = re.search(pattern, output)
     if match:

--- a/Robot-Framework/resources/serial_keywords.resource
+++ b/Robot-Framework/resources/serial_keywords.resource
@@ -95,3 +95,10 @@ Save log
     Write Advanced Testlog    journalctl.log     ${output}
     Log  ${output}
     [Teardown]    Delete All Ports
+
+Get ethernet IP address
+    Connect via serial
+    Write Data    ifconfig${\n}
+    ${output}     SerialLibrary.Read Until    ghaf@ghaf-host:
+    ${ip}         Get ip from ifconfig    ${output}   eth0
+    Set Global Variable  ${DEVICE_IP_ADDRESS}  ${ip}

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -302,7 +302,7 @@ Get wifi IP
     FOR    ${i}    IN RANGE    20
         ${output}     Execute Command      ifconfig
         Log           ${output}
-        ${ip}         Get wifi ip from ifconfig    ${output}   ${if_name}
+        ${ip}         Get ip from ifconfig    ${output}   ${if_name}
         ${status}     Run Keyword And Return Status    Should Not Be Equal As Strings    ${ip}    None
         IF  ${status}
             Log To Console     Ip is ${ip}

--- a/Robot-Framework/test-suites/bat-tests/__init__.robot
+++ b/Robot-Framework/test-suites/bat-tests/__init__.robot
@@ -4,6 +4,7 @@
 *** Settings ***
 Documentation       To be executed only for BAT tests
 Resource            ../../resources/ssh_keywords.resource
+Resource            ../../resources/serial_keywords.resource
 Suite Setup         Common Setup
 Suite Teardown      Common Teardown
 
@@ -12,6 +13,7 @@ Suite Teardown      Common Teardown
 
 Common Setup
     Set Variables   ${DEVICE}
+    Run Keyword If  "${DEVICE_IP_ADDRESS}" == ""    Get ethernet IP address
     Connect
     Log versions
     Run journalctl recording


### PR DESCRIPTION
If test config contains empty IP address for device than Robot will try to connect via serial and get IP address from ifconfig output and use it for bat tests