### PR TITLE
Add missing pytz dependency to .nix files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
               robotframework-sshlibrary
               pyserial
               python-kasa
+              pytz
             ]))
         ];
       };

--- a/pkgs/ghaf-robot/default.nix
+++ b/pkgs/ghaf-robot/default.nix
@@ -19,6 +19,7 @@ writeShellApplication {
       ps.robotframework-sshlibrary
       ps.pyserial
       ps.python-kasa
+      ps.pytz
 
       # These are taken from this flake
       robotframework-advancedlogging


### PR DESCRIPTION
`pytz` was missing from dependencies, so added it