### PR TITLE
LabWC support for application launch tests

### DIFF
--- a/Robot-Framework/lib/output_parser.py
+++ b/Robot-Framework/lib/output_parser.py
@@ -237,6 +237,17 @@ def get_app_path(output, app):
     if match:
         result = match.group(1)
     else:
-        raise Exception(f"Couldn't parse chromium path from /etc/xdg/weston/weston.ini, pattern: {pattern}")
+        raise Exception(f"Couldn't parse {app} path from /etc/xdg/weston/weston.ini, pattern: {pattern}")
+    path = result.replace('"', '\\"')
+    return path
+
+def get_app_path_from_desktop(output):
+    # Parse Exec-path from XDG .desktop application launcher file.
+    pattern = r"Exec=(.*)\n"
+    match = re.search(pattern, output)
+    if match:
+        result = match.group(1)
+    else:
+        raise Exception(f"Couldn't parse app path, pattern: {pattern}")
     path = result.replace('"', '\\"')
     return path

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -132,6 +132,13 @@ Start application
     ${path}          Get App Path  ${output}  ${app_name}
     Execute Command  nohup sh -c '$(${path})' > output.log 2>&1 &
 
+Start XDG application
+    [Arguments]      ${app_name}
+    Log To Console   ${\n}Starting ${app_name}
+    ${output}        Execute Command    cat /run/current-system/sw/share/applications/${app_name}.desktop
+    ${path}          Get App Path From Desktop  ${output}
+    Execute Command  nohup sh -c '$(${path})' > output.log 2>&1 &
+
 Start Firefox
     [Documentation]  It's needed to set display variable manually because there is no real monitor connected to DUT
     Log To Console  ${\n}Starting Firefox

--- a/Robot-Framework/test-suites/bat-tests/apps.robot
+++ b/Robot-Framework/test-suites/bat-tests/apps.robot
@@ -30,7 +30,7 @@ Start Chromium on LenovoX1
     [Tags]            bat   SP-T97   lenovo-x1
     [Setup]           Connect to netvm
     Connect to VM       ${GUI_VM}
-    Start application   chromium
+    Start XDG application   chromium
     Connect to VM       ${CHROMIUM_VM}
     Check that the application was started    chromium
     [Teardown]  Kill process  @{app_pids}
@@ -40,7 +40,7 @@ Start Zathura on LenovoX1
     [Tags]            bat   SP-T112   lenovo-x1
     [Setup]           Connect to netvm
     Connect to VM       ${GUI_VM}
-    Start application   zathura
+    Start XDG application   zathura
     Connect to VM       ${ZATHURA_VM}
     Check that the application was started    zathura
     [Teardown]  Kill process  @{app_pids}
@@ -50,7 +50,7 @@ Start Gala on LenovoX1
     [Tags]            bat   SP-T111   lenovo-x1
     [Setup]           Connect to netvm
     Connect to VM       ${GUI_VM}
-    Start application   gala
+    Start XDG application   gala
     Connect to VM       ${GALA_VM}
     Check that the application was started    gala
     [Teardown]  Kill process  @{app_pids}


### PR DESCRIPTION
Support for parsing Exec command paths from XDG .desktop files, that are used with the nwg-drawer used within LabWC edition of Lenovo X1 build.