### PR TITLE
Add prompt argument to Open Connection calls

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -50,7 +50,7 @@ Check Network Availability
 Connect
     [Documentation]   Set up the SSH connection to the device
     [Arguments]       ${IP}=${DEVICE_IP_ADDRESS}    ${PORT}=22    ${target_output}=ghaf@ghaf-host
-    ${connection}=    Open Connection    ${IP}    port=${PORT}
+    ${connection}=    Open Connection    ${IP}    port=${PORT}    prompt=\$    timeout=30
     ${output}=        Login     username=${LOGIN}    password=${PASSWORD}
     Should Contain    ${output}    ${target_output}
     [Return]          ${connection}
@@ -71,8 +71,8 @@ Connect to netvm
     ${failed_connection}  Set variable  True
     FOR    ${i}    IN RANGE    10
         TRY
-            ${connection}        Open Connection   ${NETVM_IP}  port=22
-            ${output}            Login    username=${LOGIN}     password=${PASSWORD}    jumphost_index_or_alias=${ghaf_host_ssh}
+            ${connection}=       Open Connection    ${NETVM_IP}    port=22    prompt=\$    timeout=30
+            ${output}=           Login    username=${LOGIN}     password=${PASSWORD}    jumphost_index_or_alias=${ghaf_host_ssh}
         EXCEPT    ChannelException: ChannelException(2, 'Connect failed')    type=LITERAL
             Sleep   1
             CONTINUE
@@ -90,7 +90,7 @@ Connect to VM
     ${failed_connection}  Set variable  True
     FOR    ${i}    IN RANGE    20
         TRY
-            ${connection}=       Open Connection   ${vm_name}  port=22
+            ${connection}=       Open Connection    ${vm_name}    port=22    prompt=\$    timeout=30
             ${output}=           Login    username=${LOGIN}        password=${PASSWORD}    jumphost_index_or_alias=${netvm_ssh}
         EXCEPT    ChannelException: ChannelException(2, 'Connect failed')    type=LITERAL
             Sleep   1


### PR DESCRIPTION
Add prompt argument to SSHLibrary's Open Connection calls. This makes the SSH connection succeed even if it takes more than 0.5 seconds for the actual prompt to appear after SSH connection has been established, and it will also make test faster if it appears earlier.

I wanted to add this because I started to have problems because it started to take more than 0.5 seconds for the actual prompt to appear, and then the connection failed on the "Should Contain" -keyword, because it did not contain the prompt

http://robotframework.org/SSHLibrary/SSHLibrary.html#Login

Here it says "If the [prompt](http://robotframework.org/SSHLibrary/SSHLibrary.html#Prompt) is set, everything until the prompt is read. Otherwise the output is read using the [Read](http://robotframework.org/SSHLibrary/SSHLibrary.html#Read) keyword with the given delay". Delay by default is 0.5