### PR TITLE
Add ability to delete all Linux Boot Manager entries

### DIFF
--- a/Jenkinsfiles/hw_test_set
+++ b/Jenkinsfiles/hw_test_set
@@ -14,6 +14,7 @@ zipImagePath = ''
 bootSuite = 'boot-test/'
 performanceSuite = 'performance-tests/'
 batSuite = 'bat-tests/'
+efibootSuite = 'efibootmgr/'
 deviceName = ''
 usbHubSerial = ''
 sdMuxUsbPort = ''
@@ -30,6 +31,7 @@ pipeline {
                     bootJob = "${splitted[0]}/Testing/boot_test"
                     batJob = "${splitted[0]}/Testing/smoke_tests"
                     performanceJob = "${splitted[0]}/Testing/Performance_tests"
+                    removebootmanagerJob = "${splitted[0]}/Testing/remove_efibootentries"
                     turnoffJob =  "${splitted[0]}/Testing/turn_off_device"
                     turnonJob =  "${splitted[0]}/Testing/turn_on_device"
                     configPath = "/home/${params.label}/Jenkins-agent/workspace/${splitted[0]}/Testing/test_config.json"
@@ -275,6 +277,22 @@ pipeline {
                             error("Error during performance tests")
                         }
                     }
+                }
+            }
+        }
+        stage('Remove Linux Boot Manager') {
+            steps {
+              	script {
+              	    if ("${params.job}" == "lenovo-x1-carbon-gen11-debug-installer"){
+                    build = build(
+                        job: "${batJob}", propagate: false,
+                        parameters: [
+                          [$class: 'StringParameterValue', name: 'RF_SUITE', value: "${efibootSuite}"],
+                          [$class: 'StringParameterValue', name: 'DESCRIPTION', value: "${params.server} buildID: ${params.buildID}"],
+                          [$class: 'StringParameterValue', name: 'DEVICE_NAME', value: "${deviceName}"],
+                          [$class: 'StringParameterValue', name: 'INCLD_TAG', value: "efiboot-modAND${params.device}"]
+                        ]
+                    )
                 }
             }
         }

--- a/Jenkinsfiles/hw_test_set
+++ b/Jenkinsfiles/hw_test_set
@@ -31,6 +31,7 @@ pipeline {
                     batJob = "${splitted[0]}/Testing/smoke_tests"
                     performanceJob = "${splitted[0]}/Testing/Performance_tests"
                     turnoffJob =  "${splitted[0]}/Testing/turn_off_device"
+                    turnonJob =  "${splitted[0]}/Testing/turn_on_device"
                     configPath = "/home/${params.label}/Jenkins-agent/workspace/${splitted[0]}/Testing/test_config.json"
 
                     // Check for which agent and which target device
@@ -160,7 +161,15 @@ pipeline {
             steps {
                 script{
                     if ("${params.job}" == "lenovo-x1-carbon-gen10-debug-installer"){
-                        sh "python installer.py"
+                        build = build(
+                            job: "${turnonJob}", propagate: false,
+                            parameters: [
+                              [$class: 'StringParameterValue', name: 'DESCRIPTION', value: "${params.server} buildID: ${params.buildID}"],
+                              [$class: 'StringParameterValue', name: 'DEVICE_NAME', value: "${deviceName}"],
+                              [$class: 'StringParameterValue', name: 'DEVICE_TYPE', value: "${params.device}"]
+                            ]
+                        )
+                        sh "python3 installer.py ${deviceName} ghaf"
                         sh "./BrainStem_dev_kit/bin/AcronameHubCLI -u 0 -s ${usbHubSerial}"
                         // no need to reboot device (it will be done in boot test)
                     }

--- a/Jenkinsfiles/hw_test_set
+++ b/Jenkinsfiles/hw_test_set
@@ -159,7 +159,7 @@ pipeline {
         stage('Installer') {
             steps {
                 script{
-                    if ("${params.job_name}" == "lenovo-x1-carbon-gen10-debug-installer"){
+                    if ("${params.job}" == "lenovo-x1-carbon-gen10-debug-installer"){
                         sh "python installer.py"
                         sh "./BrainStem_dev_kit/bin/AcronameHubCLI -u 0 -s ${usbHubSerial}"
                         // no need to reboot device (it will be done in boot test)

--- a/Jenkinsfiles/hw_test_set
+++ b/Jenkinsfiles/hw_test_set
@@ -156,6 +156,17 @@ pipeline {
                 }
             }
         }
+        stage('Installer') {
+            steps {
+                script{
+                    if ("${params.job_name}" == "lenovo-x1-carbon-gen10-debug-installer"){
+                        sh "python installer.py"
+                        sh "./BrainStem_dev_kit/bin/AcronameHubCLI -u 0 -s ${usbHubSerial}"
+                        // no need to reboot device (it will be done in boot test)
+                    }
+                }
+            }
+        }
         stage('Boot Test') {
             steps {
               	script{

--- a/Robot-Framework/test-suites/efibootmgr/__init__.robot
+++ b/Robot-Framework/test-suites/efibootmgr/__init__.robot
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Settings ***
+Documentation       Modify boot order
+Resource            ../../resources/ssh_keywords.resource
+Resource            ../../config/variables.robot
+Suite Setup         Common Setup
+Suite Teardown      Common Teardown
+
+
+*** Keywords ***
+
+Common Setup
+    Set Variables   ${DEVICE}
+
+Common Teardown
+    Close All Connections

--- a/Robot-Framework/test-suites/efibootmgr/efiboot_mod_script
+++ b/Robot-Framework/test-suites/efibootmgr/efiboot_mod_script
@@ -1,0 +1,4 @@
+for f in $(efibootmgr | grep Linux | awk 'NR > 0 {print $1}' | cut -c 5-8)
+do
+    sudo efibootmgr -q -b ${f} -B
+done

--- a/Robot-Framework/test-suites/efibootmgr/efiboot_mod_script
+++ b/Robot-Framework/test-suites/efibootmgr/efiboot_mod_script
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
 for f in $(efibootmgr | grep Linux | awk 'NR > 0 {print $1}' | cut -c 5-8)
 do
     sudo efibootmgr -q -b ${f} -B

--- a/Robot-Framework/test-suites/efibootmgr/efibootmgr.robot
+++ b/Robot-Framework/test-suites/efibootmgr/efibootmgr.robot
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Settings ***
+Documentation       Removing Linux Boot Manager entries from UEFI boot order.
+Force Tags          efiboot-mod
+Resource            ../../resources/serial_keywords.resource
+Resource            ../../resources/ssh_keywords.resource
+Resource            ../../resources/device_control.resource
+Resource            ../../config/variables.robot
+
+
+*** Variables ***
+${CONNECTION_TYPE}       ssh
+${IS_AVAILABLE}          False
+${DEVICE_TYPE}           ${EMPTY}
+${ENTRIES}
+
+*** Test Cases ***
+
+Remove Linux Boot Manager entries
+    [Documentation]    Remove all Linux Boot Manager entries from UEFI boot order list
+    [Tags]             lenovo-x1  efiboot-mod
+
+    Check If Device Is Up
+    IF    ${IS_AVAILABLE} == False
+        FAIL    Cannot modify the UEFI boot order
+    ELSE
+        Log To Console  Connecting to ghaf-host
+    END
+
+    Connect
+    Put File           efibootmgr/efiboot_mod_script    /home/ghaf
+    Execute Command    chmod 777 efiboot_mod_script sudo=True  sudo_password=${PASSWORD}
+    Log To Console  Deleting all 'Linux' entries from UEFI boot order with efibootmgr
+    Execute Command    ./efiboot_mod_script  sudo=True  sudo_password=${PASSWORD}
+    ${ENTRIES}            Execute Command    efibootmgr | grep Linux
+    Log To Console    efibootmgr check after removing Linux Boot Manager entries: \n${ENTRIES}
+    IF    "${ENTRIES}" != ""
+        FAIL    Failed in removing all Linux Boot Manager entries
+    ELSE
+        Log To Console  All Linux Boot Manager entries cleared
+    END
+    [Teardown]   Teardown
+
+
+*** Keywords ***
+
+Teardown
+    IF  "${CONNECTION_TYPE}" == "ssh"
+        Run Keyword If Test Failed    ssh_keywords.Save log
+    ELSE IF  "${CONNECTION_TYPE}" == "serial"
+        Run Keyword If Test Failed    serial_keywords.Save log
+    END
+    Close All Connections
+    Delete All Ports
+
+Check If Device Is Up
+    [Arguments]    ${range}=5
+    Set Global Variable    ${IS_AVAILABLE}       False
+    ${start_time}=    Get Time	epoch
+    FOR    ${i}    IN RANGE    ${range}
+        ${ping}=    Ping Host   ${DEVICE_IP_ADDRESS}
+        IF    ${ping}
+            Log To Console    Ping ${DEVICE_IP_ADDRESS} successfull
+            BREAK
+        END
+        Sleep  1
+    END
+
+    IF    ${ping}
+        ${port_22_is_available}     Check if ssh is ready on device
+        IF  ${port_22_is_available}
+            Set Global Variable    ${IS_AVAILABLE}       True
+        ELSE
+            Set Global Variable    ${IS_AVAILABLE}       False
+        END
+    END
+
+    ${diff}=    Evaluate    int(time.time()) - int(${start_time})
+
+    IF  ${IS_AVAILABLE}    Log To Console    Device ssh port available.
+
+    IF  ${IS_AVAILABLE} == False
+        Log To Console    Device is not available!
+        IF  "${SERIAL_PORT}" == "NONE"
+            Log To Console    There is no address for serial connection
+        ELSE
+            Check Serial Connection
+        END
+    END

--- a/installer.py
+++ b/installer.py
@@ -1,0 +1,73 @@
+import paramiko
+import sys
+import json
+import os
+
+if len(sys.argv) < 3:
+    print("Usage: python script.py <device_name> <sudo_password>")
+    sys.exit(1)
+
+ssh_key_path = '~/.ssh/id_ed25519_autotests'
+ssh_key_path = os.path.expanduser(ssh_key_path)
+device_name = sys.argv[1]
+password = sys.argv[2]
+
+
+config_file_path = '../Testing/test_config.json'
+try:
+    with open(config_file_path, 'r') as file:
+        data = json.load(file)
+        ip_address = data[device_name]['device_ip_address']
+except FileNotFoundError:
+    print(f"Error: The configuration file '{config_file_path}' was not found.")
+    sys.exit(1)
+except KeyError:
+    print(f"Error: Device '{device_name}' not found in configuration file.")
+    sys.exit(1)
+except json.JSONDecodeError:
+    print("Error: JSON file is malformed.")
+    sys.exit(1)
+
+# SSH Client setup
+client = paramiko.SSHClient()
+client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+try:
+    client.connect(hostname=ip_address, username='username', pkey=paramiko.RSAKey.from_private_key_file(ssh_key_path))
+    print(f"Successfully connected to {ip_address}")
+
+    session = client.get_transport().open_session()
+    session.get_pty()
+    session.exec_command('sudo ghaf-installer.sh')
+
+    stdin = session.makefile('wb', -1)
+    stdout = session.makefile('rb', -1)
+    stderr = session.makefile_stderr('rb', -1)
+
+    # Send the sudo password
+    stdin.write(password + '\n')
+    stdin.flush()
+
+    # Handle outputs and inputs directly in the main block
+    while True:
+        output = stdout.readline().decode('utf-8')
+        if output:
+            print(output, end="")
+            if "Device name [e.g. /dev/nvme0n1]: " in output:
+                stdin.write('/dev/nvme0n1' + '\n')
+                stdin.flush()
+            elif "WARNING: Next command will destroy all previous data from your device, press Enter to proceed." in output:
+                stdin.write('\n')
+                stdin.flush()
+            elif "Installation done. Please remove the installation media and reboot" in output:
+                print("Installation completed successfully.")
+                break
+
+        stderr_output = stderr.readline().decode('utf-8')
+        if stderr_output:
+            print(stderr_output, end="")
+
+finally:
+    # Ensure the session and client are closed properly
+    if session:
+        session.close()
+    client.close()


### PR DESCRIPTION
PR#585 'Change internal installation approach' is going to change the installation method so that it does not anymore just flash the ghaf image on nvme but builds it with nixos-installer. After PR#585 is merged ghaf-installer will create always a new Linux Boot Manager entry to UEFI boot order list and thus set the machine to boot from nvme regardless if USB SSD is connected or not.

With the introduced efiboot-mod test all Linux Boot Manager entries can be automatically removed from the UEFI boot order list. Wiping nvme clear can force to boot from USB but it is not possible to clear nvme if machine is locked to boot from nvme. Also it is not good to let the UEFI boot order list be flooded endlessly with Linux Boot Manager entries.

There is still a risk that the ghaf which the ghaf-installer has installed is broken and unbootable and new Linux Boot Manager entry is active. This would cause ci-test-automation not being able to boot automatically from nvme nor from USB SSD. That situation would need to be fixed manually via booting to UEFI BIOS and deactivating Linux Boot Manager entries. To avoid this happening plain ghaf image test should be ran first and only if the ghaf image is bootable then proceed to ghaf-installer tests.

Running efiboot-mod test while there is no Linux Boot Manager entries present in UEFI Boot order list does no harm. 

Requirement for this PR to work is that efibootmgr is added to ghaf. This was done in https://github.com/tiiuae/ghaf/pull/605 