### PR TITLE
Run fileio test in /gp_storage on Lenovo-X1 target

### DIFF
--- a/Robot-Framework/test-suites/performance-tests/fileio_test
+++ b/Robot-Framework/test-suites/performance-tests/fileio_test
@@ -2,36 +2,38 @@
 
 # These variables need to be given on the command line. For example: ./fileio_test 20
 THREADS="$1"
+DISK_CHECK_DIRECTORY="${2:-/}"
 
 # Default expected power mode
 ExpectedPowerModeNo=3
 
 # Create a directory for the results and copy this script into it
-RESULT_DIR="sysbench_results"
-echo -e "\nCreating directory for test results:\n./$RESULT_DIR"
+RESULT_DIR="/home/ghaf/sysbench_results"
+echo -e "\nCreating directory for test results:\n$RESULT_DIR"
 mkdir -p $RESULT_DIR
 FileName=${0##*/}
-cp ${FileName} ./$RESULT_DIR
+cp ${FileName} $RESULT_DIR
 
 # Create test_info file with system information
-echo -e "\nSaving information about test environment to ./$RESULT_DIR/test_info\n"
-echo -e "$(lscpu)" "\n\n" "$(free)" "\n\n" "$(df)" "\n\n" >> ./$RESULT_DIR/test_info
-echo -e "\nHost: $(hostname)\n" | tee -a ./$RESULT_DIR/test_info
+echo -e "\nSaving information about test environment to $RESULT_DIR/test_info\n"
+echo -e "$(lscpu)" "\n\n" "$(free)" "\n\n" "$(df)" "\n\n" > $RESULT_DIR/test_info
+echo -e "\nHost: $(hostname)\n" | tee -a $RESULT_DIR/test_info
+echo -e "\nRunning the test in $DISK_CHECK_DIRECTORY" | tee -a $RESULT_DIR/test_info
 
 # Check cpu architecture for specific actions
 if lscpu | grep -qw "aarch64"; then
-    echo -e "\nSystem architecture is aarch64." | tee -a ./$RESULT_DIR/test_info
+    echo -e "\nSystem architecture is aarch64." | tee -a $RESULT_DIR/test_info
     if hostname | grep -qw "ghaf-host"; then
-        echo -e "$(nvpmodel -q)" "\n" >> ./$RESULT_DIR/test_info
+        echo -e "$(nvpmodel -q)" "\n" >> $RESULT_DIR/test_info
         ModeNo=$(nvpmodel -q | awk -F: 'NR==2 {print $1}')
         if [ $ModeNo -eq $ExpectedPowerModeNo ]; then
-            echo "Power mode check ok: ${ModeNo}" | tee -a ./$RESULT_DIR/test_info
+            echo "Power mode check ok: ${ModeNo}" | tee -a $RESULT_DIR/test_info
         else
-            echo "Unexpected power mode detected: ${ModeNo}" | tee -a ./$RESULT_DIR/test_info
+            echo "Unexpected power mode detected: ${ModeNo}" | tee -a $RESULT_DIR/test_info
             exit 1
         fi
     else
-        echo -e "\nVirtual environment detected. Power mode not checked." | tee -a ./$RESULT_DIR/test_info
+        echo -e "\nVirtual environment detected. Power mode not checked." | tee -a $RESULT_DIR/test_info
     fi
 fi
 
@@ -40,17 +42,17 @@ TOTAL_MEM_kB=$(free | awk -F: 'NR==2 {print $2}' | awk '{print $1}')
 FILE_TOTAL_SIZE_kB=$((TOTAL_MEM_kB + 4000000))
 
 # Read available disk space in kB and check for sufficient disk space
-AVAILABLE_DISK_SPACE_kB=$(df | grep -w "/" | awk '{print $4}')
+AVAILABLE_DISK_SPACE_kB=$(df | grep -w $DISK_CHECK_DIRECTORY | awk '{print $4}')
 if [ $((FILE_TOTAL_SIZE_kB + FILE_TOTAL_SIZE_kB / 10)) -gt $AVAILABLE_DISK_SPACE_kB ]; then
-    echo -e "\nInsufficient disk space for fileio test." | tee -a ./$RESULT_DIR/test_info
+    echo -e "\nInsufficient disk space for fileio test." | tee -a $RESULT_DIR/test_info
     exit 1
 fi
 
 # Execute sysbench fileio tests if the checks passed
 sysbench fileio --file-total-size=${FILE_TOTAL_SIZE_kB}K --threads=${THREADS} --file-test-mode=seqrd prepare
-sysbench fileio --file-total-size=${FILE_TOTAL_SIZE_kB}K --threads=${THREADS} --file-test-mode=seqrd --time=30 run | tee ./$RESULT_DIR/fileio_rd_report
+sysbench fileio --file-total-size=${FILE_TOTAL_SIZE_kB}K --threads=${THREADS} --file-test-mode=seqrd --time=30 run | tee $RESULT_DIR/fileio_rd_report
 sysbench fileio cleanup
-sysbench fileio --file-total-size=${FILE_TOTAL_SIZE_kB}K --threads=${THREADS} --file-test-mode=seqwr --time=30 run | tee ./$RESULT_DIR/fileio_wr_report
+sysbench fileio --file-total-size=${FILE_TOTAL_SIZE_kB}K --threads=${THREADS} --file-test-mode=seqwr --time=30 run | tee $RESULT_DIR/fileio_wr_report
 sysbench fileio cleanup
 
 echo -e "\nTest finished.\n"

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -147,7 +147,22 @@ FileIO test
     [Tags]              fileio  SP-T67-7  nuc  orin-agx  orin-nx  lenovo-x1
 
     Transfer FileIO Test Script To DUT
-    Execute Command      ./fileio_test ${threads_number}  sudo=True  sudo_password=${PASSWORD}
+
+    # In case of Lenovo-X1 run the test in /gp_storage which has more disk space than /home/ghaf
+    # Results are still saved to /home/ghaf
+    IF  "LenovoX1" in "${DEVICE}"
+        Execute Command      cp ./fileio_test /gp_storage  sudo=True  sudo_password=${PASSWORD}
+        Execute Command      cd /gp_storage  sudo=True  sudo_password=${PASSWORD}
+        Execute Command      ./fileio_test ${threads_number} /gp_storage  sudo=True  sudo_password=${PASSWORD}
+        Execute Command      cd /home/ghaf  sudo=True  sudo_password=${PASSWORD}
+    ELSE
+        Execute Command      ./fileio_test ${threads_number}  sudo=True  sudo_password=${PASSWORD}
+    END
+
+    ${test_info}  Execute Command    cat sysbench_results/test_info
+    IF  "Insufficient disk space" in $test_info
+        FAIL            Insufficient disk space for fileio test.
+    END
 
     ${fileio_rd_output}  Execute Command    cat sysbench_results/fileio_rd_report
     Log                  ${fileio_rd_output}


### PR DESCRIPTION
Disk space on Lenovo-X1 ghaf-host has been reduced. Directory /home/ghaf doesn't have anymore enough disk space for running the fileio read test (required more disk space than memory). However ghaf-host has now multiple mountpoints of which /gp_storage is suitable for running the test (50G disk space). Change to that directory for creating test files and running the test.

Improve also test reporting in case there is not enough disk space.