### PR TITLE
Refactor nvpmodel check to be a separate test

### DIFF
--- a/Robot-Framework/test-suites/performance-tests/fileio_test
+++ b/Robot-Framework/test-suites/performance-tests/fileio_test
@@ -4,9 +4,6 @@
 THREADS="$1"
 DISK_CHECK_DIRECTORY="${2:-/}"
 
-# Default expected power mode
-ExpectedPowerModeNo=3
-
 # Create a directory for the results and copy this script into it
 RESULT_DIR="/home/ghaf/sysbench_results"
 echo -e "\nCreating directory for test results:\n$RESULT_DIR"
@@ -19,23 +16,6 @@ echo -e "\nSaving information about test environment to $RESULT_DIR/test_info\n"
 echo -e "$(lscpu)" "\n\n" "$(free)" "\n\n" "$(df)" "\n\n" > $RESULT_DIR/test_info
 echo -e "\nHost: $(hostname)\n" | tee -a $RESULT_DIR/test_info
 echo -e "\nRunning the test in $DISK_CHECK_DIRECTORY" | tee -a $RESULT_DIR/test_info
-
-# Check cpu architecture for specific actions
-if lscpu | grep -qw "aarch64"; then
-    echo -e "\nSystem architecture is aarch64." | tee -a $RESULT_DIR/test_info
-    if hostname | grep -qw "ghaf-host"; then
-        echo -e "$(nvpmodel -q)" "\n" >> $RESULT_DIR/test_info
-        ModeNo=$(nvpmodel -q | awk -F: 'NR==2 {print $1}')
-        if [ $ModeNo -eq $ExpectedPowerModeNo ]; then
-            echo "Power mode check ok: ${ModeNo}" | tee -a $RESULT_DIR/test_info
-        else
-            echo "Unexpected power mode detected: ${ModeNo}" | tee -a $RESULT_DIR/test_info
-            exit 1
-        fi
-    else
-        echo -e "\nVirtual environment detected. Power mode not checked." | tee -a $RESULT_DIR/test_info
-    fi
-fi
 
 # Calculate total memory in kB and set FILE_TOTAL_SIZE 4GB higher than the total memory
 TOTAL_MEM_kB=$(free | awk -F: 'NR==2 {print $2}' | awk '{print $1}')

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -21,6 +21,19 @@ Suite Teardown      Close All Connections
 
 *** Test Cases ***
 
+nvpmodel check test
+    [Documentation]     If power mode changed it would probably have an effect on performance test results.
+    ...                 Ensure that the power mode level is as expected (3) on Orin AGX/NX targets. Do not apply to
+    ...                 other targets.
+    [Tags]              nvpmodel  SP-T185  orin-agx  orin-nx
+    [Setup]             Skip If   not ("Orin" in "${DEVICE}")
+    ...                 Skipped because this test does not apply to other than Orin AGX/NX targets.
+    ${ExpectedNVPmode}  Set Variable  3
+    ${output}           Execute Command     nvpmodel-check ${ExpectedNVPmode}
+    IF  not ("Power mode check ok: ${ExpectedNVPmode}" in $output)
+        FAIL  ${output}\n\nExpected: ${ExpectedNVPmode}
+    END
+
 CPU One thread test
     [Documentation]     Run a CPU benchmark using Sysbench with a duration of 10 seconds and a SINGLE thread.
     ...                 The benchmark records to csv CPU events per second, events per thread, and latency data.
@@ -150,7 +163,7 @@ FileIO test
 
     # In case of Lenovo-X1 run the test in /gp_storage which has more disk space than /home/ghaf
     # Results are still saved to /home/ghaf
-    IF  "LenovoX1" in "${DEVICE}"
+    IF  "Lenovo" in "${DEVICE}"
         Execute Command      cp ./fileio_test /gp_storage  sudo=True  sudo_password=${PASSWORD}
         Execute Command      cd /gp_storage  sudo=True  sudo_password=${PASSWORD}
         Execute Command      ./fileio_test ${threads_number} /gp_storage  sudo=True  sudo_password=${PASSWORD}


### PR DESCRIPTION
Since nvpmodel check is applicable only for Orin AGX/NX targets remove it from fileio_test script which is common for all targets. Create a new test for nvpmodel check and run it only on Orin targets. Use the helper script integrated into ghaf: 
https://github.com/tiiuae/ghaf/blob/main/modules/common/development/scripts/nvpmodel_check.nix

Also remove "-X1" from the fileio test device name criteria because there is some variation in the format of the device name among testers (LenovoX1-1, Lenovo-X1...)