### PR TITLE
Skip systemctl status test for NUC

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/others.robot
+++ b/Robot-Framework/test-suites/bat-tests/others.robot
@@ -36,7 +36,14 @@ Check systemctl status
     [Documentation]    Verify systemctl status is running
     [Tags]             bat  SP-T104  nuc  orin-agx  orin-nx  riscv
     [Setup]     Connect
-    Verify Systemctl status
+    ${status}   ${output}   Run Keyword And Ignore Error    Verify Systemctl status
+    IF  '${status}' == 'FAIL'
+        IF  "NUC" in "${DEVICE}"
+            Skip    "Known issue: SP-4632"
+        ELSE
+            FAIL    ${output}
+        END
+    END
     [Teardown]  Close All Connections
 
 Check all VMs are running


### PR DESCRIPTION
Skip test in case if test fails because issue is known but has low priority.
