### PR TITLE
Apply changes introduced by ghaf PR724

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -34,7 +34,7 @@ Set Variables
     Set Global Variable  ${CHROMIUM_VM}        chromium-vm
     Set Global Variable  ${GALA_VM}            gala-vm
     Set Global Variable  ${ZATHURA_VM}         zathura-vm
-    Set Global Variable  ${ELEMENT_VM}         element-vm
+    Set Global Variable  ${COMMS_VM}           comms-vm
     Set Global Variable  ${APPFLOWY_VM}        appflowy-vm
     Set Global Variable  ${BUSINESS_VM}        business-vm
 

--- a/Robot-Framework/lib/PerformanceDataProcessing.py
+++ b/Robot-Framework/lib/PerformanceDataProcessing.py
@@ -492,7 +492,10 @@ class PerformanceDataProcessing:
         if "write" in test_name:
             threshold = thresholds['fileio']['wr']
         else:
-            threshold = thresholds['fileio']['rd']
+            if "Lenovo" in self.device:
+                threshold = thresholds['fileio']['rd_lenovo-x1']
+            else:
+                threshold = thresholds['fileio']['rd']
 
         with open(f"{self.data_dir}{self.device}_{test_name}.csv", 'r') as csvfile:
             csvreader = csv.reader(csvfile)

--- a/Robot-Framework/lib/performance_thresholds.py
+++ b/Robot-Framework/lib/performance_thresholds.py
@@ -18,7 +18,8 @@ thresholds = {
     },
     'fileio': {
         'wr': 10,
-        'rd': 20
+        'rd': 20,
+        'rd_lenovo-x1': 200
     },
     'iperf': 10
 }

--- a/Robot-Framework/test-suites/bat-tests/apps.robot
+++ b/Robot-Framework/test-suites/bat-tests/apps.robot
@@ -63,8 +63,18 @@ Start Element on LenovoX1
     [Setup]           Connect to netvm
     Connect to VM          ${GUI_VM}
     Start XDG application  Element
-    Connect to VM          ${ELEMENT_VM}
+    Connect to VM          ${COMMS_VM}
     Check that the application was started    element
+    [Teardown]  Kill process  @{app_pids}
+
+Start Slack on LenovoX1
+    [Documentation]   Start Slack in dedicated VM and verify process started
+    [Tags]            bat   SP-T191   lenovo-x1
+    [Setup]           Connect to netvm
+    Connect to VM          ${GUI_VM}
+    Start XDG application  Slack
+    Connect to VM          ${COMMS_VM}
+    Check that the application was started    slack
     [Teardown]  Kill process  @{app_pids}
 
 Start Appflowy on LenovoX1

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -275,7 +275,7 @@ Sysbench test in VMs on LenovoX1
     ...                                  gala-vm=2
     ...                                  zathura-vm=1
     ...                                  chromium-vm=4
-    ...                                  element-vm=4
+    ...                                  comms-vm=4
     ...                                  admin-vm=1
     ...                                  appflowy-vm=1
     ...                                  audio-vm=1


### PR DESCRIPTION
In ghaf PR724 element-vm is changed to comms-vm and also Slack App is added to the VM. With these fixes the element launch test (kill processes part) survives the changes. Added also launch test for the new Slack App.

In addition created separate lenovo-x1 specific performance threshold parameter for fileio read test because lenovo-x1 fileio rd test results jumped very high few weeks ago causing also variance of the results to increase compared to other targets. So assigning a larger threshold for this specific test/target was appropriate.