### PR TITLE
robotframework browser

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702233072,
-        "narHash": "sha256-H5G2wgbim2Ku6G6w+NSaQaauv6B6DlPhY9fMvArKqRo=",
+        "lastModified": 1728500571,
+        "narHash": "sha256-dOymOQ3AfNI4Z337yEwHGohrVQb4yPODCW9MDUyAc4w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "781e2a9797ecf0f146e81425c822dca69fe4a348",
+        "rev": "d51c28603def282a24fa034bcb007e2bcb5b5dd0",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,46 @@
 {
   "nodes": {
+    "blank": {
+      "locked": {
+        "lastModified": 1625557891,
+        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
+        "owner": "divnix",
+        "repo": "blank",
+        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "blank",
+        "type": "github"
+      }
+    },
+    "dream2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "purescript-overlay": [
+          "blank"
+        ],
+        "pyproject-nix": [
+          "blank"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729932741,
+        "narHash": "sha256-Ko3a3hWt7CbVn9Db0/Tj9zln3bB/CMIhlQsP92mUejU=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "7acdae705dcc79f307e752f749a9f513a0ed9b83",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +77,8 @@
     },
     "root": {
       "inputs": {
+        "blank": "blank",
+        "dream2nix": "dream2nix",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
   in
     flake-utils.lib.eachSystem systems (system: let
       pkgs = nixpkgs.legacyPackages.${system};
-    in {
+    in rec {
       packages = rec {
         ghaf-robot = pkgs.callPackage ./pkgs/ghaf-robot {
           PyP100 = self.packages.${system}.PyP100;
@@ -43,11 +43,19 @@
         robotframework-retryfailed = pkgs.python3Packages.callPackage ./pkgs/robotframework-retryfailed {};
         robotframework-seriallibrary = pkgs.python3Packages.callPackage ./pkgs/robotframework-seriallibrary {};
         robotframework-browser = pkgs.python3Packages.callPackage ./pkgs/robotframework-browser { inherit dream2nix; };
+        robotframework-browser-test = pkgs.python3Packages.callPackage ./pkgs/robotframework-browser/test.nix { inherit robotframework-browser; };
         robotframework-advancedlogging = pkgs.python3Packages.callPackage ./pkgs/robotframework-advancedlogging {};
         pkcs7 = pkgs.python3Packages.callPackage ./pkgs/pkcs7 {}; # Requirement of PyP100
         PyP100 = pkgs.python3Packages.callPackage ./pkgs/PyP100 {inherit pkcs7;};
         plugp100 = pkgs.python3Packages.callPackage ./pkgs/plugp100 {};
         default = ghaf-robot;
+      };
+
+      apps = {
+        robotframework-browser-test = {
+          program = "${packages.robotframework-browser-test}/bin/robotframework-browser-test";
+          type = "app";
+        };
       };
 
       # Development shell

--- a/flake.nix
+++ b/flake.nix
@@ -4,12 +4,23 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
     flake-utils.url = "github:numtide/flake-utils";
+    blank.url = "github:divnix/blank";
+    dream2nix = {
+      url = "github:nix-community/dream2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+
+      # Blank unused inputs, to prevent unneeded downloads
+      inputs.pyproject-nix.follows = "blank";
+      inputs.purescript-overlay.follows = "blank";
+    };
   };
 
   outputs = {
     self,
     nixpkgs,
     flake-utils,
+    dream2nix,
+    ...
   }: let
     systems = with flake-utils.lib.system; [
       x86_64-linux
@@ -31,6 +42,7 @@
         robotframework-jsonlibrary = pkgs.python3Packages.callPackage ./pkgs/robotframework-jsonlibrary {};
         robotframework-retryfailed = pkgs.python3Packages.callPackage ./pkgs/robotframework-retryfailed {};
         robotframework-seriallibrary = pkgs.python3Packages.callPackage ./pkgs/robotframework-seriallibrary {};
+        robotframework-browser = pkgs.python3Packages.callPackage ./pkgs/robotframework-browser { inherit dream2nix; };
         robotframework-advancedlogging = pkgs.python3Packages.callPackage ./pkgs/robotframework-advancedlogging {};
         pkcs7 = pkgs.python3Packages.callPackage ./pkgs/pkcs7 {}; # Requirement of PyP100
         PyP100 = pkgs.python3Packages.callPackage ./pkgs/PyP100 {inherit pkcs7;};

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A flake for for running Robot Framework tests";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/pkgs/robotframework-browser/default.nix
+++ b/pkgs/robotframework-browser/default.nix
@@ -1,0 +1,204 @@
+{
+  lib,
+  stdenv,
+  pkgs,
+  dream2nix,
+  runCommand,
+  which,
+  buildPythonPackage,
+  robotframework,
+  fetchpatch2,
+  fetchPypi,
+  fetchFromGitHub,
+  playwright-driver,
+  poetry-core,
+  robotframework-pythonlibcore,
+  overrides,
+  seedir,
+  grpcio,
+  wrapt,
+  setuptools,
+  cython,
+  c-ares,
+  openssl,
+  six,
+  pkg-config,
+  zlib,
+}:
+let
+  protobuf = buildPythonPackage rec {
+    pname = "protobuf";
+    version = "5.28.3";
+    pyproject = true;
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-ZLrbxJGApeQB83P5znqx0Ytj991KnNxDySufC0gc73s=";
+    };
+
+    build-system = [ setuptools ];
+  };
+  grpcio = buildPythonPackage rec {
+    pname = "grpcio";
+    format = "setuptools";
+    version = "1.67.0";
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-4JCyVT4Noch1RJyOdQc91EFd1xyb3mpAYkD99MDuRnw=";
+    };
+
+    outputs = [
+      "out"
+      "dev"
+    ];
+
+    nativeBuildInputs = [
+      cython
+      pkg-config
+    ];
+
+    buildInputs = [
+      c-ares
+      openssl
+      zlib
+    ];
+    propagatedBuildInputs =
+      [
+        six
+        protobuf
+      ];
+    preBuild =
+    ''
+      export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS="$NIX_BUILD_CORES"
+      if [ -z "$enableParallelBuilding" ]; then
+        GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=1
+      fi
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      unset AR
+    '';
+
+  GRPC_BUILD_WITH_BORING_SSL_ASM = "";
+  GRPC_PYTHON_BUILD_SYSTEM_OPENSSL = 1;
+  GRPC_PYTHON_BUILD_SYSTEM_ZLIB = 1;
+  GRPC_PYTHON_BUILD_SYSTEM_CARES = 1;
+  };
+
+  # the pypi source archive does not ship tests
+  doCheck = false;
+  robotframework-assertion-engine = buildPythonPackage rec {
+    pname = "robotframework-assertion-engine";
+    version = "3.0.3";
+    format = "pyproject";
+
+    src = fetchFromGitHub {
+      owner = "MarketSquare";
+      repo = "AssertionEngine";
+      rev = "v${version}";
+      sha256 = "sha256-RPaCf5IzLEUVsolpWvTD/ShXrFo+GAkVaEfmwSBGQdM=";
+    };
+
+    nativeBuildInputs = [ poetry-core ];
+    propagatedBuildInputs = [
+      robotframework
+      robotframework-pythonlibcore
+    ];
+
+  };
+
+  version = "18.9.1";
+  pname = "robotframework-browser";
+  rf-browser-sources = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-+6RXnLOtZJzQOoz3fu5T8gEphgf6x8/PHbP3iqrp/WI=";
+  };
+  browser-wrapper-sources =  stdenv.mkDerivation {
+    preferLocalBuild = true;
+    pname = "browser-wrapper-sources";
+    inherit version;
+    src = rf-browser-sources;
+    buildPhase = "";
+    installPhase = ''
+      cp -rv Browser/wrapper $out
+    '';
+  };
+  browser-wrapper = dream2nix.lib.evalModules {
+    packageSets.nixpkgs = pkgs; 
+    modules = [
+      ({ dream2nix, config, ...}: {
+        imports = [
+          dream2nix.modules.dream2nix.nodejs-package-lock-v3
+          dream2nix.modules.dream2nix.nodejs-granular-v3
+        ];
+        mkDerivation.src = browser-wrapper-sources;
+        deps = {...}: { inherit stdenv; };
+        nodejs-package-lock-v3 = {
+          packageLockFile = "${config.mkDerivation.src}/package-lock.json";
+        };
+        nodejs-granular-v3.overrides."grpc-tools".mkDerivation.postPatch = ''
+          find ${pkgs.grpc-tools}
+          substituteInPlace package.json --replace-fail "node-pre-gyp install" "cp ${pkgs.grpc-tools}/bin/protoc bin/ && cp ${pkgs.grpc-tools}/bin/grpc_node_plugin bin";
+        '';
+        mkDerivation.postPatch = ''
+          substituteInPlace package.json --replace-fail "node ./node/build.wrapper.js" "echo Nope" 
+        '';
+        mkDerivation.nativeBuildInputs = [ which ];
+        mkDerivation.postInstall = ''
+          mkdir -p $out/bin
+          which node
+          makeWrapper "$(which node)" "$out/bin/node" \
+            --prefix NODE_PATH : ${placeholder "out"}/lib/node_modules \
+            --set-default PLAYWRIGHT_BROWSERS_PATH "${playwright-driver.passthru.browsers}"
+        '';
+        name = "browser-wrapper";
+        inherit version;
+      })
+    ];
+  };
+in
+buildPythonPackage rec {
+  inherit pname version;
+  format = "setuptools";
+  src = rf-browser-sources;
+
+  postPatch = ''
+    substituteInPlace Browser/playwright.py --replace-fail '"node"' '"${browser-wrapper}/bin/node"'
+  '';
+
+  postInstall = ''
+    ln -sf ${browser-wrapper}/lib/node_modules $out/lib/python3.11/site-packages/Browser/wrapper/node_modules 
+  '';
+
+#  patches = [
+#     (fetchpatch2 {
+#       url = "https://github.com/MarketSquare/robotframework-browser/commit/d4456964ba3bae455f5de4a09d465a61d1c4a6ca.patch";
+#       sha256 = "sha256-GIM8yFWJoT3iNS0w7y1ofzE2ivsdS1BmUB2QDpmmjXo=";
+#     })
+#   ];
+
+  doCheck = false; # Tests failing
+  preCheck = ''
+    export PLAYWRIGHT_BROWSERS_PATH=${playwright-driver.browsers}
+  '';
+
+  pythonImportsCheck = [ "Browser" ];
+
+  propagatedBuildInputs = [
+    browser-wrapper # FIXME
+    robotframework
+    robotframework-assertion-engine
+    robotframework-pythonlibcore
+    overrides
+    seedir
+    protobuf
+    grpcio
+    wrapt
+  ];
+
+  meta = with lib; {
+    description = "Robot Framework Browser library powered by Playwright.";
+    homepage = "https://github.com/MarketSquare/robotframework-browser";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/robotframework-browser/make-browsers.py
+++ b/pkgs/robotframework-browser/make-browsers.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+import json
+import shutil
+import sys
+import os
+
+root = sys.argv[1]
+br_json = sys.argv[2]
+
+print("processing {}".format(br_json))
+with open(br_json) as file:
+    browsers = json.load(file)
+    browsers = {each["name"]: each for each in browsers["browsers"]}
+
+
+for each in sys.argv[3:]:
+    name, path = each.split("=")
+    targetname = os.path.basename(path)
+    if targetname == "chromium":
+        targetname = "chrome" 
+    dirname = os.path.join(root, "{}-{}/{}-linux".format(name, browsers[name]["revision"], targetname))
+    target = os.path.join(dirname, targetname)
+    os.makedirs(dirname)
+    print("symlinking {} to {}".format(path, target))
+    os.symlink(path, target)
+
+

--- a/pkgs/robotframework-browser/test.nix
+++ b/pkgs/robotframework-browser/test.nix
@@ -1,0 +1,5 @@
+{ pkgs, robotframework-browser }:
+
+pkgs.writers.writePython3Bin "robotframework-browser-test" {
+  libraries = [ robotframework-browser ];
+} (builtins.readFile ./test.py)

--- a/pkgs/robotframework-browser/test.py
+++ b/pkgs/robotframework-browser/test.py
@@ -1,0 +1,5 @@
+import Browser
+browser = Browser.Browser()
+browser.new_page("https://playwright.dev")
+assert 'Playwright' in browser.get_text("h1")
+browser.close_browser()


### PR DESCRIPTION
Add robot framework browser.

For test  `nix run -L ".#robotframework-browser-test"`
Or perform testing stepts from https://github.com/MarketSquare/robotframework-browser/tree/main

Current limitation:
 - Only chromium browser supported
 - At least one IFD in nix stuff (I would address it later if it critical)
 - Node part download all dependencies, where only runtime needed.