### PR TITLE
Fix sysbench test in NetVM

### DIFF
--- a/Robot-Framework/lib/PerformanceDataProcessing.py
+++ b/Robot-Framework/lib/PerformanceDataProcessing.py
@@ -203,7 +203,10 @@ class PerformanceDataProcessing:
 
         # Set threshold for fail depending on test type: single/multi thread
         if "One thread" in test_name or "1thread" in test_name:
-            threshold = thresholds['cpu']['single']
+            if "NUC" in self.device:
+                threshold = thresholds['cpu']['single_nuc']
+            else:
+               threshold = thresholds['cpu']['single']
         else:
             threshold = thresholds['cpu']['multi']
 
@@ -453,9 +456,15 @@ class PerformanceDataProcessing:
         # Set threshold for fail depending on test type: single/multi thread, write/read
         if "One thread" in test_name or "1thread" in test_name:
             if "rite" in test_name:
-                threshold = thresholds['mem']['single']['wr']
+                if "NUC" in self.device:
+                    threshold = thresholds['mem']['single']['wr_nuc']
+                else:
+                    threshold = thresholds['mem']['single']['wr']
             else:
-                threshold = thresholds['mem']['single']['rd']
+                if "NUC" in self.device:
+                    threshold = thresholds['mem']['single']['rd_nuc']
+                else:
+                    threshold = thresholds['mem']['single']['rd']
         else:
             if "rite" in test_name:
                 threshold = thresholds['mem']['multi']['wr']

--- a/Robot-Framework/lib/performance_thresholds.py
+++ b/Robot-Framework/lib/performance_thresholds.py
@@ -4,7 +4,8 @@
 thresholds = {
     'cpu': {
         'multi': 700,
-        'single': 40
+        'single': 40,
+        'single_nuc': 120
     },
     'mem': {
         'multi': {
@@ -13,7 +14,9 @@ thresholds = {
         },
         'single': {
             'wr': 350,
-            'rd': 250
+            'rd': 250,
+            'wr_nuc': 800,
+            'rd_nuc': 800
         }
     },
     'fileio': {

--- a/Robot-Framework/test-suites/bat-tests/timesync.robot
+++ b/Robot-Framework/test-suites/bat-tests/timesync.robot
@@ -50,7 +50,7 @@ Check that time is correct
     [Documentation]   Check that current system time is correct (time tolerance = 10 sec)
     [Arguments]       ${timezone}=UTC
 
-    ${is_started} =   Set Variable    False
+    ${is_synchronized} =   Set Variable    False
     FOR    ${i}    IN RANGE    3
         ${output}      Execute Command    timedatectl -a
         ${local_time}  ${universal_time}  ${rtc_time}  ${device_time_zone}  ${is_synchronized}   Parse time info  ${output}

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -256,7 +256,7 @@ Sysbench test in NetVM
     END
     IF  "${statistics_mem_wr}[flag]" == "-1"
         ${add_msg}      Create fail message  ${statistics_mem_wr}
-        ${fail_msg}=    Set Variable  ${fail_msg}\nMEM WRITE:\n${add_msg}
+        ${fail_msg}=    Set Variable  ${msg}\nMEM WRITE:\n${add_msg}
     END
     IF  "${statistics_mem_wr}[flag]" == "1"
         ${add_msg}      Create improved message  ${statistics_mem_wr}


### PR DESCRIPTION
Fixed wrong variable name. Added target specific thresholds for NUC since it has higher deviation in cpu/mem results than other targets.

Also minor correction to keyword 'Check that time is correct'