### PR TITLE
Remove unnecessary libraries

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/apps.robot
+++ b/Robot-Framework/test-suites/bat-tests/apps.robot
@@ -7,9 +7,6 @@ Force Tags          apps
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../config/variables.robot
 Resource            ../../resources/common_keywords.resource
-Library             ../../lib/gui_testing.py
-Library             Collections
-Library             BuiltIn
 Suite Teardown      Close All Connections
 
 


### PR DESCRIPTION
gui_testing.py was causing module not found error. If the error arises when gui test suite is included it should be dealt with.