### PR TITLE
Fix sysbench fileio test

### DIFF
--- a/Robot-Framework/test-suites/performance-tests/fileio_test
+++ b/Robot-Framework/test-suites/performance-tests/fileio_test
@@ -5,7 +5,7 @@ THREADS="$1"
 DISK_CHECK_DIRECTORY="${2:-/}"
 
 # Create a directory for the results and copy this script into it
-RESULT_DIR="/home/ghaf/sysbench_results"
+RESULT_DIR="/tmp/sysbench_results"
 echo -e "\nCreating directory for test results:\n$RESULT_DIR"
 mkdir -p $RESULT_DIR
 FileName=${0##*/}


### PR DESCRIPTION
Used https://github.com/tiiuae/ci-test-automation/pull/191 as the starting point.

Notes:
- Each Execute Command keyword run in a new shell. So doing cd on one Execute Command line does not affect the working directory of another Execute Command line. However, with Write it remains in the same shell.
- Had to Read Until "Test finished.". Read Until Prompt didn't work for some reason.
- Had to increase timeout temporarily for Read Until. For now I set it to 15min (and then back to 30s), should be enough as on my local test runs the fileio test took 4.5 minutes.