### PR TITLE
Fix bat init and disable suspend after login

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -29,6 +29,8 @@ Log in via GUI
         Type string and press enter  ${USER_PASSWORD}
     END
     Verify login
+    Log To Console    Disabling automated lock and suspend
+    Execute Command   systemctl --user stop swayidle
 
 Log out
     [Documentation]   Log out and optionally verify that desktop is not available
@@ -69,7 +71,6 @@ Locate image on screen
         IF    $pass_status=='PASS'    BREAK
         Sleep  0.5
     END
-    Connect to VM           ${GUI_VM}
     IF    $pass_status=='FAIL'    FAIL  Image recognition failure: ${image_to_be_searched}
     Log To Console    Coordinates: ${coordinates}
     ${mouse_x}  Get From Dictionary   ${coordinates}  x
@@ -79,6 +80,7 @@ Locate image on screen
 Locate and click
     [Arguments]   ${image_to_be_searched}  ${confidence}=0.99  ${iterations}=5
     ${mouse_x}  ${mouse_y}  Locate image on screen  ${image_to_be_searched}   ${confidence}
+    Connect to VM     ${GUI_VM}
     Execute Command   ydotool mousemove --absolute -x ${mouse_x} -y ${mouse_y}  sudo=True  sudo_password=${PASSWORD}
     Execute Command   ydotool click 0xC0  sudo=True  sudo_password=${PASSWORD}
 

--- a/Robot-Framework/test-suites/bat-tests/__init__.robot
+++ b/Robot-Framework/test-suites/bat-tests/__init__.robot
@@ -7,6 +7,7 @@ Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/serial_keywords.resource
 Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/connection_keywords.resource
+Resource            ../../resources/gui_keywords.resource
 Suite Setup         BAT tests setup
 Suite Teardown      BAT tests teardown
 
@@ -21,14 +22,15 @@ BAT tests setup
         Connect to VM         ${GUI_VM}
         Save most common icons and paths to icons
         Create test user
-        GUI Log in
+        Log in via GUI
     END
+    Switch Connection    ${CONNECTION}
 
 BAT tests teardown
     Connect to ghaf host
     Log journctl
     IF  "Lenovo" in "${DEVICE}"
         Connect to netvm
-        GUI Log out
+        Log out
     END
     Close All Connections

--- a/Robot-Framework/test-suites/bat-tests/apps.robot
+++ b/Robot-Framework/test-suites/bat-tests/apps.robot
@@ -7,7 +7,6 @@ Force Tags          apps
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../config/variables.robot
 Resource            ../../resources/common_keywords.resource
-Test Setup          Run Keywords  Move cursor  AND  Switch Connection  ${CONNECTION}
 
 
 *** Variables ***
@@ -103,3 +102,4 @@ Kill Process And Log journalctl
     ${output}     Execute Command    journalctl
     Log  ${output}
     Kill process  @{APP_PIDS}
+    Close All Connections

--- a/Robot-Framework/test-suites/bat-tests/business_vm.robot
+++ b/Robot-Framework/test-suites/bat-tests/business_vm.robot
@@ -8,8 +8,7 @@ Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/virtualization_keywords.resource
 Resource            ../../config/variables.robot
 Resource            ../../resources/common_keywords.resource
-Test Setup          Move cursor
-Test Teardown       Kill process  @{APP_PIDS}
+Test Teardown       Business Apps Test Teardown
 
 
 *** Test Cases ***
@@ -76,3 +75,10 @@ Start Xarchiver on LenovoX1
     Start XDG application   "Xarchiver"
     Connect to VM       ${BUSINESS_VM}
     Check that the application was started    xarchiver
+
+
+*** Keywords ***
+
+Business Apps Test Teardown
+    Kill process       @{APP_PIDS}
+    Close All Connections

--- a/Robot-Framework/test-suites/bat-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/bat-tests/gui-vm.robot
@@ -61,4 +61,4 @@ Gui-vm apps teardown
     Connect to VM       ${GUI_VM}  ${USER_LOGIN}  ${USER_PASSWORD}
     ${app_log}          Execute command    cat output.log
     Log                 ${app_log}
-    Move cursor
+    Close All Connections

--- a/Robot-Framework/test-suites/bat-tests/timesync.robot
+++ b/Robot-Framework/test-suites/bat-tests/timesync.robot
@@ -19,7 +19,7 @@ ${change_time}      ${EMPTY}
 Time synchronization
     [Documentation]   Stop timesyncd, change time on ghaf host and check that time was changed
     ...               Start timesyncd and check that time was synchronized
-    [Tags]            bat   SP-T97   nuc  orin-agx  orin-nx  riscv
+    [Tags]            bat   SP-T97   nuc  orin-agx  orin-nx  riscv  lenovo-x1
 
     ${host}  Connect
     Check that time is correct  timezone=UTC
@@ -68,12 +68,12 @@ Check that time is correct
 
 Set time
     [Arguments]       ${time}=${wrong_time}
-    ${change_time}    Get Time	epoch
-    ${change_time}    Set Test Variable     ${change_time}
-    Log To Console    Setting time ${time}
-    Execute Command   hwclock --set --date="${time}"  sudo=True  sudo_password=${PASSWORD}
-    Execute Command   hwclock -s  sudo=True  sudo_password=${PASSWORD}
-    ${output}         Execute Command  timedatectl -a
+    ${change_time}        Get Time	epoch
+    Set Test Variable     ${change_time}  ${change_time}
+    Log To Console        Setting time ${time}
+    Execute Command       hwclock --set --date="${time}"  sudo=True  sudo_password=${PASSWORD}
+    Execute Command       hwclock -s  sudo=True  sudo_password=${PASSWORD}
+    ${output}             Execute Command  timedatectl -a
 
 Check time was changed
     [Documentation]   Check that current system time is equal to given (time tolerance = 10 sec)


### PR DESCRIPTION
In addition
- Removed cursor movements implemented to prevent auto suspend
- Close the ssh connections which are not going to be used
- Include timesync test into lenovo-x1 tests