### PR TITLE
Enable chrome launch test to close another window

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -25,6 +25,7 @@ Check that the application is not running
     ${pids}=  Set Variable  ${EMPTY}
     FOR   ${i}   IN RANGE  ${range}
         ${keyword_status}  ${pids}  Run Keyword And Ignore Error   Find pid by name    ${app_name}
+        Set Global Variable  @{APP_PIDS}  @{pids}
         ${status}    Run Keyword And Return Status   Should Be Empty  ${pids}
         IF    ${status}    BREAK
         Sleep   1


### PR DESCRIPTION
At first launch chrome opens window for selecting account. At the moment this window is closed it opens still another window, the actual browser window. This is a feature of chrome and we need to adapt the launch test for that.

This PR handles also the situation that chrome has already been launched and only single window needs to be closed. 

Different scenarios can be tested by manually opening 0-2 chrome windows prior to running the test SP-T41.