### PR TITLE
Tag 'pre-merge' set only for selected 4 tests.

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/apps.robot
+++ b/Robot-Framework/test-suites/bat-tests/apps.robot
@@ -17,7 +17,7 @@ Resource            ../../resources/common_keywords.resource
 
 Start Firefox
     [Documentation]   Start Firefox and verify process started
-    [Tags]            bat   pre-merge   SP-T41  nuc  orin-agx
+    [Tags]            bat  SP-T41  nuc  orin-agx
     [Setup]           Skip If   "${JOB}" == "nvidia-jetson-orin-agx-debug-nodemoapps-from-x86_64.x86_64-linux"
     ...               Skipped because this build doesn't contain applications
     Connect
@@ -39,7 +39,7 @@ Start Chrome on LenovoX1
 
 Start Zathura on LenovoX1
     [Documentation]   Start Zathura in dedicated VM and verify process started
-    [Tags]            bat   pre-merge   SP-T105   lenovo-x1
+    [Tags]            bat  SP-T105   lenovo-x1
     Connect to netvm
     Check if ssh is ready on vm    ${ZATHURA_VM}
     Connect to VM       ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
@@ -52,7 +52,7 @@ Start Zathura on LenovoX1
 
 Start Gala on LenovoX1
     [Documentation]   Start Gala in dedicated VM and verify process started
-    [Tags]            bat   pre-merge   SP-T104   lenovo-x1
+    [Tags]            bat  SP-T104   lenovo-x1
     Connect to netvm
     Check if ssh is ready on vm    ${GALA_VM}
     Connect to VM          ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
@@ -63,7 +63,7 @@ Start Gala on LenovoX1
 
 Start Element on LenovoX1
     [Documentation]   Start Element in dedicated VM and verify process started
-    [Tags]            bat   pre-merge   SP-T52   lenovo-x1
+    [Tags]            bat  SP-T52   lenovo-x1
     Connect to netvm
     Check if ssh is ready on vm    ${COMMS_VM}
     Connect to VM          ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
@@ -74,7 +74,7 @@ Start Element on LenovoX1
 
 Start Slack on LenovoX1
     [Documentation]   Start Slack in dedicated VM and verify process started
-    [Tags]            bat   pre-merge   SP-T181   lenovo-x1
+    [Tags]            bat  SP-T181   lenovo-x1
     Connect to netvm
     Check if ssh is ready on vm    ${COMMS_VM}
     Connect to VM          ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}

--- a/Robot-Framework/test-suites/bat-tests/business_vm.robot
+++ b/Robot-Framework/test-suites/bat-tests/business_vm.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       Testing Business VM
-Force Tags          bat   pre-merge  businessvm  lenovo-x1
+Force Tags          bat  businessvm  lenovo-x1
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/virtualization_keywords.resource
 Resource            ../../config/variables.robot

--- a/Robot-Framework/test-suites/bat-tests/netvm.robot
+++ b/Robot-Framework/test-suites/bat-tests/netvm.robot
@@ -22,7 +22,7 @@ ${NETVM_SSH}       ${EMPTY}
 
 Verify NetVM is started
     [Documentation]         Verify that NetVM is active and running
-    [Tags]                  bat   pre-merge   SP-T45  nuc  orin-agx  orin-nx  lenovo-x1
+    [Tags]                  bat  SP-T45  nuc  orin-agx  orin-nx  lenovo-x1
     [Setup]                 Connect to ghaf host
     Verify service status   service=${netvm_service}
     Check Network Availability      ${NETVM_IP}    expected_result=True    range=5
@@ -30,7 +30,7 @@ Verify NetVM is started
 
 Wifi passthrought into NetVM
     [Documentation]     Verify that wifi works inside netvm
-    [Tags]              bat   pre-merge   SP-T101   SP-T111  orin-agx  lenovo-x1
+    [Tags]              bat  SP-T101   SP-T111  orin-agx  lenovo-x1
     [Setup]             Run Keywords
     ...                 Connect to ghaf host  AND  Connect to netvm
     Configure wifi      ${NETVM_SSH}  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
@@ -55,14 +55,14 @@ Wifi passthrought into NetVM (NUC)
 
 NetVM stops and starts successfully
     [Documentation]     Verify that NetVM stops properly and starts after that
-    [Tags]              bat   pre-merge   SP-T47  SP-T90  nuc  orin-nx  lenovo-x1
+    [Tags]              bat  SP-T47  SP-T90  nuc  orin-nx  lenovo-x1
     [Setup]     Connect to ghaf host
     Restart NetVM
     [Teardown]  Run Keywords  Start NetVM if dead   AND  Close All Connections
 
 NetVM is wiped after restarting
     [Documentation]     Verify that created file will be removed after restarting VM
-    [Tags]              bat   pre-merge   SP-T48  nuc  orin-nx  lenovo-x1
+    [Tags]              bat  SP-T48  nuc  orin-nx  lenovo-x1
     [Setup]             Run Keywords
     ...                 Connect to ghaf host  AND  Connect to netvm
     Switch Connection   ${NETVM_SSH}
@@ -79,7 +79,7 @@ NetVM is wiped after restarting
 
 Verify NetVM PCI device passthrough
     [Documentation]     Verify that proper PCI devices have been passed through to the NetVM
-    [Tags]              bat   pre-merge   SP-T96  nuc  orin-agx  orin-nx
+    [Tags]              bat  SP-T96  nuc  orin-agx  orin-nx
     [Setup]             Run Keywords
     ...                 Connect to ghaf host  AND  Connect to netvm
     Verify microvm PCI device passthrough    host_connection=${GHAF_HOST_SSH}    vm_connection=${NETVM_SSH}    vmname=${NETVM_NAME}

--- a/Robot-Framework/test-suites/bat-tests/optee.robot
+++ b/Robot-Framework/test-suites/bat-tests/optee.robot
@@ -28,7 +28,7 @@ OP-TEE xtest
        ...              2. Delete corresponding "OP-TEE xtest XXXX" test case
        ...
        ...              (3. If everything is fixed (no more "-x"-flags), remove this comment!!)
-       [Tags]  bat   pre-merge  optee  optee-xtest  orin-agx  orin-nx  SP-T122
+       [Tags]  bat  optee  optee-xtest  orin-agx  orin-nx  SP-T122
 
        ${stdout}    ${stderr}    ${rc}=    Execute Command    xtest -x 1008 -x 1033    sudo=True    sudo_password=${PASSWORD}    return_stdout=True    return_stderr=True    return_rc=True
        Log     ${stdout}
@@ -39,7 +39,7 @@ OP-TEE xtest 1008
     [Documentation]   Xtest 1008
     ...               Test will be skipped in case of failure, because this is a known issue.
     ...               Please read OP-TEE Test suite comment
-    [Tags]  bat   pre-merge  optee  optee-xtest  orin-agx  orin-nx  SP-T129
+    [Tags]  bat  optee  optee-xtest  orin-agx  orin-nx  SP-T129
 
     ${stdout}    ${stderr}    ${rc}=    Execute Command    xtest 1008   sudo=True    sudo_password=${PASSWORD}    return_stdout=True    return_stderr=True    return_rc=True
     Should Be Equal As Integers    ${rc}    1
@@ -50,7 +50,7 @@ OP-TEE xtest 1033
     [Documentation]   Xtest 1033
     ...               Test will be skipped in case of failure, because this is a known issue.
     ...               Please read OP-TEE Test suite comment
-    [Tags]  bat   pre-merge  optee  optee-xtest  orin-agx  orin-nx  SP-T129
+    [Tags]  bat  optee  optee-xtest  orin-agx  orin-nx  SP-T129
 
     ${stdout}    ${stderr}    ${rc}=    Execute Command    xtest 1033   sudo=True    sudo_password=${PASSWORD}    return_stdout=True    return_stderr=True    return_rc=True
     Should Be Equal As Integers    ${rc}    1
@@ -63,7 +63,7 @@ Basic pkcs11-tool-optee test
     ...               calling OP-TEE. Then it generates RSA 2048-bit and ECDSA
     ...               secp256r1 keys, for which signing and signature
     ...               verification operations are tested.
-    [Tags]            bat   pre-merge  optee  SP-T113  orin-agx  orin-nx
+    [Tags]            bat  optee  SP-T113  orin-agx  orin-nx
 
     ${tool}=    Set Variable    "pkcs11-tool-optee"
     List key slots    ${tool}

--- a/Robot-Framework/test-suites/bat-tests/others.robot
+++ b/Robot-Framework/test-suites/bat-tests/others.robot
@@ -48,7 +48,7 @@ Check systemctl status
 
 Check all VMs are running
     [Documentation]    Verify systemctl status of all VMs is running
-    [Tags]             bat   pre-merge  SP-T68  lenovo-x1
+    [Tags]             bat  SP-T68  lenovo-x1
     [Setup]     Connect
     ${output}   Execute Command    microvm -l
     @{vms}      Extract VM names   ${output}


### PR DESCRIPTION
The idea is to select the most robust & reliable cases at first to start with.  More tests are going to be tagged one by one when a test is seen having such maturity that it should fail only if there is really something wrong

Selected tests:
    Start Chrome on LenovoX1
    Test ghaf version format
    Test nixos version format
    Check systemctl status
    
This PR changes only automated test tags, we need to finetune the 'pre-merge' jenkins pipelines a bit as well due to this.    