### PR TITLE
Allow setting more variables via command line

### DIFF
--- a/Robot-Framework/lib/send_report.py
+++ b/Robot-Framework/lib/send_report.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+import paramiko
+import time
+import sys
+
+passwd = sys.argv[1]
+
+def main():
+    start_time = time.time()
+    print('Sending ci-test-automation report files to chrome-vm:/tmp to be read with chrome app.')
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy)
+    client.connect("chrome-vm", port=22, username='ghaf', password=passwd)
+    chan = client.invoke_shell()
+
+    print("Remove already existing report files on chrome-vm.")
+    send_and_receive(chan, 'sudo rm /tmp/*.html /tmp/output.xml\n', 5, 999, 'password')
+    send_and_receive(chan, 'ghaf\n', 5, 999)
+
+    print("Sending files.")
+    scp = client.open_sftp()
+    scp.put('../test-suites/report.html', '/tmp/report.html')
+    scp.put('../test-suites/log.html', '/tmp/log.html')
+    scp.put('../test-suites/output.xml', '/tmp/output.xml')
+    time.sleep(5)
+    scp.close()
+
+    print("Editing ownership.")
+    send_and_receive(chan, 'sudo chown appuser:users /tmp/*.html /tmp/output.xml\n', 5, 999, 'password')
+    send_and_receive(chan, 'ghaf\n', 5, 999)
+
+    client.close()
+    end_time = time.time()
+    execution_time = end_time - start_time
+    print("Elapsed time: " + str(execution_time))
+
+def send_and_receive(chan, cmd, wait_time, recv_buffer, expected=''):
+
+    chan.send(cmd)
+
+    clock = 0
+    while True:
+
+        data = chan.recv_ready()
+        if data:
+            clock = 0
+            resp = chan.recv(recv_buffer)
+            output = resp.decode('utf-8')
+            print(output)
+            if output.find(expected) != -1:
+                time.sleep(0.5)
+                return True
+        else:
+            time.sleep(1)
+            # print(clock)
+            clock += 1
+        if clock > wait_time:
+            return False
+
+
+main()

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -12,6 +12,7 @@ Library             Collections
 
 ${START_MENU}         ./launcher.png
 ${LOGGED_IN_STATUS}   ${True}
+${DISABLE_LOGOUT}     ${EMPTY}
 
 *** Keywords ***
 
@@ -35,6 +36,12 @@ Log in via GUI
 Log out
     [Documentation]   Log out and optionally verify that desktop is not available
     [Arguments]        ${log_out_icon}=./logout.png
+    # Allow disabling logout in case of running test automation locally from ghaf-host.
+    # This prevents terminal from being shutdown and allows test run to finish.
+    IF  $DISABLE_LOGOUT == 'true'
+        Log To Console    Log out disabled. Skipping log out procedure.
+        RETURN
+    END
     Start ydotoold
     Get icon           ghaf-artwork  power.svg  crop=0  background=black
     Locate and click   ./icon.png  0.95  5

--- a/Robot-Framework/test-suites/bat-tests/__init__.robot
+++ b/Robot-Framework/test-suites/bat-tests/__init__.robot
@@ -7,8 +7,13 @@ Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/connection_keywords.resource
 Resource            ../../resources/gui_keywords.resource
+Library             OperatingSystem
 Suite Setup         BAT tests setup
 Suite Teardown      BAT tests teardown
+
+
+*** Variables ***
+${DISABLE_LOGOUT}     ${EMPTY}
 
 
 *** Keywords ***

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,7 @@
               pandas
               pyscreeze
               python3Packages.opencv4
+              paramiko
             ]))
         ];
       };


### PR DESCRIPTION
The purpose of this PR is to bring more flexibility into manual use of ci-test-automation and to make local smoke testing faster. Fully automated setups should not be affected.

CONFIG_PATH (path to test_config.json) can be given via command line. If not given it defaults to the current path. 

If CONFIG_PATH is set to `None` reading config file variables will be ignored which allows setting target IP address from command line. This makes local testing more straightforward, not having to create or modify test_config.json.

Prevents Set Variables from overwriting password (given via cmd line) if /run/secrets/dut-pass does not exist.

Custom test user name and password are now allowed. They can be stored to /etc/secrets/testuser and /etc/secrets/testpw. If those files don't exist test user credentials default to testuser/testpw. 

**Steps to run smoke tests locally from ghaf-host:**
```
Open terminal and ssh to ghaf-host
cd /home
sudo su
git clone https://github.com/leivos-unikie/ci-test-automation.git
cd ci-test-automation/Robot-Framework/test-suites
nix develop
git checkout optional_config
robot -v CONFIG_PATH:None -v DISABLE_LOGOUT:true -v DEVICE:Lenovo-X1 -v DEVICE_IP_ADDRESS:192.168.100.1 -v PASSWORD:ghaf -i lenovo-x1ANDpre-merge ./
```

I ran also with
`robot -v CONFIG_PATH:None -v DEVICE:Lenovo-X1 -v DEVICE_IP_ADDRESS:192.168.100.1 -v PASSWORD:ghaf -i lenovo-x1ANDbat -i lenovo-x1ANDgui-apps ./`
after setting wifi credentials to /run/secrets and all test cases passed except timesync test (in current state it assumes unchanged time on the machine running robot framework).

If running the tests from separate machine just set the target IP to DEVICE_IP_ADDRESS.

If running tests locally from ghaf-host of Lenovo-X1 the result files can be sent to chrome-vm after the tests have finished by `python ../lib/send_report.py password` and then opened with chrome app by typing /tmp/report.html to the url field.