### PR TITLE
Add 'robotframework-debuglibrary' -package to QA test environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,11 +27,13 @@
           robotframework-jsonlibrary = self.packages.${system}.robotframework-jsonlibrary;
           robotframework-retryfailed = self.packages.${system}.robotframework-retryfailed;
           robotframework-seriallibrary = self.packages.${system}.robotframework-seriallibrary;
+          robotframework-debuglibrary = self.packages.${system}.robotframework-debuglibrary;
         };
         robotframework-jsonlibrary = pkgs.python3Packages.callPackage ./pkgs/robotframework-jsonlibrary {};
         robotframework-retryfailed = pkgs.python3Packages.callPackage ./pkgs/robotframework-retryfailed {};
         robotframework-seriallibrary = pkgs.python3Packages.callPackage ./pkgs/robotframework-seriallibrary {};
         robotframework-advancedlogging = pkgs.python3Packages.callPackage ./pkgs/robotframework-advancedlogging {};
+        robotframework-debuglibrary = pkgs.python3Packages.callPackage ./pkgs/robotframework-debuglibrary {};
         pkcs7 = pkgs.python3Packages.callPackage ./pkgs/pkcs7 {}; # Requirement of PyP100
         PyP100 = pkgs.python3Packages.callPackage ./pkgs/PyP100 {inherit pkcs7;};
         plugp100 = pkgs.python3Packages.callPackage ./pkgs/plugp100 {};
@@ -53,6 +55,7 @@
               self.packages.${system}.robotframework-retryfailed
               self.packages.${system}.robotframework-seriallibrary
               self.packages.${system}.robotframework-advancedlogging
+              self.packages.${system}.robotframework-debuglibrary
               self.packages.${system}.PyP100
               self.packages.${system}.plugp100
               robotframework-sshlibrary

--- a/pkgs/ghaf-robot/default.nix
+++ b/pkgs/ghaf-robot/default.nix
@@ -9,6 +9,7 @@
   robotframework-jsonlibrary,
   robotframework-retryfailed,
   robotframework-seriallibrary,
+  robotframework-debuglibrary,
   stdenv,
   writeShellApplication,
 }:
@@ -34,6 +35,7 @@ writeShellApplication {
       robotframework-jsonlibrary
       robotframework-retryfailed
       robotframework-seriallibrary
+      robotframework-debuglibrary
       PyP100
       plugp100
     ]))

--- a/pkgs/robotframework-debuglibrary/default.nix
+++ b/pkgs/robotframework-debuglibrary/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  robotframework,
+}:
+buildPythonPackage rec {
+  version = "v2.5.0";
+  pname = "robotframework-debuglibrary";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "xyb";
+    repo = "robotframework-debuglibrary";
+    rev = "v2.5.0";
+    sha256 = "sha256-GgS6qj5wl3l3DmGRsmgr6oKvatdIWyz+Ys9X8yHWLRY=";
+  };
+
+  doCheck = false; # Tests failing
+  propagatedBuildInputs = [
+    robotframework
+  ];
+
+  meta = with lib; {
+    description = "Robotframework-DebugLibrary is a debug library for RobotFramework, which can be used as an interactive shell(REPL) also.";
+    homepage = "https://github.com/xyb/robotframework-debuglibrary";
+    license = licenses.bsd3;
+  };
+}

--- a/requirements
+++ b/requirements
@@ -2,6 +2,7 @@ pyserial==3.5
 robotframework-seriallibrary==0.4.2
 robotframework-sshlibrary==3.8.0
 robotframework-advancedlogging==2.0.0
+robotframework-debuglibrary==2.5.0
 robotframework==5.0.1
 PyP100==0.1.2
 python-kasa~=0.5.1


### PR DESCRIPTION
Configured the 'robotframework-debuglibrary' -package in to the system.

Usage: One can set a ' break point' into the robot framework code and stop the test into some interesting phase.
When test case stopped a debugging command shell opens and one can give robot framework keywords into that & see the results. This is usable feature when developing new tests/debugging the old ones.

This is not set on by default for all the files but one needs to set  2 lines described below if one want to use the feature.

Usage:
1) Add '**Library    DebugLibrary**' into the 'robot file' you want to set 'debug break point'
```
*** Settings ***
...
Library            DebugLibrary
```
2) Add '**Debug**' into the same 'robot-file' to line you want execution to stop
```
...
Do something
Log to console  Debug set to next line
Debug
```
And that opens the debug shell
```
>>>> Enter interactive shell
Only accepted plain text format keyword separated with two or more spaces.
Type "help" for more information.
> 
```
 If you want to fail test after debug you can set something like this here after 'Debug':
` FAIL   Fail the test after debugging.   `

3) When you want to leave from debugging shell, just type '**exit'**

After one is done with debugging remove the 2 lines 'Library  DebugLibrary' & 'Debug' from the file