### PR TITLE
Remove netvm restart tests from OrinAGX scope

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/netvm.robot
+++ b/Robot-Framework/test-suites/bat-tests/netvm.robot
@@ -53,14 +53,14 @@ Wifi passthrought into NetVM (NUC)
 
 NetVM stops and starts successfully
     [Documentation]     Verify that NetVM stops properly and starts after that
-    [Tags]              bat  SP-T47  SP-T90  nuc  orin-nx  orin-agx  lenovo-x1
+    [Tags]              bat  SP-T47  SP-T90  nuc  orin-nx  lenovo-x1
     [Setup]             Connect to ghaf host
     Restart NetVM
     [Teardown]          Run Keywords  Start NetVM if dead   AND  Close All Connections
 
 NetVM is wiped after restarting
     [Documentation]     Verify that created file will be removed after restarting VM
-    [Tags]              bat  SP-T48  nuc  orin-nx  orin-agx  lenovo-x1
+    [Tags]              bat  SP-T48  nuc  orin-nx  lenovo-x1
     [Setup]             Connect to netvm
     Create file         /etc/test.txt
     Switch Connection   ${GHAF_HOST_SSH}


### PR DESCRIPTION
Remove 2 tests from Orin-AGX execution since there is still something to investigate.