### PR TITLE
Log user when connecting to vm

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -94,7 +94,7 @@ Connect to netvm
 
 Connect to VM
     [Arguments]          ${vm_name}    ${user}=${LOGIN}   ${pw}=${PASSWORD}
-    Log To Console       Connecting to ${vm_name}
+    Log To Console       Connecting to ${vm_name} as ${user}
     Check if ssh is ready on vm        ${vm_name}
     ${failed_connection}  Set variable  True
     FOR    ${i}    IN RANGE    3


### PR DESCRIPTION
The goal is to make the logs more clear. Now there are sometimes multiple `Connecting to gui-vm` logs after each other.

Example of the output:

```
Creating test user
Connecting to gui-vm as milla
Connecting to gui-vm as ghaf
Logged out state detected. Logging in.
Connecting to gui-vm as ghaf
Check: ydotool daemon running
Typing username and password to login
Connecting to gui-vm as ghaf
Typing
Pressing Enter
Connecting to gui-vm as ghaf
Typing
Pressing Enter
Trying to reset scaling
Connecting to gui-vm as milla
Auto scaling reset failed
```