### PR TITLE
Adapt to ghaf pr915

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -30,12 +30,9 @@ Set Variables
     Set Global Variable  ${THREADS_NUMBER}     ${config['addresses']['${DEVICE}']['threads']}
     Set Global Variable  ${SWITCH_BOT}         ${config['addresses']['${DEVICE}']['switch_bot']}
     Set Global Variable  ${NETVM_NAME}         net-vm
-    Set Global Variable  ${CHROMIUM_VM_NAME}   chromium-vm
-    Set Global Variable  ${GUI_VM_NAME}        gui-vm
-    Set Global Variable  ${ZATHURA_VM_NAME}    zathura-vm
-    Set Global Variable  ${GALA_VM_NAME}       gala-vm
     Set Global Variable  ${NETVM_SERVICE}      microvm@${NETVM_NAME}.service
-    Set Global Variable  ${NETVM_IP}           192.168.101.1
+    Set Global Variable  ${NETVM_IP}           192.168.100.1
+    Set Global Variable  ${HOST_IP}            192.168.100.2
     Set Global Variable  ${GUI_VM}             gui-vm
     Set Global Variable  ${CHROME_VM}          chrome-vm
     Set Global Variable  ${GALA_VM}            gala-vm

--- a/Robot-Framework/resources/connection_keywords.resource
+++ b/Robot-Framework/resources/connection_keywords.resource
@@ -40,6 +40,7 @@ Initialize Variables And Connect
     IF  ${port_22_is_available} == False
         FAIL    Failed because port 22 of device was not available, tests can not be run.
     END
+    Connect to netvm
     ${CONNECTION}        Connect to ghaf host
     Set Global Variable  ${CONNECTION}
 

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -35,7 +35,6 @@ Log in via GUI
 Log out
     [Documentation]   Log out and optionally verify that desktop is not available
     [Arguments]        ${log_out_icon}=./logout.png
-    Switch Connection    ${CONNECTION}
     Start ydotoold
     Get icon           ghaf-artwork  power.svg  crop=0  background=black
     Locate and click   ./icon.png  0.95  5

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -10,9 +10,6 @@ Library             Process
 Library             ../lib/output_parser.py
 
 
-*** Variables ***
-${NETVM_IP}        192.168.101.1
-
 *** Keywords ***
 
 Ping Host
@@ -49,33 +46,29 @@ Check Network Availability
     END
 
 Connect
-    [Documentation]   Set up the SSH connection to the device
-    [Arguments]       ${IP}=${DEVICE_IP_ADDRESS}    ${PORT}=22    ${target_output}=ghaf@ghaf-host
+    [Documentation]   Set up the SSH connection to the device through net-vm
+    [Arguments]       ${IP}=${DEVICE_IP_ADDRESS}    ${PORT}=22    ${target_output}=ghaf@net-vm
     ${connection}=    Open Connection    ${IP}    port=${PORT}    prompt=\$    timeout=30
     ${output}=        Login     username=${LOGIN}    password=${PASSWORD}
     Should Contain    ${output}    ${target_output}
     RETURN            ${connection}
 
-Connect to ghaf host
-    [Documentation]      Open ssh connection to ghaf host
-    Log To Console       Connecting to Ghaf Host
-    ${connection}        Connect
-    Set Global Variable  ${GHAF_HOST_SSH}    ${connection}
-    RETURN               ${connection}
-
 Connect to netvm
-    [Documentation]      Connect to netvm directly from test run machine, using
-    ...                  jumphost, this allows using standard SSHLibrary
-    ...                  commands, like 'Execute Command'
+    [Documentation]      Open ssh connection net-vm
+    ${connection}        Connect
+    Set Global Variable  ${NETVM_SSH}    ${connection}
+    RETURN               ${NETVM_SSH}
+
+Connect to ghaf host
+    [Documentation]      Open SSH connection to Ghaf Host through net-vm
     [Arguments]    ${timeout}=60
-    Connect to ghaf host
-    Log To Console       Connecting to NetVM
+    Log To Console       Connecting to Ghaf Host via NetVM
     ${failed_connection}  Set variable  True
-    ${start_time}  Get Time	epoch
+    ${start_time}  Get Time     epoch
     FOR    ${i}    IN RANGE    10
         TRY
-            ${connection}=       Open Connection    ${NETVM_IP}    port=22    prompt=\$    timeout=30
-            ${output}=           Login    username=${LOGIN}     password=${PASSWORD}    jumphost_index_or_alias=${GHAF_HOST_SSH}
+            ${connection}=       Open Connection    ${HOST_IP}    port=22    prompt=\$    timeout=30
+            ${output}=           Login    username=${LOGIN}     password=${PASSWORD}    jumphost_index_or_alias=${NETVM_SSH}
         EXCEPT    ChannelException: ChannelException(2, 'Connect failed')    type=LITERAL
             ${diff}=    Evaluate    int(time.time()) - int(${start_time})
             IF   ${diff} < ${timeout}
@@ -88,9 +81,9 @@ Connect to netvm
         ${failed_connection}  Set variable  False
         BREAK
     END
-    IF  ${failed_connection}    FAIL  Couldn't connect NetVM
-    Set Global Variable  ${NETVM_SSH}    ${connection}
-    RETURN               ${NETVM_SSH}
+    IF  ${failed_connection}    FAIL  Couldn't connect to Ghaf Host
+    Set Global Variable  ${GHAF_HOST_SSH}    ${connection}
+    RETURN               ${GHAF_HOST_SSH}
 
 Connect to VM
     [Arguments]          ${vm_name}    ${user}=${LOGIN}   ${pw}=${PASSWORD}
@@ -313,7 +306,7 @@ Check if ssh is ready on netvm
     [Arguments]    ${timeout}=60
     ${start_time}  Get Time	epoch
     FOR    ${i}    IN RANGE    ${timeout}
-        ${output}  ${rc}    Execute Command    nc -zvw3 192.168.101.1 22    return_rc=True
+        ${output}  ${rc}    Execute Command    nc -zvw3 ${NETVM_IP} 22    return_rc=True
         ${status}    Run Keyword And Return Status
         ...          Should Be Equal As Integers    ${rc}    0
         IF  ${status}

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -46,29 +46,64 @@ Check Network Availability
     END
 
 Connect
-    [Documentation]   Set up the SSH connection to the device through net-vm
-    [Arguments]       ${IP}=${DEVICE_IP_ADDRESS}    ${PORT}=22    ${target_output}=ghaf@net-vm
+    [Documentation]   Set up the SSH connection to the device
+    [Arguments]       ${IP}=${DEVICE_IP_ADDRESS}    ${PORT}=22    ${target_output}=None
+    IF  '${target_output}' != 'None'
+        Log To Console    Expecting ${target_output} target output
+    ELSE IF  "Lenovo" in "${DEVICE}"
+        ${target_output}  Set Variable  ghaf@net-vm
+    ELSE
+        ${target_output}  Set Variable  ghaf@ghaf-host
+    END
     ${connection}=    Open Connection    ${IP}    port=${PORT}    prompt=\$    timeout=30
     ${output}=        Login     username=${LOGIN}    password=${PASSWORD}
     Should Contain    ${output}    ${target_output}
     RETURN            ${connection}
 
-Connect to netvm
-    [Documentation]      Open ssh connection net-vm
-    ${connection}        Connect
-    Set Global Variable  ${NETVM_SSH}    ${connection}
-    RETURN               ${NETVM_SSH}
-
 Connect to ghaf host
     [Documentation]      Open SSH connection to Ghaf Host through net-vm
-    [Arguments]    ${timeout}=60
-    Log To Console       Connecting to Ghaf Host via NetVM
+    IF  "Lenovo" in "${DEVICE}"
+        ${connection}        Connect
+        Set Global Variable  ${NETVM_SSH}    ${connection}
+        ${connection}        Connect to VM       ${HOST_IP}
+    ELSE
+        Log To Console       Connecting to Ghaf Host
+        ${connection}        Connect
+    END
+    Set Global Variable  ${GHAF_HOST_SSH}    ${connection}
+    RETURN               ${GHAF_HOST_SSH}
+
+Connect to netvm
+    [Documentation]      Open ssh connection net-vm
+    ${connected}   Check ssh connection status   net-vm
+    IF  not ${connected}
+        IF  "Lenovo" in "${DEVICE}"
+            ${connection}   Connect
+        ELSE
+            Connect to ghaf host
+            Log To Console       Connecting to NetVM
+            ${connection}        Connect to VM        ${NETVM_NAME}
+        END
+        Set Global Variable  ${NETVM_SSH}    ${connection}
+        RETURN               ${NETVM_SSH}
+    END
+
+Connect to VM
+    [Documentation]      Connect to any VM or ghaf-host over internal virtual network
+    [Arguments]          ${vm_name}    ${user}=${LOGIN}   ${pw}=${PASSWORD}   ${timeout}=60
+    Log To Console       Connecting to ${vm_name} as ${user}
+    Check if ssh is ready on vm        ${vm_name}
     ${failed_connection}  Set variable  True
-    ${start_time}  Get Time     epoch
+    ${start_time}  Get Time	epoch
+    IF  "Lenovo" in "${DEVICE}"
+        ${jumphost}   Set Variable  ${NETVM_SSH}
+    ELSE
+        ${jumphost}   Set Variable  ${GHAF_HOST_SSH}
+    END
     FOR    ${i}    IN RANGE    10
         TRY
-            ${connection}=       Open Connection    ${HOST_IP}    port=22    prompt=\$    timeout=30
-            ${output}=           Login    username=${LOGIN}     password=${PASSWORD}    jumphost_index_or_alias=${NETVM_SSH}
+            ${connection}=       Open Connection    ${vm_name}    port=22    prompt=\$    timeout=30
+            ${output}=           Login    username=${user}        password=${pw}    jumphost_index_or_alias=${jumphost}
         EXCEPT    ChannelException: ChannelException(2, 'Connect failed')    type=LITERAL
             ${diff}=    Evaluate    int(time.time()) - int(${start_time})
             IF   ${diff} < ${timeout}
@@ -81,28 +116,7 @@ Connect to ghaf host
         ${failed_connection}  Set variable  False
         BREAK
     END
-    IF  ${failed_connection}    FAIL  Couldn't connect to Ghaf Host
-    Set Global Variable  ${GHAF_HOST_SSH}    ${connection}
-    RETURN               ${GHAF_HOST_SSH}
-
-Connect to VM
-    [Arguments]          ${vm_name}    ${user}=${LOGIN}   ${pw}=${PASSWORD}
-    Log To Console       Connecting to ${vm_name} as ${user}
-    Check if ssh is ready on vm        ${vm_name}
-    ${failed_connection}  Set variable  True
-    FOR    ${i}    IN RANGE    3
-        TRY
-            ${connection}=       Open Connection    ${vm_name}    port=22    prompt=\$    timeout=30
-            ${output}=           Login    username=${user}        password=${pw}    jumphost_index_or_alias=${netvm_ssh}
-        EXCEPT    ChannelException: ChannelException(2, 'Connect failed')    type=LITERAL
-            Sleep   1
-            CONTINUE
-        END
-        ${failed_connection}  Set variable  False
-        BREAK
-    END
     IF  ${failed_connection}    FAIL  Couldn't connect ${vm_name}
-
     RETURN             ${connection}
 
 Verify Systemctl status
@@ -324,7 +338,6 @@ Check if ssh is ready on netvm
 
 Check if ssh is ready on vm
     [Arguments]    ${vm}  ${timeout}=30
-    Switch Connection    ${NETVM_SSH}
     ${start_time}  Get Time	epoch
     FOR    ${i}    IN RANGE    ${timeout}
         ${output}  ${rc}    Execute Command    nc -zvw3 ${vm} 22    return_rc=True

--- a/Robot-Framework/test-suites/bat-tests/__init__.robot
+++ b/Robot-Framework/test-suites/bat-tests/__init__.robot
@@ -26,11 +26,9 @@ BAT tests setup
     Switch Connection    ${CONNECTION}
 
 BAT tests teardown
-    ${connection}   Connect
-    Set Global Variable   ${CONNECTION}   ${connection}
+    Connect to ghaf host
     Log journctl
     IF  "Lenovo" in "${DEVICE}"
-        Connect to netvm
         Log out
     END
     Close All Connections

--- a/Robot-Framework/test-suites/bat-tests/check_logs.robot
+++ b/Robot-Framework/test-suites/bat-tests/check_logs.robot
@@ -24,7 +24,7 @@ Check Grafana logs
     [Teardown]       Remove Wifi configuration  ${TEST_WIFI_SSID}
     Configure wifi   ${NETVM_SSH}  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Check Internet Connection
-    Connect to ghaf host
+    Connect to VM    ${ADMIN_VM}
     ${mac}           Execute Command  cat /var/lib/private/alloy/MACAddress  sudo=True  sudo_password=${PASSWORD}
     ${date}          DateTime.Get Current Date  result_format=%Y-%m-%d
     Wait Until Keyword Succeeds  60s  2s  Check Logs Are available  ${date}  ${mac}

--- a/Robot-Framework/test-suites/bat-tests/netvm.robot
+++ b/Robot-Framework/test-suites/bat-tests/netvm.robot
@@ -21,7 +21,7 @@ ${NETVM_SSH}       ${EMPTY}
 
 Verify NetVM is started
     [Documentation]         Verify that NetVM is active and running
-    [Tags]                  #bat  SP-T45  nuc  orin-agx  orin-nx  lenovo-x1
+    [Tags]                  bat  SP-T45  nuc  orin-agx  orin-nx  lenovo-x1
     [Setup]                 Connect to ghaf host
     Verify service status   service=${netvm_service}
     Check Network Availability      ${NETVM_IP}    expected_result=True    range=5
@@ -29,7 +29,7 @@ Verify NetVM is started
 
 Wifi passthrought into NetVM
     [Documentation]     Verify that wifi works inside netvm
-    [Tags]              #bat  SP-T101   SP-T111  orin-agx  lenovo-x1
+    [Tags]              bat  SP-T101   SP-T111  orin-agx  lenovo-x1
     [Setup]             Connect to netvm
     Configure wifi      ${NETVM_SSH}  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Get wifi IP
@@ -42,7 +42,7 @@ Wifi passthrought into NetVM
 
 Wifi passthrought into NetVM (NUC)
     [Documentation]     Verify that wifi works inside netvm
-    [Tags]              #bat   SP-T111  nuc
+    [Tags]              bat   SP-T111  nuc
     [Setup]             Connect to netvm
     Configure wifi via wpa_supplicant      ${netvm_ssh}  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Check Network Availability    8.8.8.8   expected_result=True
@@ -52,14 +52,14 @@ Wifi passthrought into NetVM (NUC)
 
 NetVM stops and starts successfully
     [Documentation]     Verify that NetVM stops properly and starts after that
-    [Tags]              #bat  SP-T47  SP-T90  nuc  orin-nx  lenovo-x1
+    [Tags]              bat  SP-T47  SP-T90  nuc  orin-nx
     [Setup]             Connect to ghaf host
     Restart NetVM
     [Teardown]          Run Keywords  Start NetVM if dead   AND  Close All Connections
 
 NetVM is wiped after restarting
     [Documentation]     Verify that created file will be removed after restarting VM
-    [Tags]              #bat  SP-T48  nuc  orin-nx  lenovo-x1
+    [Tags]              bat  SP-T48  nuc  orin-nx
     [Setup]             Connect to netvm
     Create file         /etc/test.txt
     Switch Connection   ${GHAF_HOST_SSH}
@@ -74,7 +74,7 @@ NetVM is wiped after restarting
 
 Verify NetVM PCI device passthrough
     [Documentation]     Verify that proper PCI devices have been passed through to the NetVM
-    [Tags]              #bat  SP-T96  nuc  orin-agx  orin-nx
+    [Tags]              bat  SP-T96  nuc  orin-agx  orin-nx
     [Setup]             Connect to netvm
     Verify microvm PCI device passthrough    host_connection=${GHAF_HOST_SSH}    vm_connection=${NETVM_SSH}    vmname=${NETVM_NAME}
     [Teardown]          Run Keywords   Close All Connections

--- a/Robot-Framework/test-suites/bat-tests/netvm.robot
+++ b/Robot-Framework/test-suites/bat-tests/netvm.robot
@@ -12,7 +12,6 @@ Suite Teardown      Close All Connections
 
 
 *** Variables ***
-${NETVM_IP}        192.168.101.1
 ${NETVM_STATE}     ${EMPTY}
 ${GHAF_HOST_SSH}   ${EMPTY}
 ${NETVM_SSH}       ${EMPTY}
@@ -22,7 +21,7 @@ ${NETVM_SSH}       ${EMPTY}
 
 Verify NetVM is started
     [Documentation]         Verify that NetVM is active and running
-    [Tags]                  bat  SP-T45  nuc  orin-agx  orin-nx  lenovo-x1
+    [Tags]                  #bat  SP-T45  nuc  orin-agx  orin-nx  lenovo-x1
     [Setup]                 Connect to ghaf host
     Verify service status   service=${netvm_service}
     Check Network Availability      ${NETVM_IP}    expected_result=True    range=5
@@ -30,7 +29,7 @@ Verify NetVM is started
 
 Wifi passthrought into NetVM
     [Documentation]     Verify that wifi works inside netvm
-    [Tags]              bat  SP-T101   SP-T111  orin-agx  lenovo-x1
+    [Tags]              #bat  SP-T101   SP-T111  orin-agx  lenovo-x1
     [Setup]             Connect to netvm
     Configure wifi      ${NETVM_SSH}  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Get wifi IP
@@ -43,7 +42,7 @@ Wifi passthrought into NetVM
 
 Wifi passthrought into NetVM (NUC)
     [Documentation]     Verify that wifi works inside netvm
-    [Tags]              bat   SP-T111  nuc
+    [Tags]              #bat   SP-T111  nuc
     [Setup]             Connect to netvm
     Configure wifi via wpa_supplicant      ${netvm_ssh}  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Check Network Availability    8.8.8.8   expected_result=True
@@ -53,21 +52,21 @@ Wifi passthrought into NetVM (NUC)
 
 NetVM stops and starts successfully
     [Documentation]     Verify that NetVM stops properly and starts after that
-    [Tags]              bat  SP-T47  SP-T90  nuc  orin-nx  lenovo-x1
+    [Tags]              #bat  SP-T47  SP-T90  nuc  orin-nx  lenovo-x1
     [Setup]             Connect to ghaf host
     Restart NetVM
     [Teardown]          Run Keywords  Start NetVM if dead   AND  Close All Connections
 
 NetVM is wiped after restarting
     [Documentation]     Verify that created file will be removed after restarting VM
-    [Tags]              bat  SP-T48  nuc  orin-nx  lenovo-x1
+    [Tags]              #bat  SP-T48  nuc  orin-nx  lenovo-x1
     [Setup]             Connect to netvm
     Create file         /etc/test.txt
     Switch Connection   ${GHAF_HOST_SSH}
     Restart NetVM
     Close All Connections
     Connect to ghaf host
-    Check Network Availability      ${NETVM_IP}    expected_result=True    range=15
+    Check Network Availability      ${DEVICE_IP_ADDRESS}    expected_result=True    range=15
     Connect to netvm
     Log To Console      Check if created file still exists
     Check file doesn't exist    /etc/test.txt
@@ -75,7 +74,7 @@ NetVM is wiped after restarting
 
 Verify NetVM PCI device passthrough
     [Documentation]     Verify that proper PCI devices have been passed through to the NetVM
-    [Tags]              bat  SP-T96  nuc  orin-agx  orin-nx
+    [Tags]              #bat  SP-T96  nuc  orin-agx  orin-nx
     [Setup]             Connect to netvm
     Verify microvm PCI device passthrough    host_connection=${GHAF_HOST_SSH}    vm_connection=${NETVM_SSH}    vmname=${NETVM_NAME}
     [Teardown]          Run Keywords   Close All Connections


### PR DESCRIPTION
Continuing from https://github.com/tiiuae/ci-test-automation/pull/222 (which was later reverted by https://github.com/tiiuae/ci-test-automation/pull/227) to adapt ci-test-automation to new network settings:

X1: ethernet-USB adapter connects to net-vm, not anymore to ghaf-host
Orin-AGX: ethernet interface still on ghaf-host (same as before)
Orin-NX: ethernet-USB adapter interface still on ghaf-host and ethernet interface on net-vm (same as before)