### PR TITLE
Remove check against hard coded limits in iperf result analysis

### DIFF
--- a/Robot-Framework/test-suites/performance-tests/network.robot
+++ b/Robot-Framework/test-suites/performance-tests/network.robot
@@ -40,7 +40,7 @@ Measure TCP Throughput Small Packets
     ${bps_rx}          Get Throughput Values  ${output2.stdout}  direction=receiver
     Set To Dictionary  ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
     Log                <img src="${DEVICE}_${TEST NAME}.png" alt="TCP Transfer Small Packets" width="1200">    HTML
-    ${statistics}       Save Speed Data   ${TEST NAME}  ${speed_data}
+    ${statistics}      Save Speed Data   ${TEST NAME}  ${speed_data}
     Report Statistics  ${statistics}
 
 Measure TCP Bidir Throughput Small Packets
@@ -199,8 +199,10 @@ Get Throughput Values
     ELSE
         ${MBps}  Get Regexp Matches  ${output}    (?im)\\s(\\d+(\\.\\d+)?) MBytes\\/sec.*${direction}  1
     END
-    ${expected_throughput}  Set Variable If  ${bidir}  ${85}  ${90}
-    Run Keyword And Continue On Failure  Should Be True  ${MBps}[0] > ${expected_throughput}
+    ${status}    Run Keyword And Return Status   Should Not Be Empty  ${MBps}
+    IF  not ${status}
+        Log      Failed to get the result from ${TEST NAME}   console=yes
+    END
     RETURN  ${MBps}[0]
 
 Report statistics


### PR DESCRIPTION
There was an extra layer of harcoded check for iperf tests in keyword Get Throughput Values in addition of applying the adaptative result analysis tooling of PerformanceDataProcessing. Pass/fail criteria of that extra check was based on single hard coded limit for all targets. 

However results show that different targets have different baselines. The existing general result analysis tooling is able to adapt to different baselines on different targets and can detect any significant deviation from baseline. Extra check is not needed.

Added some extra logging in case measurement result is empty.