### PR TITLE
Fix lenovo-x1 relay boot test

### DIFF
--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -48,8 +48,7 @@ Verify booting LenovoX1
     ELSE
         Log To Console  The device started
     END
-
-    Connect
+    Check if netvm has started on Lenovo-X1
     Verify service status   service=init.scope
     [Teardown]   Test Teardown
 


### PR DESCRIPTION
Previously only the old boot test was fixed but forgot to add the fix also to the new relay boot test.