### PR TITLE
Add memory test also to address internal memory.

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -483,9 +483,17 @@ Restart VM
 
 Check External SSD Size
     [Documentation]  Check the size of ssd used in setup
+    Log to console   Memory to be checked: SSD
     ${lsblk}  Execute Command  lsblk
     ${size}  Get Regexp Matches  ${lsblk}  (?im)(sda .*\\d*:\\d{1}.*\\d{1}\\s)(\\d{1,3})  2
     RETURN  ${size}[0]
+
+Check Internal eMMC Size
+    [Documentation]  Check the size of eMMC used in setup
+    Log to console   Memory to be checked: eMMC
+    ${lsblk}  Execute Command  lsblk
+    ${size}   Get Regexp Matches  ${lsblk}  (?im)(nvme0n1 .*\\d*:\\d{1}.*\\d{1}\\s)(\\d{1,3})  2
+    RETURN    ${size}[0]
 
 Check Storagevm Size
     [Documentation]  Check the size of storagevm

--- a/Robot-Framework/test-suites/bat-tests/others.robot
+++ b/Robot-Framework/test-suites/bat-tests/others.robot
@@ -77,7 +77,15 @@ Check Memory status
     [Tags]  bat  lenovo-x1  SSRCSP-5321
     [Setup]     Connect to ghaf host
     [Teardown]  Close All Connections
-    ${ssd}          Check External SSD Size
-    ${storage}      Check Storagevm Size
-    Should Be True  ${ssd} > ${storage} > ${100}
-    Should Be True  ${${ssd}*${0.80}} <= ${storage}
+    ${lsblk}  Execute Command  lsblk
+    log       ${lsblk}
+    ${SSD}    run keyword and return status  should contain   ${lsblk}   sda
+    ${eMMC}   run keyword and return status  should contain   ${lsblk}   nvme0n1p
+
+    ${memory}  run keyword if  ${SSD}   Check External SSD Size
+    ...    ELSE IF             ${eMMC}  Check Internal eMMC Size
+    ...    ELSE                Fail     Failure. Something missing? No SSD or eMMC partitions captured!
+
+    ${storage}  Check Storagevm Size
+    Should Be True  ${memory} > ${storage} > ${100}
+    Should Be True  ${${memory}*${0.80}} <= ${storage}


### PR DESCRIPTION
Added new keyword: 'Check Internal eMMC Size for reading internal memory.

The tests 'Check Memory status was changed in a way that if 'lsblk' lists something including 'sda' -> it is supposed that device is booted from SSD, otherwise from internal memory.

The actual size check was not touched so the criteria is same for both memory checks.