### PR TITLE
Add iterations to Connect keyword

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -82,19 +82,6 @@ Check If Device Is Up
         END
     END
 
-Check if netvm has started on Lenovo-X1
-    [Arguments]    ${iterations}=10
-    FOR    ${i}    IN RANGE    ${iterations}
-        ${pass_status}  ${connection}  Run Keyword And Ignore Error    Connect    target_output=ghaf@net-vm
-        IF    $pass_status=='PASS'
-            RETURN
-        ELSE
-            Close All Connections
-        END
-        Sleep  1
-    END
-    FAIL   Failed to connect net-vm
-
 Log versions
     ${ghaf_version}     Execute Command   ghaf-version
     Log to console      Ghaf version: ${ghaf_version}

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -47,22 +47,34 @@ Check Network Availability
 
 Connect
     [Documentation]   Set up the SSH connection to the device
-    [Arguments]       ${IP}=${DEVICE_IP_ADDRESS}    ${PORT}=22    ${target_output}=None
+    [Arguments]       ${IP}=${DEVICE_IP_ADDRESS}    ${PORT}=22    ${target_output}=None   ${iterations}=1
     IF  '${target_output}' != 'None'
         Log To Console    Expecting ${target_output} target output
-    ELSE IF  "Lenovo" in "${DEVICE}"
+    ELSE IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}"
         ${target_output}  Set Variable  ghaf@net-vm
     ELSE
         ${target_output}  Set Variable  ghaf@ghaf-host
     END
-    ${connection}=    Open Connection    ${IP}    port=${PORT}    prompt=\$    timeout=30
-    ${output}=        Login     username=${LOGIN}    password=${PASSWORD}
-    Should Contain    ${output}    ${target_output}
-    RETURN            ${connection}
+    # Iterations are necessary at boot for those targets which should expose net-vm to ethernet interface.
+    # Ghaf-host is accessible on these targets for a short period of time at boot.
+    Log    Trying to connect to ${target_output}  console=True
+    FOR    ${i}    IN RANGE    ${iterations}
+        ${connection}=    Open Connection    ${IP}    port=${PORT}    prompt=\$    timeout=30
+        ${output}=        Login     username=${LOGIN}    password=${PASSWORD}
+        ${pass_status}  ${output}  Run Keyword And Ignore Error  Should Contain    ${output}    ${target_output}
+        IF    $pass_status=='PASS'
+            RETURN  ${connection}
+        ELSE
+            Close All Connections
+            Log To Console    Failed to connect.
+        END
+        Sleep  5
+    END
+    FAIL   Failed to connect
 
 Connect to ghaf host
     [Documentation]      Open SSH connection to Ghaf Host
-    IF  "Lenovo" in "${DEVICE}"
+    IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}"
         ${connection}        Connect
         Set Global Variable  ${NETVM_SSH}    ${connection}
         ${connection}        Connect to VM       ${HOST_IP}
@@ -77,7 +89,7 @@ Connect to netvm
     [Documentation]      Open ssh connection to net-vm
     ${connected}   Check ssh connection status   net-vm
     IF  not ${connected}
-        IF  "Lenovo" in "${DEVICE}"
+        IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}"
             ${connection}   Connect
         ELSE
             Connect to ghaf host
@@ -91,11 +103,12 @@ Connect to netvm
 Connect to VM
     [Documentation]      Connect to any VM or ghaf-host over internal virtual network
     [Arguments]          ${vm_name}    ${user}=${LOGIN}   ${pw}=${PASSWORD}   ${timeout}=60
+    ${connected}   Check ssh connection status   net-vm
     Log To Console       Connecting to ${vm_name} as ${user}
     Check if ssh is ready on vm        ${vm_name}
     ${failed_connection}  Set variable  True
     ${start_time}  Get Time	epoch
-    IF  "Lenovo" in "${DEVICE}"
+    IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}"
         ${jumphost}   Set Variable  ${NETVM_SSH}
     ELSE
         ${jumphost}   Set Variable  ${GHAF_HOST_SSH}

--- a/Robot-Framework/resources/virtualization_keywords.resource
+++ b/Robot-Framework/resources/virtualization_keywords.resource
@@ -12,10 +12,10 @@ Library             String
 
 Verify microvm PCI device passthrough
     [Documentation]     Verify that proper PCI devices have been passed through to the VM
-    [Arguments]    ${host_connection}    ${vm_connection}    ${vmname}
-    Switch Connection   ${vm_connection}
+    [Arguments]    ${vmname}
+    Connect to VM if not already connected   ${vmname}
     @{pciids}=    Get list of PCI IDs
-    Switch Connection   ${host_connection}
+    Connect to ghaf host
     @{pcipassthrus}=    Get microvm PCI passthrough list    vmname=${vmname}
     FOR    ${pcipass}    IN    @{pcipassthrus}
         ${pciidpass}=    Get PCI ID from PCI Address    address=${pcipass}

--- a/Robot-Framework/test-suites/bat-tests/netvm.robot
+++ b/Robot-Framework/test-suites/bat-tests/netvm.robot
@@ -52,14 +52,14 @@ Wifi passthrought into NetVM (NUC)
 
 NetVM stops and starts successfully
     [Documentation]     Verify that NetVM stops properly and starts after that
-    [Tags]              bat  SP-T47  SP-T90  nuc  orin-nx
+    [Tags]              bat  SP-T47  SP-T90  nuc
     [Setup]             Connect to ghaf host
     Restart NetVM
     [Teardown]          Run Keywords  Start NetVM if dead   AND  Close All Connections
 
 NetVM is wiped after restarting
     [Documentation]     Verify that created file will be removed after restarting VM
-    [Tags]              bat  SP-T48  nuc  orin-nx
+    [Tags]              bat  SP-T48  nuc
     [Setup]             Connect to netvm
     Create file         /etc/test.txt
     Switch Connection   ${GHAF_HOST_SSH}
@@ -76,7 +76,7 @@ Verify NetVM PCI device passthrough
     [Documentation]     Verify that proper PCI devices have been passed through to the NetVM
     [Tags]              bat  SP-T96  nuc  orin-agx  orin-nx
     [Setup]             Connect to netvm
-    Verify microvm PCI device passthrough    host_connection=${GHAF_HOST_SSH}    vm_connection=${NETVM_SSH}    vmname=${NETVM_NAME}
+    Verify microvm PCI device passthrough    vmname=${NETVM_NAME}
     [Teardown]          Run Keywords   Close All Connections
 
 

--- a/Robot-Framework/test-suites/bat-tests/optee.robot
+++ b/Robot-Framework/test-suites/bat-tests/optee.robot
@@ -5,7 +5,7 @@
 Documentation       Test OP-TEE PKCS#11 through pkcs11-tool wrappers
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../config/variables.robot
-Suite Setup         Connect
+Suite Setup         Connect to ghaf host
 Suite Teardown      Close All Connections
 
 

--- a/Robot-Framework/test-suites/boot-test/boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/boot_test.robot
@@ -30,7 +30,7 @@ Verify booting after restart by power
         Log To Console  The device started
     END
     IF  "${CONNECTION_TYPE}" == "ssh"
-        Connect
+        Connect   iterations=10
         Verify service status   service=init.scope
     ELSE IF  "${CONNECTION_TYPE}" == "serial"
         Verify init.scope status via serial
@@ -47,9 +47,8 @@ Verify booting LenovoX1
     ELSE
         Log To Console  The device started
     END
-    Check if netvm has started on Lenovo-X1
+    Connect   iterations=10
     Verify service status   service=init.scope
-
     [Teardown]   Teardown
 
 Verify booting RiscV Polarfire

--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -31,7 +31,7 @@ Verify booting after restart by power
         Log To Console  The device started
     END
     IF  "${CONNECTION_TYPE}" == "ssh"
-        Connect
+        Connect   iterations=10
         Verify service status   service=init.scope
     ELSE IF  "${CONNECTION_TYPE}" == "serial"
         Verify init.scope status via serial
@@ -48,7 +48,7 @@ Verify booting LenovoX1
     ELSE
         Log To Console  The device started
     END
-    Check if netvm has started on Lenovo-X1
+    Connect   iterations=10
     Verify service status   service=init.scope
     [Teardown]   Test Teardown
 

--- a/Robot-Framework/test-suites/gui-tests/__init__.robot
+++ b/Robot-Framework/test-suites/gui-tests/__init__.robot
@@ -4,7 +4,6 @@
 *** Settings ***
 Documentation       GUI tests
 Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/serial_keywords.resource
 Resource            ../../resources/gui_keywords.resource
 Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/connection_keywords.resource

--- a/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
@@ -91,7 +91,7 @@ GUI Reboot
         Log To Console            Device started
     END
     IF  "Lenovo" in "${DEVICE}"
-        Connect to netvm
+        ${NETVM_SSH}              Connect   iterations=10
         Connect to VM             ${GUI_VM}
     ELSE
         Connect to ghaf host


### PR DESCRIPTION
After ethernet interface was passed through to net-vm on lenovo-x1 iterative check of login to net-vm was first added to boot tests of lenovo-x1. Failures after gui reboot tests showed that iterations have to be added to the Connect keyword instead of using them only in the boot test.

The default number of iterations in Connect is 1 (as previous) but in boot tests and gui reboot 10 iterations are given.

Also Orin-NX needs to have iterative Connect keyword at boot and the output target has to be net-vm as with lenovo-x1. Both lenovo-x1 and orin-nx expose ghaf-host for about 10 sec time window at boot. During that time window ssh login attempts end up to ghaf-host.

- Modified also `Connect to ghaf host` to connect via net-vm on Orin-NX (as with lenovo-x1).

- Removed orin-nx tag from those test cases which include stopping net-vm. 

- `Connect to ghaf host` in optee suite setup instead of plain `Connect`

- Switching between connections didn't work anymore in `Verify NetVM PCI device passthrough`. Fixed that.