### PR TITLE
Prevent fail in connect iteration to fail the keyword

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -59,9 +59,9 @@ Connect
     # Ghaf-host is accessible on these targets for a short period of time at boot.
     Log    Trying to connect to ${target_output}  console=True
     FOR    ${i}    IN RANGE    ${iterations}
-        ${connection}=    Open Connection    ${IP}    port=${PORT}    prompt=\$    timeout=30
-        ${output}=        Login     username=${LOGIN}    password=${PASSWORD}
-        ${pass_status}  ${output}  Run Keyword And Ignore Error  Should Contain    ${output}    ${target_output}
+        ${pass_status}  ${connection}    Run Keyword And Ignore Error  Open Connection    ${IP}       port=${PORT}    prompt=\$    timeout=30
+        ${pass_status}  ${login_output}  Run Keyword And Ignore Error  Login     username=${LOGIN}    password=${PASSWORD}
+        ${pass_status}  ${output}        Run Keyword And Ignore Error  Should Contain     ${login_output}   ${target_output}
         IF    $pass_status=='PASS'
             RETURN  ${connection}
         ELSE


### PR DESCRIPTION
It was noticed that the whole Connect keyword can fail if Login of single iteration fails. With this change it will be avoided. 

In the beginning of boot ethernet interface is on ghaf-host but gets then passed through to net-vm at some point. If the switch of ethernet interface from ghaf-host to net-vm happens between Open Connection and Login keywords it is possible that the opened connection is actually lost in between and thus Login fails. This can randomly fail the Login keyword of the iteration at boot.