### PR TITLE
Add some more GUI tests.

### DIFF
--- a/Robot-Framework/test-suites/gui-tests/__init__.robot
+++ b/Robot-Framework/test-suites/gui-tests/__init__.robot
@@ -19,6 +19,7 @@ GUI Tests Setup
         Verify service status   range=15  service=microvm@gui-vm.service  expected_status=active  expected_state=running
         Connect to netvm
         Connect to VM           ${GUI_VM}
+        Create test user
     END
     Run journalctl recording
     Save most common icons and paths to icons

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -36,6 +36,38 @@ Start and close PDF Viewer via GUI on LenovoX1
     Start app via GUI on LenovoX1   ${ZATHURA_VM}  zathura
     Close app via GUI on LenovoX1   ${ZATHURA_VM}  zathura  ./window-close-neg.png
 
+Start and close Calculator via GUI on LenovoX1
+    [Documentation]   Start Calculator via GUI test automation and verify related process started
+    ...               Close Calculator via GUI test automation and verify related process stopped
+    [Tags]            SSRCSP-T202  lenovo-x1
+    Get icon   app  gnome-calculator.svg   crop=10
+    Start app via GUI on LenovoX1   ${GUI_VM}  gnome-calculator
+    Close app via GUI on LenovoX1   ${GUI_VM}  gnome-calculator  ./window-close.png
+
+Start and close Bluetooth Settings via GUI on LenovoX1
+    [Documentation]   Start Bluetooh via GUI test automation and verify related process started
+    ...               Close Blutooth via via GUI test automation and verify related process stopped
+    [Tags]            SSRCSP-T204  lenovo-x1
+    Get icon   app  blueman.svg   crop=30
+    Start app via GUI on LenovoX1   ${GUI_VM}  blueman-manager-wrapped-wrapped
+    Close app via GUI on LenovoX1   ${GUI_VM}  blueman-manager-wrapped-wrapped  ./window-close-neg.png
+
+Start and close Control Panel via GUI on LenovoX1
+    [Documentation]   Start Control Panel via GUI test automation and verify related process started
+    ...               Close Control Panel via GUI test automation and verify related process stopped
+    [Tags]            SSRCSP-T205  lenovo-x1
+    Get icon   app  gnome-control-center.svg   crop=10
+    Start app via GUI on LenovoX1   ${GUI_VM}  ctrl-panel
+    Close app via GUI on LenovoX1   ${GUI_VM}  ctrl-panel  ./window-close.png
+
+Start and close File Manager via GUI on LenovoX1
+    [Documentation]   Start File Manager via GUI test automation and verify related process started
+    ...               Close File Manager via GUI test automation and verify related process stopped
+    [Tags]            SSRCSP-T206  lenovo-x1
+    Get icon   app  xfce-filemanager.svg   crop=30
+    Start app via GUI on LenovoX1   ${GUI_VM}  pcmanfm
+    Close app via GUI on LenovoX1   ${GUI_VM}  pcmanfm  ./window-close-neg.png
+
 Start and close Firefox via GUI on Orin AGX
     [Documentation]   Passing this test requires that display is connected to the target device
     ...               Start Firefox via GUI test automation and verify related process started


### PR DESCRIPTION
Added some more tests starting applications from GUI. (Calculator, BT, Control Panel & File Manager)
Also added 'test user creation' to GUI test setup in case the suite is executed as 'standalone'.

Test passed in Jenkins pipeline: [502](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/502/console) (Jenkins failed to assign results to the build, but that has nothing to do with tests)