### PR TITLE
Remove systemctl status check from Orin-NX for now

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/others.robot
+++ b/Robot-Framework/test-suites/bat-tests/others.robot
@@ -34,7 +34,7 @@ Check QSPI version
 
 Check systemctl status
     [Documentation]    Verify systemctl status is running
-    [Tags]             bat   pre-merge  SP-T98  nuc  orin-agx  orin-nx  riscv
+    [Tags]             bat   pre-merge  SP-T98  nuc  orin-agx  riscv  # orin-nx failing is a known issue
     [Setup]     Connect to ghaf host
     ${status}   ${output}   Run Keyword And Ignore Error    Verify Systemctl status
     IF  '${status}' == 'FAIL'


### PR DESCRIPTION
It is a known issue that the status is degraded. Bug has been opened.