### PR TITLE
Optimize Kill process

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -224,7 +224,7 @@ Find pid by name
 Kill process
     [Arguments]    @{pids}    ${sig}=9
     FOR   ${pid}  IN  @{pids}
-        IF  '${PID}' == '${EMPTY}'
+        IF  '${pid}' == '${EMPTY}'
             BREAK
         END
         Execute Command    kill -${sig} ${pid}  sudo=True  sudo_password=${password}  timeout=15
@@ -237,6 +237,18 @@ Kill process
             END
         END
         IF  ${ps_exists}  FAIL  Process ${pid} haven't stopped
+        # Check if any of the original pids are still running
+        ${any_running} =    Set Variable    False
+        FOR    ${check_pid}  IN  @{pids}
+            ${ps_exists} =    Is Process Started    ${check_pid}
+            IF  ${ps_exists}
+                ${any_running} =    Set Variable    True
+                BREAK
+            END
+        END
+        IF  not ${any_running}
+            BREAK
+        END
     END
     Log To Console    Killed processes: @{pids}
 


### PR DESCRIPTION
This change reduces the Lenovo-X1 bat suite length by 4.5 minutes from 12.5 minutes to 8 minutes - a decrease of about 35 %.

It seems that every time one of the processes is killed, all the others are also terminated simultaneously. This change adds a check after process is killed to see if any of the processes are still running. If none are running, there is no need to go through & kill them one by one. 

Killing processes one by one takes a long time. For Chrome it took about 74 s. With this change it now only takes 5 s.

[Nightly pipeline](https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/job/ghaf-hw-test/2346/robot/report/bat/report.html) (12:36)
[Test run with Lenovo-X1](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/547/artifact/Robot-Framework/test-suites/lenovo-x1ANDbat/report.html) (8:11)
