### PR TITLE
Add timeouts for bat test execution.

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/__init__.robot
+++ b/Robot-Framework/test-suites/bat-tests/__init__.robot
@@ -8,6 +8,7 @@ Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/connection_keywords.resource
 Resource            ../../resources/gui_keywords.resource
 Library             OperatingSystem
+Test Timeout        10 minutes
 Suite Setup         BAT tests setup
 Suite Teardown      BAT tests teardown
 
@@ -19,6 +20,7 @@ ${DISABLE_LOGOUT}     ${EMPTY}
 *** Keywords ***
 
 BAT tests setup
+    [timeout]    5 minutes
     Initialize Variables, Connect And Start Logging
 
     IF  "Lenovo" in "${DEVICE}"
@@ -31,6 +33,7 @@ BAT tests setup
     Switch Connection    ${CONNECTION}
 
 BAT tests teardown
+    [timeout]    5 minutes
     Connect to ghaf host
     Log journctl
     IF  "Lenovo" in "${DEVICE}"


### PR DESCRIPTION
There has been some Jenkins pipeline freezing lately with Orin-NX. Last one this morning had to be aborted manually and it was noticed that actually tests got passed but the teardown did freeze for some unknown reason.

In order to avoid pipeline stucks due to possible test case execution failures, a 10 min timeout was set for bat tests. 
For the bat-test 'setup & teardown', a 5 min timeout was set.

In addition to this, we should ask devops persons about the possibility to add timeout also for Jenkins jobs.

We really cannot be sure about the root causes: Sometimes it maybe that tests/testHW freezes(fails) , sometimes there might be something Jenkins related issues ongoing.

Test results: Orin-NX[584](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/584/artifact/Robot-Framework/test-suites/batANDorin-nx/log.html) and Lenovo-X1:[582](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/582/artifact/Robot-Framework/test-suites/batANDlenovo-x1/log.html)