### PR TITLE
Fix orin-AGX netvm failing cases.

### DIFF
--- a/Robot-Framework/resources/connection_keywords.resource
+++ b/Robot-Framework/resources/connection_keywords.resource
@@ -18,7 +18,9 @@ Remove Wifi configuration
     [Arguments]         ${SSID}
     Switch Connection   ${netvm_ssh}
     Log To Console      Removing Wifi configuration
-    Execute Command     nmcli connection delete id ${SSID}
+    ${stdout}  ${stderr}  ${rc}=  Execute Command  nmcli connection delete id ${SSID}
+    ...   sudo=True   sudo_password=${PASSWORD}   return_stdout=True   return_stderr=True   return_rc=True
+    Should Be Equal As Integers    ${rc}    0
 
 Turn OFF WiFi
     [Arguments]         ${SSID}

--- a/Robot-Framework/test-suites/bat-tests/netvm.robot
+++ b/Robot-Framework/test-suites/bat-tests/netvm.robot
@@ -38,6 +38,9 @@ Wifi passthrought into NetVM (Orin-AGX)
     Check Network Availability    8.8.8.8   expected_result=False
     Turn ON WiFi        ${TEST_WIFI_SSID}
     Check Network Availability    8.8.8.8   expected_result=True
+    Turn OFF WiFi       ${TEST_WIFI_SSID}
+    Check Network Availability    8.8.8.8   expected_result=False
+    Sleep               1
     [Teardown]          Run Keywords  Remove Wifi configuration  ${TEST_WIFI_SSID}  AND  Close All Connections
 
 Wifi passthrought into NetVM (Lenovo-X1)
@@ -68,14 +71,14 @@ Wifi passthrought into NetVM (NUC)
 
 NetVM stops and starts successfully
     [Documentation]     Verify that NetVM stops properly and starts after that
-    [Tags]              bat  SP-T47  SP-T90  nuc
+    [Tags]              bat  SP-T47  SP-T90  nuc  orin-agx
     [Setup]             Connect to ghaf host
     Restart NetVM
     [Teardown]          Run Keywords  Start NetVM if dead   AND  Close All Connections
 
 NetVM is wiped after restarting
     [Documentation]     Verify that created file will be removed after restarting VM
-    [Tags]              bat  SP-T48  nuc
+    [Tags]              bat  SP-T48  nuc  orin-agx
     [Setup]             Connect to netvm
     Create file         /etc/test.txt
     Switch Connection   ${GHAF_HOST_SSH}


### PR DESCRIPTION
Test cases '`NetVM stops and starts successfully`' and '`NetVM is wiped after restarting'` did fail on Orin-AGX.

After 'some' investigations & trials, the conclusion is that actually it was the test '`Wifi passthrought into NetVM (Orin-AGX)`' that is the reason for the failures seen. During the Teardown of that test case the WiFi-connection was tried to be deleted, but actually it was not.

The outcome of that deletion was not checked in test code and that error code: '`Return code 7. Connection deletion failed.(Error: Connection deletion failed: Insufficient privileges)`' was missed and it was expected that the deletion was done. Because deletion was not successful, it had affect to the tests executed after that.

The test code was changed in such way that we use `sudo`  and also now check if the deletion was successful or not.
There might have also been some timing issue around as well. 

Test results:
- Orin-AGX: [652](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/652/artifact/Robot-Framework/test-suites/batANDorin-agx/log.html)
- LenovoX1(check if netvm-WiFi test still works): [654](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/654/artifact/Robot-Framework/test-suites/batANDlenovo-x1/log.html)