### PR TITLE
Remove WiFi part from Grafana logging test

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/check_logs.robot
+++ b/Robot-Framework/test-suites/bat-tests/check_logs.robot
@@ -21,8 +21,6 @@ ${GRAFANA_LOGS}       https://loki.ghaflogs.vedenemo.dev
 Check Grafana logs
     [Documentation]  Check that all virtual machines are sending logs to Grafana
     [Tags]           SP-T172
-    [Teardown]       Remove Wifi configuration  ${TEST_WIFI_SSID}
-    Configure wifi   ${NETVM_SSH}  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Check Internet Connection
     Connect to VM    ${ADMIN_VM}
     ${id}           Execute Command  cat /etc/common/device-id  sudo=True  sudo_password=${PASSWORD}


### PR DESCRIPTION
Changing WiFI deletion command due to Orin-AGX issues, the keyword usage in grafana -side got broken.
However it was seen that  WiFi part can be completely removed from grafana logging test because it is no more prerequisite. 

Test: [Check Grafana logs(Lenovo-X1)](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/692/artifact/Robot-Framework/test-suites/SP-T172ANDlenovo-x1/log.html)