### PR TITLE
Save jrnl.txt instead 'cat jrnl.txt'.

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -44,8 +44,9 @@ Run journalctl recording
 Log journctl
     ${jrnl_size}  Execute Command    ls -lh /tmp/jrnl.txt
     Log           ${jrnl_size}
-    ${jrnl}       Execute Command    cat /tmp/jrnl.txt
-    Log           ${jrnl}
+    # Copy journal log file to Robot outputs
+    SSHLibrary.Get file   /tmp/jrnl.txt   ${OUTPUT_DIR}/jrnl.txt
+    OperatingSystem.File Should Exist     ${OUTPUT_DIR}/jrnl.txt
     @{pid}        Find pid by name   journalctl
     Kill process  @{pid}
 


### PR DESCRIPTION
There has been cases where Bat -test suite's Teardown stucks on Orin-NX when trying to capture the content of 'journal.txt' into a variable. The Issue happens randomly so it is hard to capture intentionally. Currently there is 5 min timeout that triggers the tesrdown to fail.

This failure causes the situation where all the executed tests are marked as failed even if that is not true.

The implementation was changed in such way that the 'cat' command is not used but the 'jrnl.txt' file is copied and saved 
-> the hiccups with 'cat' should be avoided now and saving the file should be more robust way to handle this.

Some more testing with DEV setup where 'Ghaf HW test' got script from this branch.

Testing (together with jenkins groovy changes [ghaf-jenkins-pipeline-141](https://github.com/tiiuae/ghaf-jenkins-pipeline/pull/141
)
-  Trigger (Ghaf main pipeline) [105](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/ghaf-main-pipeline/105/)
-   HW tests [646-652](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/ghaf-hw-test/651/robot/report/bat/)  - the jrnl.txt is included to the bat-directory with other test results. (if bat- tests got executed)
- Another view to results: [651](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/ghaf-hw-test/651/)