### PR TITLE
Remove 'nuc' -tag from 'FileIO test'.

### DIFF
--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -160,7 +160,9 @@ FileIO test
     ...                 The benchmark records File Operations, Throughput, Average Events per Thread,
     ...                 and Latency for read and write operations.
     ...                 Create visual plots to represent these metrics comparing to previous tests.
-    [Tags]              fileio  SP-T61-7  nuc  orin-agx  orin-nx  lenovo-x1   dell-7330
+    ...                 KNOWN ISSUES:
+    ...                 Tag removed 'nuc': SSRCSP-6126
+    [Tags]              fileio  SP-T61-7  orin-agx  orin-nx  lenovo-x1   dell-7330
 
     Transfer FileIO Test Script To DUT
 


### PR DESCRIPTION
FileIO test has bee failing for a while on NUC. 
Removing tag until there is some implementation changes done to enable fixing.

Test result on prod HW: [x-gahf-test 80](https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/80/)