### PR TITLE
Change plot_dir to relative path

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -19,6 +19,7 @@ ${CONFIG_PATH}            ../config
 ${POWER_MEASUREMENT_DIR}  ../../../power_measurements/
 ${PERF_DATA_DIR}          ../../../Performance_test_results/
 ${PLOT_DIR}               ./
+${REL_PLOT_DIR}           ./
 
 
 *** Keywords ***
@@ -30,6 +31,7 @@ Set Variables
         Set Global Variable  ${POWER_MEASUREMENT_DIR}  ${OUTPUT_DIR}/outputs/power_measurements/
         Set Global Variable  ${PERF_DATA_DIR}  ${OUTPUT_DIR}/outputs/Performance_test_results/
         Set Global Variable  ${PLOT_DIR}  ${OUTPUT_DIR}/outputs/performance_plots/
+        Set Global Variable  ${REL_PLOT_DIR}  ./outputs/performance_plots/
     END
     IF  $CONFIG_PATH == 'None'
         Log To Console    No path for test_config.json given. Ignore reading the config variables.

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -46,7 +46,7 @@ CPU One thread test
     Log                 ${output}
     &{cpu_data}         Parse Cpu Results   ${output}
     &{statistics}       Save Cpu Data       ${TEST NAME}  ${cpu_data}
-    Log                 <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="CPU Plot" width="1200">    HTML
+    Log                 <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="CPU Plot" width="1200">    HTML
     IF  "${statistics}[flag]" == "-1"
         ${fail_msg}     Create fail message  ${statistics}
         FAIL            ${fail_msg}
@@ -65,7 +65,7 @@ CPU multimple threads test
     Log                 ${output}
     &{cpu_data}         Parse Cpu Results   ${output}
     &{statistics}       Save Cpu Data       ${TEST NAME}  ${cpu_data}
-    Log                 <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="CPU Plot" width="1200">    HTML
+    Log                 <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="CPU Plot" width="1200">    HTML
     IF  "${statistics}[flag]" == "-1"
         ${fail_msg}     Create fail message  ${statistics}
         FAIL            ${fail_msg}
@@ -85,7 +85,7 @@ Memory Read One thread test
     Log                 ${output}
     &{mem_data}         Parse Memory Results   ${output}
     &{statistics}       Save Memory Data       ${TEST NAME}  ${mem_data}
-    Log                 <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
+    Log                 <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
     IF  "${statistics}[flag]" == "-1"
         ${fail_msg}     Create fail message  ${statistics}
         FAIL            ${fail_msg}
@@ -105,7 +105,7 @@ Memory Write One thread test
     Log                 ${output}
     &{mem_data}         Parse Memory Results   ${output}
     &{statistics}       Save Memory Data       ${TEST NAME}  ${mem_data}
-    Log                 <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
+    Log                 <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
     IF  "${statistics}[flag]" == "-1"
         ${fail_msg}     Create fail message  ${statistics}
         FAIL            ${fail_msg}
@@ -125,7 +125,7 @@ Memory Read multimple threads test
     Log                 ${output}
     &{mem_data}         Parse Memory Results   ${output}
     ${statistics}       Save Memory Data       ${TEST NAME}  ${mem_data}
-    Log                 <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
+    Log                 <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
     IF  "${statistics}[flag]" == "-1"
         ${fail_msg}     Create fail message  ${statistics}
         FAIL            ${fail_msg}
@@ -145,7 +145,7 @@ Memory Write multimple threads test
     Log                 ${output}
     &{mem_data}         Parse Memory Results   ${output}
     &{statistics}       Save Memory Data       ${TEST NAME}  ${mem_data}
-    Log                 <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
+    Log                 <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
     IF  "${statistics}[flag]" == "-1"
         ${fail_msg}     Create fail message  ${statistics}
         FAIL            ${fail_msg}
@@ -201,8 +201,8 @@ FileIO test
     &{fileio_wr_data}    Parse FileIO Write Results   ${fileio_wr_output}
     &{statistics_wr}     Save FileIO Data       ${TEST NAME}_write  ${fileio_wr_data}
 
-    Log    <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}_read.png" alt="Mem Plot" width="1200">    HTML
-    Log    <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}_write.png" alt="Mem Plot" width="1200">   HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_read.png" alt="Mem Plot" width="1200">    HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_write.png" alt="Mem Plot" width="1200">   HTML
 
     ${fail_msg}=  Set Variable  ${EMPTY}
     IF  "${statistics_rd}[flag]" == "-1"
@@ -244,9 +244,9 @@ Sysbench test in NetVM
     &{statistics_mem_rd}    Read Mem csv and plot  net-vm_${TEST NAME}_memory_read_1thread
     &{statistics_mem_wr}    Read Mem csv and plot  net-vm_${TEST NAME}_memory_write_1thread
 
-    Log    <img src="${PLOT_DIR}${DEVICE}_net-vm_${TEST NAME}_cpu_1thread.png" alt="CPU Plot" width="1200">       HTML
-    Log    <img src="${PLOT_DIR}${DEVICE}_net-vm_${TEST NAME}_memory_read_1thread.png" alt="Mem Plot" width="1200">    HTML
-    Log    <img src="${PLOT_DIR}${DEVICE}_net-vm_${TEST NAME}_memory_write_1thread.png" alt="Mem Plot" width="1200">    HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_net-vm_${TEST NAME}_cpu_1thread.png" alt="CPU Plot" width="1200">       HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_net-vm_${TEST NAME}_memory_read_1thread.png" alt="Mem Plot" width="1200">    HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_net-vm_${TEST NAME}_memory_write_1thread.png" alt="Mem Plot" width="1200">    HTML
 
     ${msg}=  Set Variable  ${EMPTY}
     IF  "${statistics_cpu}[flag]" == "-1"
@@ -314,13 +314,13 @@ Sysbench test in VMs on LenovoX1
 
     Read VMs data CSV and plot  test_name=${TEST NAME}  vms_dict=${threads}
 
-    Log    <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}_cpu_1thread.png" alt="CPU Plot" width="1200">       HTML
-    Log    <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}_memory_read_1thread.png" alt="Mem Plot" width="1200">    HTML
-    Log    <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}_memory_write_1thread.png" alt="Mem Plot" width="1200">    HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_cpu_1thread.png" alt="CPU Plot" width="1200">       HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_memory_read_1thread.png" alt="Mem Plot" width="1200">    HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_memory_write_1thread.png" alt="Mem Plot" width="1200">    HTML
 
-    Log    <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}_cpu.png" alt="CPU Plot" width="1200">       HTML
-    Log    <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}_memory_read.png" alt="Mem Plot" width="1200">    HTML
-    Log    <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}_memory_write.png" alt="Mem Plot" width="1200">    HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_cpu.png" alt="CPU Plot" width="1200">       HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_memory_read.png" alt="Mem Plot" width="1200">    HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_memory_write.png" alt="Mem Plot" width="1200">    HTML
 
     ${length}       Get Length    ${FAILED_VMS}
 
@@ -355,8 +355,8 @@ Perf-Bench test
     Run Process  rm ${default_file_format}  shell=True
 
     Read And Plot PerfBench Results
-    Log    <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}_perf_results.csv.png" alt="PerfBench Results" width="1200">       HTML
-    Log    <img src="${PLOT_DIR}${DEVICE}_${TEST NAME}_perf_find_bit_results.csv.png" alt="PerfBench Bit Results" width="1200">       HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_perf_results.csv.png" alt="PerfBench Results" width="1200">       HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_perf_find_bit_results.csv.png" alt="PerfBench Bit Results" width="1200">       HTML
 
 *** Keywords ***
 


### PR DESCRIPTION
In case of using non-default output directory the path to performance plots was set absolute. If report.html is opened from the location it was originally created it can show the links to performance plots but if the result folder is moved to another location the links to plots are broken in report.html.

This commit sets relative path to performance plots also for non-default output directory as it is the case for default output directory.