### PR TITLE
Fix Start Bluetooth Settings

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/bat-tests/gui-vm.robot
@@ -38,7 +38,7 @@ Start Bluetooth Settings on LenovoX1
     [Documentation]   Start Bluetooth Settings and verify process started
     [Tags]            bluetooth_settings  SP-T204
     Start XDG application  'Bluetooth Settings'
-    Check that the application was started    blueman
+    Check that the application was started    blueman-manager
 
 Start File Manager on LenovoX1
     [Documentation]   Start File Manager and verify process started


### PR DESCRIPTION
Noticed that `Start Bluetooth Settings on LenovoX1` always passes. Fixed it by changing the search to use unique name.

`Check that the application was started` runs `grep` with argument. Issue was that even before Bluetooth Settings is opened there is two processes running with `blueman` in the name. Because of that it did not matter if the app opened or not, running process was always found.
```
[milla@gui-vm:~]$ ps aux | grep blueman | grep -v grep
milla       1300  1.6  0.4 628140 59084 ?        Sl   07:58   0:00 /nix/store/0l539chjmcq5kdd43j6dgdjky4sjl7hl-python3-3.12.8/bin/python /nix/store/2jriiij72vpc3kz59kvn02q8gj7kybdv-blueman-2.4.4/bin/..blueman-applet-wrapped-wrapped
milla       1494  0.6  0.2 443360 28520 ?        Sl   07:58   0:00 /nix/store/0l539chjmcq5kdd43j6dgdjky4sjl7hl-python3-3.12.8/bin/python /nix/store/2jriiij72vpc3kz59kvn02q8gj7kybdv-blueman-2.4.4/bin/..blueman-tray-wrapped-wrapped
```


[Test run](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/775/robot/report/report.html#totals)

