### PR TITLE
Exclude welcome check for Lenovo & Dell.

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -269,6 +269,8 @@ Verify service status
     [Arguments]       ${range}=45  ${service}=${EMPTY}   ${expected_status}=active   ${expected_state}=running  ${expected_rc}=0
     ${vmservice}      Run Keyword And Return Status  Should Contain  ${service}  microvm@
     ${finished}       Set Variable  False
+
+    ${welcome_check}  Set Variable If  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"    False    True
     
     FOR    ${i}    IN RANGE    ${range}
         ${output}  ${stderr}  ${rc}=   Execute Command  systemctl status ${service}  return_stderr=True  return_rc=True
@@ -280,7 +282,7 @@ Verify service status
         ${state}      Run Keyword And Return Status    Should Be True	'${state}' == '${expected_state}'    Expected ${expected_state} but in fact ${state}
 
         # 'Welcome to NixOS' is not got if 'non-vm service' or if service is expected to be inactive/dead.
-        IF  ${vmservice} and '${expected_state}' == 'running' and ${status} and ${state}
+        IF  ${vmservice} and '${expected_state}' == 'running' and ${status} and ${state} and ${welcome_check}
             ${finished}    Run Keyword And Return Status    Should Contain    ${output}    Welcome to NixOS
             IF  ${finished}
                 BREAK


### PR DESCRIPTION
Excluding 'Welcome to NixOS' waiting from Lenovo & Dell, it is enough to check if process status and state are as expected.

Tests on Orin-AGX: [782](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/782/robot/report/log.html)
