### PR TITLE
Support Cosmic

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -61,6 +61,7 @@ Set Variables
     Set Global Variable  ${GUI_VM}             gui-vm
     Set Global Variable  ${ZATHURA_VM}         zathura-vm
     Set Global Variable  @{VMS}                ${ADMIN_VM}  ${AUDIO_VM}  ${BUSINESS_VM}  ${CHROME_VM}  ${COMMS_VM}  ${GALA_VM}  ${GUI_VM}  ${ZATHURA_VM}
+    Set Global Variable  ${COMPOSITOR}         labwc
 
     Set Log Level       NONE
 

--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -9,9 +9,9 @@ Resource            ../resources/gui_keywords.resource
 *** Keywords ***
 
 Check that the application was started
-    [Arguments]          ${app_name}  ${range}=2
+    [Arguments]          ${app_name}  ${range}=2  ${exact_match}=false
     FOR   ${i}   IN RANGE  ${range}
-        @{found_pids}        Find pid by name    ${app_name}
+        @{found_pids}        Find pid by name    ${app_name}  ${exact_match}
         Set Global Variable  @{APP_PIDS}  @{found_pids}
         ${status}    Run Keyword And Return Status   Should Not Be Empty  ${APP_PIDS}
         IF    ${status}    BREAK
@@ -21,10 +21,10 @@ Check that the application was started
     Log To Console       ${app_name} is started
 
 Check that the application is not running
-    [Arguments]          ${app_name}  ${range}=2
+    [Arguments]          ${app_name}  ${range}=2  ${exact_match}=false
     ${pids}=  Set Variable  ${EMPTY}
     FOR   ${i}   IN RANGE  ${range}
-        ${keyword_status}  ${pids}  Run Keyword And Ignore Error   Find pid by name    ${app_name}
+        ${keyword_status}  ${pids}  Run Keyword And Ignore Error   Find pid by name    ${app_name}  ${exact_match}
         Set Global Variable  @{APP_PIDS}  @{pids}
         ${status}    Run Keyword And Return Status   Should Be Empty  ${pids}
         IF    ${status}    BREAK

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -10,75 +10,139 @@ Library             Collections
 
 *** Variables ***
 
-${START_MENU}         ./launcher.png
-${LOGGED_IN_STATUS}   ${True}
-${DISABLE_LOGOUT}     ${EMPTY}
-${GUI_TEMP_DIR}       ${OUTPUT_DIR}/outputs/gui-temp/
+${APP_MENU_LAUNCHER}   ./launcher.png
+${LOCK_ICON}           ./lock.png
+${DISABLE_LOGOUT}      ${EMPTY}
+${GUI_TEMP_DIR}        ${OUTPUT_DIR}/outputs/gui-temp/
 
 *** Keywords ***
 
-Log in via GUI
-    [Documentation]   Login and verify that task bar is available
-    [Arguments]       ${stop_swayidle}=True
-    Switch Connection    ${CONNECTION}
-    Verify logout
-    IF  ${LOGGED_IN_STATUS}
-        Log To Console          Already logged in. Skipping login.
+Log in, unlock and verify
+    [Documentation]   Open desktop by logging in or unlocking. Verify that desktop is available.
+    [Arguments]       ${stop_swayidle}=True  ${enable_dnd}=False
+    Start ydotoold
+    ${logout_status}    Check if logged out   1
+    IF  ${logout_status}
+        Log in via GUI
+        Wait for Ghaf session activation
     ELSE
-        Log To Console          Logged out state detected. Logging in.
-        Start ydotoold
-        Log To Console          Typing username and password to login
-        Type string and press enter  ${USER_LOGIN}
-        Type string and press enter  ${USER_PASSWORD}
+        ${lock}       Check if locked
+        IF  ${lock}   Unlock
     END
     Try to reset scaling
-    Verify login
-    IF  ${stop_swayidle}
-        Stop swayidle
-    END
+    Verify desktop availability
+    IF  ${stop_swayidle}   Stop swayidle
+    IF  ${enable_dnd}      Set do not disturb state   true
 
-Log out
-    [Documentation]   Log out and optionally verify that desktop is not available
+Log out and verify
+    [Documentation]   Log out. Verify that session was logged out.
+    [Arguments]       ${disable_dnd}=True
     # Allow disabling logout in case of running test automation locally from ghaf-host.
     # This prevents terminal from being shutdown and allows test run to finish.
     IF  $DISABLE_LOGOUT == 'true'
         Log To Console    Log out disabled. Skipping log out procedure.
         RETURN
     END
+    IF  ${disable_dnd}   Set do not disturb state   false
     Start ydotoold
-    Get icon           ghaf-artwork  power.svg  crop=0  background=black
-    Locate and click   icon.png  0.95  5
-    Get icon           ghaf-artwork  logout.svg  crop=0  background=black
-    Locate and click   icon.png  0.95  5
+    ${logout_status}      Check if logged out    1
+    IF  not ${logout_status}
+        Log out via GUI
+        ${logout_status}  Check if logged out
+        IF  not ${logout_status}    FAIL  Failed to log out.
+    END
+    Stop ydotoold
+
+Log in via GUI
+    [Documentation]   Log in by typing username (labwc) and password (labwc&cosmic).
+    Log To Console    Logging in
+    IF  $COMPOSITOR == 'cosmic'
+        # Make sure that password field is active by clicking on screen
+        Execute Command   ydotool mousemove --absolute -x 50 -y 50  sudo=True  sudo_password=${PASSWORD}
+        Execute Command   ydotool click 0xC0  sudo=True  sudo_password=${PASSWORD}
+    ELSE
+        Type string and press enter  ${USER_LOGIN}
+    END
+    Type string and press enter  ${USER_PASSWORD}  confidential=True
+
+Log out via GUI
+    [Documentation]   Log out by using keyboard shortcut (cosmic) or by clicking the logout icon.
+    # Allow disabling logout in case of running test automation locally from ghaf-host.
+    # This prevents terminal from being shutdown and allows test run to finish.
+    IF  $DISABLE_LOGOUT == 'true'
+        Log To Console    Log out disabled. Skipping log out procedure.
+        RETURN
+    END
+    IF  $COMPOSITOR == 'cosmic'
+        Log To Console    Logging out by pressing Super+Shift+Escape 
+        Execute Command   ydotool key 125:1 42:1 1:1 1:0 42:0 125:0  sudo=True  sudo_password=${PASSWORD}
+        Tab and enter     tabs=2
+    ELSE
+        Get icon           ghaf-artwork  power.svg  crop=0  background=black
+        Locate and click   icon.png  0.95  5
+        Get icon           ghaf-artwork  logout.svg  crop=0  background=black
+        Locate and click   icon.png  0.95  5
+    END
 
 Type string and press enter
-    [Arguments]   ${string}=${EMPTY}
-    Connect to VM           ${GUI_VM}
-    Log To Console    Typing
+    [Arguments]    ${string}=${EMPTY}  ${confidential}=False
+    Connect to VM   ${GUI_VM}
+    IF  ${confidential} 
+        Log To Console    Typing password
+    ELSE
+        Log To Console    Typing "${string}"
+    END
     IF  $string != '${EMPTY}'
         Execute Command   ydotool type ${string}  sudo=True  sudo_password=${PASSWORD}
     END
     Log To Console    Pressing Enter
-    Execute Command   ydotool key -d 0 28:1 28:0  sudo=True  sudo_password=${PASSWORD}
+    Execute Command   ydotool key 28:1 28:0  sudo=True  sudo_password=${PASSWORD}
+
+Tab and enter
+    [Arguments]    ${tabs}=1
+    Connect to VM       ${GUI_VM}
+    Log To Console      Pressing Tab ${tabs} times and then Enter to select
+    ${command}=    Set Variable    ${EMPTY}
+    FOR  ${i}  IN RANGE  ${tabs}
+        ${command}=    Set Variable  ${command} 15:1 15:0
+    END
+    ${command}=    Set Variable  ${command} 28:1 28:0
+    Execute Command    ydotool key ${command}  sudo=True  sudo_password=${PASSWORD}
 
 Locate image on screen
     [Documentation]    Take a screenshot. Locate given image on the screenshot.
-    ...                Return center coordinates of the image in mouse coordinate system
+    ...                Return center coordinates of the image in mouse coordinate system.
     [Arguments]        ${image_to_be_searched}  ${confidence}=0.999   ${iterations}=5
     ${coordinates}=        Set Variable  ${EMPTY}
     ${pass_status}=        Set Variable  FAIL
     Connect to VM           ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
-    FOR   ${i}   IN RANGE  ${iterations}
-        Log To Console     Taking screenshot
-        Execute Command    rm screenshot.png
-        ${rc}=             Execute Command  grim screenshot.png  return_stdout=False  return_rc=${true}   timeout=5
-        IF  "${rc}" == "0"
-            SSHLibrary.Get File  screenshot.png   ${GUI_TEMP_DIR}screenshot.png
-            Log To Console    Locating image ${image_to_be_searched} on screenshot
-            ${pass_status}  ${coordinates}  Run Keyword And Ignore Error  Locate image  ${GUI_TEMP_DIR}${image_to_be_searched}   ${confidence}
+    IF  $COMPOSITOR == 'cosmic'
+        Execute Command        mkdir test-images
+        FOR   ${i}   IN RANGE  ${iterations}
+            Log To Console     Taking cosmic screenshot
+            ${result}=         Run Keyword And Ignore Error  Execute Command  cosmic-screenshot --interactive=false --save-dir ./test-images  return_stdout=True   return_rc=True   timeout=5
+            Log                ${result}
+            IF  "${result}[1][1]" == "0"
+                SSHLibrary.Get File  ${result[1][0]}  ${GUI_TEMP_DIR}screenshot.png
+                Log To Console    Locating image ${image_to_be_searched} on ${result[1][0]}
+                ${pass_status}  ${coordinates}  Run Keyword And Ignore Error  Locate image  ${GUI_TEMP_DIR}${image_to_be_searched}   ${confidence}
+            END
+            IF    $pass_status=='PASS'    BREAK
+            Sleep  1
         END
-        IF    $pass_status=='PASS'    BREAK
-        Sleep  0.5
+    ELSE
+        FOR   ${i}   IN RANGE  ${iterations}
+            Log To Console     Taking grim screenshot
+            Execute Command    rm screenshot.png
+            ${rc}=             Execute Command  grim screenshot.png  return_stdout=False  return_rc=${true}   timeout=5
+            IF  "${rc}" == "0"
+                SSHLibrary.Get File  screenshot.png   ${GUI_TEMP_DIR}screenshot.png
+                Log To Console    Locating image ${image_to_be_searched} on screenshot
+                ${pass_status}  ${coordinates}  Run Keyword And Ignore Error  Locate image  ${GUI_TEMP_DIR}${image_to_be_searched}   ${confidence}
+            END
+            IF    $pass_status=='PASS'    BREAK
+            Sleep  1
+        END
     END
     IF    $pass_status=='FAIL'    FAIL  Image recognition failure: ${image_to_be_searched}
     Log To Console    Coordinates: ${coordinates}
@@ -88,14 +152,18 @@ Locate image on screen
 
 Locate and click
     [Arguments]   ${image_to_be_searched}  ${confidence}=0.99  ${iterations}=5
-    ${mouse_x}  ${mouse_y}  Locate image on screen  ${image_to_be_searched}   ${confidence}  ${iterations}
+    ${mouse_x}  ${mouse_y}  Locate image on screen  ${image_to_be_searched}  ${confidence}  ${iterations}
     Connect to VM     ${GUI_VM}
     Execute Command   ydotool mousemove --absolute -x ${mouse_x} -y ${mouse_y}  sudo=True  sudo_password=${PASSWORD}
     Execute Command   ydotool click 0xC0  sudo=True  sudo_password=${PASSWORD}
 
 Start ydotoold
     [Documentation]    Start ydotool daemon if it is not already running.
-    Connect to VM  ${GUI_VM}
+    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
+        Connect to VM    ${GUI_VM}
+    ELSE
+        Connect
+    END
     ${ydotoold_state}=    Execute Command    sh -c 'ps aux | grep ydotoold | grep -v grep'
     IF  $ydotoold_state == '${EMPTY}'
         Log To Console    Starting ydotool daemon
@@ -108,110 +176,171 @@ Start ydotoold
 
 Stop ydotoold
     [Documentation]    Kill ydotool daemon
+    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
+        Connect to VM    ${GUI_VM}
+    ELSE
+        Connect
+    END
     Log To Console    Stopping ydotool daemon
     Execute Command   pkill ydotoold  sudo=True  sudo_password=${PASSWORD}
 
 Move cursor to corner
     [Documentation]    Move the cursor to the upper left corner so that it will not block searching further gui screenshots
     Log To Console    Moving cursor to corner from blocking further image detection
-    Start ydotoold
     Execute Command   ydotool mousemove --absolute -x 50 -y 50  sudo=True  sudo_password=${PASSWORD}
 
-Verify login
-    [Documentation]    Check that launcher icon is available on desktop
+Verify desktop availability
+    [Documentation]         Check that launcher icon is available on desktop
     Log To Console          Verifying login by trying to detect the launcher icon
-    Locate image on screen  ${START_MENU}  0.95  15
+    Locate image on screen  ${APP_MENU_LAUNCHER}  0.95  10
 
 Move cursor
-    Start ydotoold
     ${x}    Evaluate  random.randint(50, 500)  modules=random
     ${y}    Evaluate  random.randint(50, 500)  modules=random
     Execute Command   ydotool mousemove --absolute -x ${x} -y ${y}  sudo=True  sudo_password=${PASSWORD}
 
-Verify logout
-    [Documentation]    Check that dekstop is not available by running 'grim' which should have return code 1 in this case
-    [Arguments]        ${iterations}=5
-    ${status}=         Set Variable  ${EMPTY}
+Check if logged out
+    [Documentation]    Check if system is in logged out state
+    [Arguments]        ${iterations}=10
     Connect to VM      ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
     FOR   ${i}   IN RANGE  ${iterations}
-        ${rc}=    Execute Command  grim check.png  return_stdout=False  return_rc=${true}
-        IF  "${rc}" == "1"
-            Set Global Variable  ${LOGGED_IN_STATUS}  ${False}
-            BREAK
+        IF  $COMPOSITOR == 'cosmic'
+            ${activity}=       Execute Command    systemctl --user is-active ghaf-session.target  return_stdout=True
+            IF  $activity == "active"
+                Log To Console      Ghaf session is ${activity}, user is logged in
+            ELSE
+                Log To Console      Ghaf session is ${activity}, user is logged out
+                RETURN    ${True}
+            END
         ELSE
-            Set Global Variable  ${LOGGED_IN_STATUS}  ${True}
+            # In theory checking ghaf-session should also work with labwc, but for some reason it
+            # does not always work. Grim returns 1 when desktop is not available.
+            ${rc}=    Execute Command  grim check.png  return_stdout=False  return_rc=${true}
+            IF  "${rc}" == "1"
+                Log To Console       User is logged out
+                RETURN    ${True}
+            ELSE
+                Log To Console       User is logged in
+            END
         END
         Sleep  1
     END
-    [Teardown]         Connect to VM   ${GUI_VM}
+    RETURN    ${False}
+    [Teardown]    Connect to VM   ${GUI_VM}
+
+Wait for Ghaf session activation
+    [Documentation]    Wait until ghaf session is in active state
+    Connect to VM      ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
+    Log To Console     Waiting for the Ghaf session to start...  no_newline=true 
+    FOR   ${i}   IN RANGE  30
+        ${activity}=       Execute Command    systemctl --user is-active ghaf-session.target  return_stdout=True
+        IF  $activity == "active"
+            Log To Console        Success
+            Log To Console        Ghaf session is ${activity}, user is logged in
+            RETURN
+        ELSE
+            Log To Console   ${i}.  no_newline=true
+        END
+        Sleep   0.5
+    END
+    FAIL    Ghaf session did not activate
+    [Teardown]    Connect to VM   ${GUI_VM}
 
 Get icon
     [Documentation]    Copy icon svg file to test agent machine. Crop and convert the svg file to png.
     [Arguments]        ${path}   ${icon_name}   ${crop}=0   ${background}=none   ${output_filename}=icon.png
-    IF  $path == "app"
-        SSHLibrary.Get File  ${APP_ICON_PATH}/${icon_name}   ${GUI_TEMP_DIR}icon.svg
-    ELSE IF  $path == "ghaf-artwork"
-        SSHLibrary.Get File  ${ARTWORK_PATH}/${icon_name}   ${GUI_TEMP_DIR}icon.svg
-    ELSE
+    IF  $COMPOSITOR == 'cosmic'
         SSHLibrary.Get File  ${path}/${icon_name}   ${GUI_TEMP_DIR}icon.svg
+        Convert app icon  ${crop}   ${background}   input_file=${GUI_TEMP_DIR}icon.svg  output_file=${GUI_TEMP_DIR}${output_filename}
+    ELSE
+        IF  $path == "app"
+            SSHLibrary.Get File  ${APP_ICON_PATH}/${icon_name}   ${GUI_TEMP_DIR}icon.svg
+        ELSE IF  $path == "ghaf-artwork"
+            SSHLibrary.Get File  ${ARTWORK_PATH}/${icon_name}   ${GUI_TEMP_DIR}icon.svg
+        ELSE
+            SSHLibrary.Get File  ${path}/${icon_name}   ${GUI_TEMP_DIR}icon.svg
+        END
+        Convert app icon  ${crop}   ${background}   input_file=${GUI_TEMP_DIR}icon.svg  output_file=${GUI_TEMP_DIR}${output_filename}
     END
-    Convert app icon  ${crop}   ${background}   input_file=${GUI_TEMP_DIR}icon.svg  output_file=${GUI_TEMP_DIR}${output_filename}
 
 Check if locked
-    [Documentation]    Check if the screen lock has been activated
-    Verify logout      2
-    IF  ${LOGGED_IN_STATUS}
-        Start ydotoold
-        Type string and press enter
-        Log To Console     Searching for view-reveal-symbolic.svg
-        Get icon           ${ICON_THEME}/symbolic/actions  view-reveal-symbolic.svg  background=black
+    [Documentation]    Check if the screen lock is active
+    ${logout_status}   Check if logged out   1
+    IF  not ${logout_status}
+        IF  $COMPOSITOR == 'cosmic'
+            Get icon       ${ICONS}/Cosmic/scalable/actions  system-lock-screen-symbolic.svg  background=black
+        ELSE
+            Get icon           ${ICON_THEME}/symbolic/actions  view-reveal-symbolic.svg  background=black
+            Type string and press enter
+        END
         ${status}   ${output}      Run Keyword And Ignore Error   Locate image on screen  icon.png  0.95  3
         IF  '${status}' == 'PASS'
+            Log To Console    Screen is locked
             RETURN    ${True}
         END
     END
+    Log To Console    Screen lock is not active
     RETURN    ${False}
 
 Unlock
     [Documentation]    Unlock the screen be typing password
-    Start ydotoold
+    Connect to VM      ${GUI_VM}
+    IF  $COMPOSITOR == 'cosmic'
+        # Make sure that password field is active by clicking it
+        Locate and click   ${LOCK_ICON}   0.95  5
+    END
     Log To Console     Typing password to unlock
-    Type string and press enter  ${USER_PASSWORD}
+    Type string and press enter  ${USER_PASSWORD}  confidential=True
 
 Save most common icons and paths to icons
     [Documentation]         Save those icons by name which will be used in multiple test cases
     ...                     Save paths to icon packs in gui-vm nix store
-    ${icons}                Execute Command   find $(echo $XDG_DATA_DIRS | tr ':' ' ') -type d -name "icons" 2>/dev/null
-    Set Global Variable     ${ICON_THEME}        ${icons}/Papirus
-    Log To Console          Saving path to app icon-pack
-    Set Global Variable     ${APP_ICON_PATH}  ${ICON_THEME}/128x128/apps
-    Log                     ${APP_ICON_PATH}  console=True
-    Log To Console          Saving path to ghaf-artwork icons
-    ${ghaf_artwork_path}    Execute Command   echo /nix/store/$(ls /nix/store | grep ghaf-artwork- | grep -v .drv)/icons
-    Set Global Variable     ${ARTWORK_PATH}  ${ghaf_artwork_path}
-    Log                     ${ARTWORK_PATH}  console=True
-    Log To Console          Saving gui icons
-    Get icon                ghaf-artwork  launcher.svg  crop=0  background=black  output_filename=launcher.png
-    Get icon                ${ICON_THEME}/symbolic/actions  window-close-symbolic.svg  crop=0  output_filename=window-close.png  background=white
-    Negate app icon         ${GUI_TEMP_DIR}window-close.png  ${GUI_TEMP_DIR}window-close-neg.png
+    IF  $COMPOSITOR == 'cosmic'
+        Log To Console          Saving commonly used icons
+        ${ICONS}                Execute Command   find $(echo $XDG_DATA_DIRS | tr ':' ' ') -type d -name "icons" 2>/dev/null
+        Set Global Variable     ${ICONS}
+        Get icon                ${ICONS}/hicolor/scalable/apps  com.system76.CosmicAppLibrary.svg  crop=0  background=black  output_filename=launcher.png
+        Get icon                ${ICONS}/Papirus/symbolic/actions  window-close-symbolic.svg  crop=0  background=white  output_filename=window-close.png
+        Negate app icon         ${GUI_TEMP_DIR}window-close.png  ${GUI_TEMP_DIR}window-close-neg.png
+        Get icon                ${ICONS}/Cosmic/scalable/actions  system-search-symbolic.svg  crop=0  background=white  output_filename=search.png
+        Negate app icon         ${GUI_TEMP_DIR}search.png  ${GUI_TEMP_DIR}search-neg.png
+        Get icon                ${ICONS}/hicolor/scalable/apps  com.system76.CosmicAppletPower-symbolic.svg  crop=0  background=black  output_filename=power.png
+        Get icon                ${ICONS}/Cosmic/scalable/actions  system-lock-screen-symbolic.svg  background=black  output_filename=lock.png
+    ELSE
+        ${icons}                Execute Command   find $(echo $XDG_DATA_DIRS | tr ':' ' ') -type d -name "icons" 2>/dev/null
+        Set Global Variable     ${ICON_THEME}        ${icons}/Papirus
+        Log To Console          Saving path to app icon-pack
+        Set Global Variable     ${APP_ICON_PATH}  ${ICON_THEME}/128x128/apps
+        Log                     ${APP_ICON_PATH}  console=True
+        Log To Console          Saving path to ghaf-artwork icons
+        ${ghaf_artwork_path}    Execute Command   echo /nix/store/$(ls /nix/store | grep ghaf-artwork- | grep -v .drv)/icons
+        Set Global Variable     ${ARTWORK_PATH}  ${ghaf_artwork_path}
+        Log                     ${ARTWORK_PATH}  console=True
+        Log To Console          Saving gui icons
+        Get icon                ghaf-artwork  launcher.svg  crop=0  background=black  output_filename=launcher.png
+        Get icon                ${ICON_THEME}/symbolic/actions  window-close-symbolic.svg  crop=0  output_filename=window-close.png  background=white
+        Negate app icon         ${GUI_TEMP_DIR}window-close.png  ${GUI_TEMP_DIR}window-close-neg.png
+    END
 
 Try to reset scaling
-    [Documentation]    Disable hidpi-auto-scaling
-    Log To Console     Trying to reset scaling
-    Connect to VM      ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
-    FOR   ${i}   IN RANGE  5
-        Execute Command   systemctl --user start hidpi-auto-scaling-reset
-        ${output}         Execute Command   journalctl --since "5 seconds ago" --user -u hidpi-auto-scaling-reset
-        ${status}=        Run Keyword And Return Status    Should contain    ${output}    Finished
-        IF  ${status}
-            Execute Command   systemctl --user reload ewwbar
-            Log To Console    Auto scaling reset succeeded
-            BREAK
-        Sleep    1
+    [Documentation]    Disable hidpi-auto-scaling (labwc only)
+    IF  $COMPOSITOR != 'cosmic'
+        Log To Console     Trying to reset scaling
+        Connect to VM      ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
+        FOR   ${i}   IN RANGE  5
+            Execute Command   systemctl --user start hidpi-auto-scaling-reset
+            ${output}         Execute Command   journalctl --since "5 seconds ago" --user -u hidpi-auto-scaling-reset
+            ${status}=        Run Keyword And Return Status    Should contain    ${output}    Finished
+            IF  ${status}
+                Execute Command   systemctl --user reload ewwbar
+                Log To Console    Auto scaling reset succeeded
+                BREAK
+            Sleep    1
+            END
         END
-    END
-    IF  not ${status}
-        Log To Console   Auto scaling reset failed
+        IF  not ${status}
+            Log To Console   Auto scaling reset failed
+        END
     END
 
 Stop swayidle
@@ -219,3 +348,24 @@ Stop swayidle
     Log To Console    Disabling automated lock and suspend
     Connect to VM     ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
     Execute Command   systemctl --user stop swayidle
+
+Set do not disturb state
+    [Documentation]   Set do not disturb to true or false (cosmic only)
+    [Arguments]       ${state}
+    IF  $COMPOSITOR == 'cosmic'
+        Log To Console    Setting Do Not Disturb to ${state}
+        Connect to VM     ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
+        Execute Command   echo ${state} > ~/.config/cosmic/com.system76.CosmicNotifications/v1/do_not_disturb
+    END
+
+Set compositor
+    [Documentation]   Set compositor to cosmic if cosmic process is running. By default compositor is set labwc.
+    Log To Console    Checking compositor
+    ${cosmic_processes}=    Execute Command    sh -c 'ps aux | grep cosmic | grep -v grep'
+    Log    ${cosmic_processes}
+    IF  $cosmic_processes != '${EMPTY}'
+        Log To Console   Compositor: cosmic
+        Set Global Variable   ${COMPOSITOR}   cosmic
+    ELSE
+        Log To Console   Compositor: labwc
+    END

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -205,12 +205,16 @@ Check application name
     RETURN  '${app}[0]'
 
 Start XDG application
-    [Arguments]      ${app_name}
+    [Arguments]      ${app_name}  ${gui_vm_app}=false
     Log To Console   ${\n}Starting ${app_name}
     ${app_name}      Check application name  ${app_name}
     ${output}        Execute Command    cat /run/current-system/sw/share/applications/${app_name}.desktop
     ${path}          Get App Path From Desktop  ${output}
-    Execute Command  nohup sh -c '${path}' > output.log 2>&1 &
+    IF  $gui_vm_app and $COMPOSITOR == 'cosmic'
+        Execute Command  nohup sh -c 'WAYLAND_DISPLAY=wayland-1 ${path}' > output.log 2>&1 &
+    ELSE
+        Execute Command  nohup sh -c '${path}' > output.log 2>&1 &
+    END
     Sleep    8
     ${output}        Execute Command  cat output.log
     Log    ${output}
@@ -237,9 +241,13 @@ Is process started
     RETURN      ${status}
 
 Find pid by name
-    [Arguments]   ${proc_name}
+    [Arguments]   ${proc_name}  ${exact_match}=false
     Log To Console    Looking for pids of the process ${proc_name}
-    ${output}=    Execute Command    sh -c 'ps aux | grep "${proc_name}" | grep -v grep'
+    IF  $exact_match=='true'
+        ${output}=    Execute Command    sh -c 'ps aux | grep -E " ${proc_name}$" | grep -v grep'
+    ELSE
+        ${output}=    Execute Command    sh -c 'ps aux | grep "${proc_name}" | grep -v grep'
+    END
     Log           ${output}
     @{pids}=      Find Pid    ${output}  ${proc_name}
     Log To Console    Found PIDs for process '${proc_name}':\n${pids}

--- a/Robot-Framework/test-suites/bat-tests/__init__.robot
+++ b/Robot-Framework/test-suites/bat-tests/__init__.robot
@@ -22,13 +22,12 @@ ${DISABLE_LOGOUT}     ${EMPTY}
 BAT tests setup
     [timeout]    5 minutes
     Initialize Variables, Connect And Start Logging
-
     IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Connect to netvm
         Connect to VM         ${GUI_VM}
+        Set compositor
         Save most common icons and paths to icons
         Create test user
-        Log in via GUI
+        Log in, unlock and verify
     END
     Switch Connection    ${CONNECTION}
 
@@ -37,6 +36,6 @@ BAT tests teardown
     Connect to ghaf host
     Log journalctl
     IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Log out
+        Log out and verify
     END
     Close All Connections

--- a/Robot-Framework/test-suites/bat-tests/business_vm.robot
+++ b/Robot-Framework/test-suites/bat-tests/business_vm.robot
@@ -52,6 +52,7 @@ Start Video Editor on LenovoX1
 Start Text Editor on LenovoX1
     [Documentation]   Start Text Editor in Business-vm and verify process started
     [Tags]  text_editor  SP-T243
+    IF  $COMPOSITOR == 'cosmic'   Skip   App not available in Cosmic
     Start XDG application   "Text Editor"
     Connect to VM       ${BUSINESS_VM}
     Check that the application was started    text-editor
@@ -59,10 +60,10 @@ Start Text Editor on LenovoX1
 Start Xarchiver on LenovoX1
     [Documentation]   Start Xarchiver in Business-vm and verify process started
     [Tags]  xarchiver  SP-T242
+    IF  $COMPOSITOR == 'cosmic'   Skip   App not available in Cosmic
     Start XDG application   "Xarchiver"
     Connect to VM       ${BUSINESS_VM}
     Check that the application was started    xarchiver
-
 
 *** Keywords ***
 

--- a/Robot-Framework/test-suites/bat-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/bat-tests/gui-vm.robot
@@ -19,32 +19,56 @@ Test Teardown       Gui-vm Apps Test Teardown
 Start Calculator on LenovoX1
     [Documentation]   Start Calculator and verify process started
     [Tags]            calculator  SP-T202
-    Start XDG application  Calculator
+    Start XDG application  Calculator  gui_vm_app=true
     Check that the application was started    calculator
 
 Start Sticky Notes on LenovoX1
     [Documentation]   Start Sticky Notes and verify process started
     [Tags]            sticky_notes  SP-T201-1
-    Start XDG application  'Sticky Notes'
+    Start XDG application  'Sticky Notes'  gui_vm_app=true
     Check that the application was started    sticky-wrapped
 
 Start Ghaf Control Panel on LenovoX1
     [Documentation]   Start Ghaf Control Panel and verify process started
     [Tags]            control_panel  SP-T205
-    Start XDG application   'Ghaf Control Panel'
+    Start XDG application  'Ghaf Control Panel'  gui_vm_app=true
     Check that the application was started    ctrl-panel
 
 Start Bluetooth Settings on LenovoX1
     [Documentation]   Start Bluetooth Settings and verify process started
     [Tags]            bluetooth_settings  SP-T204
-    Start XDG application  'Bluetooth Settings'
-    Check that the application was started    blueman-manager
+    Start XDG application  'Bluetooth Settings'  gui_vm_app=true
+    Check that the application was started    blueman-manager-wrapped-wrapped
 
-Start File Manager on LenovoX1
-    [Documentation]   Start File Manager and verify process started
-    [Tags]            file_manager  SP-T206
-    Start XDG application  'File Manager'
-    Check that the application was started    pcmanfm
+Start COSMIC Files on LenovoX1
+    [Documentation]   Start Cosmic Files and verify process started
+    [Tags]            cosmic_files  SP-T206
+    IF  $COMPOSITOR == 'cosmic'
+        Start XDG application  com.system76.CosmicFiles  gui_vm_app=true
+        Check that the application was started    cosmic-files %U  exact_match=true
+    ELSE
+        Skip   App only available in Cosmic
+    END
+
+Start COSMIC Settings on LenovoX1
+    [Documentation]   Start Cosmic Settings and verify process started
+    [Tags]            cosmic_settings  SP-T254
+    IF  $COMPOSITOR == 'cosmic'
+        Start XDG application  com.system76.CosmicSettings  gui_vm_app=true
+        Check that the application was started    cosmic-settings  exact_match=true
+    ELSE
+        Skip   App only available in Cosmic
+    END
+
+Start COSMIC Text Editor on LenovoX1
+    [Documentation]   Start Cosmic Text Editor and verify process started
+    [Tags]            cosmic_editor  SP-T243
+    IF  $COMPOSITOR == 'cosmic'
+        Start XDG application   com.system76.CosmicEdit  gui_vm_app=true
+        Check that the application was started    cosmic-edit %F  exact_match=true
+    ELSE
+        Skip   App only available in Cosmic
+    END
 
 *** Keywords ***
 

--- a/Robot-Framework/test-suites/gui-tests/__init__.robot
+++ b/Robot-Framework/test-suites/gui-tests/__init__.robot
@@ -8,36 +8,27 @@ Resource            ../../resources/gui_keywords.resource
 Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/connection_keywords.resource
 Library             ../../lib/GuiTesting.py   ${OUTPUT_DIR}/outputs/gui-temp/
-Suite Setup         Run Keywords  Initialize Variables, Connect And Start Logging  AND  GUI Tests Setup
-Suite Teardown      Close All Connections
+Test Timeout        10 minutes
+Suite Setup         GUI Tests Setup
+Suite Teardown      GUI Tests Teardown
 
 
 *** Keywords ***
 
 GUI Tests Setup
+    Initialize Variables, Connect And Start Logging
     IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Verify service status   range=15  service=microvm@gui-vm.service  expected_status=active  expected_state=running
-        Connect to netvm
-        Connect to VM           ${GUI_VM}
+        Connect to VM       ${GUI_VM}
+        Set compositor
+        Save most common icons and paths to icons
         Create test user
+        Log in, unlock and verify   enable_dnd=True
     END
-    Run journalctl recording
-    Save most common icons and paths to icons
-    Log To Console              Check if the screen is in locked state
-    ${lock}                     Check if locked
-    IF  ${lock}
-        Log To Console          Screen lock detected
-        Unlock
-    ELSE
-        Log To Console          Screen lock not active. Checking if logged in...
-        Log in via GUI
+
+GUI Tests Teardown
+    Connect to ghaf host
+    Log journalctl
+    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
+        Log out and verify   disable_dnd=True
     END
-    Verify login
-    # Open and close app launcher menu to workaround a bug (icons not visible at first launch of app menu)
-    Log To Console    Opening and closing the app menu
-    Log To Console    Going to click the app menu icon
-    Locate and click  ${start_menu}  0.95  5
-    Move cursor to corner
-    Log To Console    Going to click the app menu icon
-    Locate and click  ${start_menu}  0.95  5
-    Move cursor to corner
+    Close All Connections

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -9,122 +9,186 @@ Resource            ../../config/variables.robot
 Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/gui_keywords.resource
 Library             ../../lib/GuiTesting.py   ${OUTPUT_DIR}/outputs/gui-temp/
-Suite Teardown      GUI Apps Teardown
+Test Setup          GUI Apps Test Setup
+Test Teardown       GUI Apps Test Teardown
 
 
 *** Variables ***
 
-@{APP_PIDS}         ${EMPTY}
-${start_menu}       ./launcher.png
+@{APP_PIDS}             ${EMPTY}
 
 
 *** Test Cases ***
 
-Start and close chrome via GUI on LenovoX1
-    [Documentation]   Start Chrome via GUI test automation and verify related process started
-    ...               Close Chrome via GUI test automation and verify related process stopped
-    [Tags]            SP-T41   lenovo-x1
-    Get icon   app  google-chrome.svg  crop=30
-    Start app via GUI on LenovoX1   ${CHROME_VM}  chrome
-    Close app via GUI on LenovoX1   ${CHROME_VM}  google-chrome  ./window-close-neg.png   2
+Start and close Google Chrome via GUI on LenovoX1
+    [Documentation]   Start Google Chrome via GUI test automation and verify related process started
+    ...               Close Google Chrome via GUI test automation and verify related process stopped
+    [Tags]            SP-T41-2  lenovo-x1
+    IF  $COMPOSITOR == 'cosmic'
+        Start app via GUI on LenovoX1   ${CHROME_VM}  chrome  display_name=Chrome
+        Close app via GUI on LenovoX1   ${CHROME_VM}  google-chrome  ./window-close-neg.png   2
+    ELSE
+        Get icon   app  google-chrome.svg  crop=30
+        Start app via GUI on LenovoX1   ${CHROME_VM}  chrome
+        Close app via GUI on LenovoX1   ${CHROME_VM}  google-chrome  ./window-close-neg.png   2
+    END
+    [Teardown]        Run Keyword If Test Failed     Skip if   $COMPOSITOR == 'cosmic'   "Known issue: Chrome does not have top bar"
 
 Start and close PDF Viewer via GUI on LenovoX1
     [Documentation]   Start PDF Viewer via GUI test automation and verify related process started
     ...               Close PDF Viewer via GUI test automation and verify related process stopped
-    [Tags]            SP-T70   lenovo-x1
-    Get icon   app  zathura.svg  crop=30
-    Start app via GUI on LenovoX1   ${ZATHURA_VM}  zathura
-    Close app via GUI on LenovoX1   ${ZATHURA_VM}  zathura  ./window-close-neg.png
+    [Tags]            SP-T70  lenovo-x1
+    IF  $COMPOSITOR == 'cosmic'
+        Start app via GUI on LenovoX1   ${ZATHURA_VM}  zathura   display_name=PDF
+        Close app via GUI on LenovoX1   ${ZATHURA_VM}  zathura  ./window-close.png
+    ELSE
+        Get icon   app  zathura.svg  crop=30
+        Start app via GUI on LenovoX1   ${ZATHURA_VM}  zathura
+        Close app via GUI on LenovoX1   ${ZATHURA_VM}  zathura  ./window-close-neg.png
+    END
 
 Start and close Sticky Notes via GUI on LenovoX1
     [Documentation]   Start Sticky Notes via GUI test automation and verify related process started
     ...               Close Sticky Notes via GUI test automation and verify related process stopped
     [Tags]            SP-T201-2  lenovo-x1
-    Get icon   /run/current-system/sw/share/icons/hicolor/scalable/apps  com.vixalien.sticky.svg   crop=15
-    Start app via GUI on LenovoX1   ${GUI_VM}  sticky-wrapped  #.com.vixalien.sticky-wrapped
-    Close app via GUI on LenovoX1   ${GUI_VM}  sticky-wrapped  ./window-close.png
+    IF  $COMPOSITOR == 'cosmic'
+        Skip   App not available in Cosmic
+    ELSE
+        Get icon   /run/current-system/sw/share/icons/hicolor/scalable/apps  com.vixalien.sticky.svg   crop=15
+        Start app via GUI on LenovoX1   ${GUI_VM}  sticky-wrapped
+        Close app via GUI on LenovoX1   ${GUI_VM}  sticky-wrapped  ./window-close.png
+    END
 
 Start and close Calculator via GUI on LenovoX1
     [Documentation]   Start Calculator via GUI test automation and verify related process started
     ...               Close Calculator via GUI test automation and verify related process stopped
-    [Tags]            SP-T202  lenovo-x1
-    Get icon   app  gnome-calculator.svg   crop=10
-    Start app via GUI on LenovoX1   ${GUI_VM}  gnome-calculator
-    Close app via GUI on LenovoX1   ${GUI_VM}  gnome-calculator  ./window-close.png
+    [Tags]            SP-T202-2  lenovo-x1
+    IF  $COMPOSITOR == 'cosmic'
+        Start app via GUI on LenovoX1   ${GUI_VM}  gnome-calculator  display_name=Calculator
+        Close app via GUI on LenovoX1   ${GUI_VM}  gnome-calculator  ./window-close-neg.png
+    ELSE
+        Get icon   app  gnome-calculator.svg   crop=10
+        Start app via GUI on LenovoX1   ${GUI_VM}  gnome-calculator
+        Close app via GUI on LenovoX1   ${GUI_VM}  gnome-calculator  ./window-close.png
+    END
 
 Start and close Bluetooth Settings via GUI on LenovoX1
-    [Documentation]   Start Bluetooth via GUI test automation and verify related process started
-    ...               Close Bluetooth via via GUI test automation and verify related process stopped
-    [Tags]            SP-T204  lenovo-x1
-    Get icon   app  blueman.svg   crop=30
-    Start app via GUI on LenovoX1   ${GUI_VM}  blueman-manager-wrapped-wrapped
-    Close app via GUI on LenovoX1   ${GUI_VM}  blueman-manager-wrapped-wrapped  ./window-close-neg.png
+    [Documentation]   Start Bluetooth Settings via GUI test automation and verify related process started
+    ...               Close Bluetooth Settings via GUI test automation and verify related process stopped
+    [Tags]            SP-T204-2  lenovo-x1
+    IF  $COMPOSITOR == 'cosmic'
+        Start app via GUI on LenovoX1   ${GUI_VM}  blueman-manager-wrapped-wrapped  display_name=Bluetooth
+        Close app via GUI on LenovoX1   ${GUI_VM}  blueman-manager-wrapped-wrapped  ./window-close.png
+    ELSE
+        Get icon   app  blueman.svg   crop=30
+        Start app via GUI on LenovoX1   ${GUI_VM}  blueman-manager-wrapped-wrapped
+        Close app via GUI on LenovoX1   ${GUI_VM}  blueman-manager-wrapped-wrapped  ./window-close-neg.png
+    END
 
-Start and close Control Panel via GUI on LenovoX1
-    [Documentation]   Start Control Panel via GUI test automation and verify related process started
-    ...               Close Control Panel via GUI test automation and verify related process stopped
-    [Tags]            SP-T205  lenovo-x1
-    Get icon   app  gnome-control-center.svg   crop=10
-    Start app via GUI on LenovoX1   ${GUI_VM}  ctrl-panel
-    Close app via GUI on LenovoX1   ${GUI_VM}  ctrl-panel  ./window-close.png
-
-Start and close File Manager via GUI on LenovoX1
-    [Documentation]   Start File Manager via GUI test automation and verify related process started
-    ...               Close File Manager via GUI test automation and verify related process stopped
-    [Tags]            SP-T206  lenovo-x1
-    Get icon   app  xfce-filemanager.svg   crop=30
-    Start app via GUI on LenovoX1   ${GUI_VM}  pcmanfm
-    Close app via GUI on LenovoX1   ${GUI_VM}  pcmanfm  ./window-close-neg.png
+Start and close Ghaf Control Panel via GUI on LenovoX1
+    [Documentation]   Start Ghaf Control Panel via GUI test automation and verify related process started
+    ...               Close Ghaf Control Panel via GUI test automation and verify related process stopped
+    [Tags]            SP-T205-2  lenovo-x1
+    IF  $COMPOSITOR == 'cosmic'
+        Start app via GUI on LenovoX1   ${GUI_VM}  ctrl-panel  display_name=Control
+        Close app via GUI on LenovoX1   ${GUI_VM}  ctrl-panel  ./window-close-neg.png
+    ELSE
+        Get icon   app  gnome-control-center.svg   crop=10
+        Start app via GUI on LenovoX1   ${GUI_VM}  ctrl-panel
+        Close app via GUI on LenovoX1   ${GUI_VM}  ctrl-panel  ./window-close.png
+    END
+    
+Start and close COSMIC Files via GUI on LenovoX1
+    [Documentation]   Start COSMIC Files via GUI test automation and verify related process started
+    ...               Close COSMIC Files via GUI test automation and verify related process stopped
+    [Tags]            SP-T206-2  lenovo-x1
+    IF  $COMPOSITOR == 'cosmic'
+        Start app via GUI on LenovoX1   ${GUI_VM}  cosmic-files  display_name=Files  exact_match=true
+        Close app via GUI on LenovoX1   ${GUI_VM}  cosmic-files  ./window-close-neg.png  exact_match=true
+    ELSE
+        Skip   App only available in Cosmic
+    END
 
 Start and close Firefox via GUI on Orin AGX
     [Documentation]   Passing this test requires that display is connected to the target device
     ...               Start Firefox via GUI test automation and verify related process started
     ...               Close Firefox via GUI test automation and verify related process stopped
-    [Tags]            SP-T41   # orin-agx can be added after arranging display connection for Orin-AGX in the test setup
-    Get icon  app  firefox.svg  crop=30
+    [Tags]            SP-T41-2   # orin-agx can be added after arranging display connection for Orin-AGX in the test setup
+    Get icon   ${ICONS}/Papirus/128x128/apps  firefox.svg  crop=30
     Start app via GUI on Orin AGX   firefox
     Close app via GUI on Orin AGX   firefox
 
 *** Keywords ***
 
+GUI Apps Test Setup
+    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
+        Connect to netvm
+        Connect to VM   ${GUI_VM}
+    ELSE
+        Connect
+    END
+    Start ydotoold
+
+GUI Apps Test Teardown
+    Connect to VM   ${GUI_VM}
+    Move cursor to corner
+    Close All Connections
+
 Start app via GUI on LenovoX1
     [Documentation]    Start Application via GUI test automation and verify related process started
     [Arguments]        ${app-vm}
     ...                ${app}
+    ...                ${display_name}=""
     ...                ${launch_icon}=icon.png
-
-    Connect to VM if not already connected  gui-vm
+    ...                ${exact_match}=false
+    Connect to VM   ${GUI_VM}
     Check if ssh is ready on vm    ${app-vm}
 
-    Start ydotoold
-
-    Log To Console    Going to click the app menu icon
-    Locate and click  ${start_menu}  0.95  5
-    Log To Console    Going to click the application launch icon
-    Locate and click  ${launch_icon}  0.95  5
+    IF  $COMPOSITOR == 'cosmic'
+        Open app menu
+        Type string and press enter  ${display_name}
+        Tab and enter   tabs=1
+    ELSE
+        Log To Console    Going to click the app menu icon
+        Locate and click  ${APP_MENU_LAUNCHER}  0.95  5
+        Log To Console    Going to click the application launch icon
+        Locate and click  ${launch_icon}  0.95  5
+    END
 
     Connect to VM       ${app-vm}
-    Check that the application was started    ${app}  10
+    Check that the application was started    ${app}  10  ${exact_match}
 
     [Teardown]    Run Keywords    Connect to VM     ${GUI_VM}
     ...           AND             Move cursor to corner
 
-Close app via GUI on LenovoX1
+Open app menu
+    [Documentation]    Check if app menu is open and if not open it (cosmic)
+    # Searches for app menu magnifying glass to identify if app menu is open
+    Log To Console     Checking that app menu is not already open
+    ${status}   ${output}      Run Keyword And Ignore Error   Locate image on screen  search-neg.png  0.90  1
+    IF  '${status}' == 'PASS'
+        Log To Console    App menu is already open
+    ELSE
+        Log To Console    Opening app menu
+        Locate and click  ${APP_MENU_LAUNCHER}  0.95  5
+    END
+
+Close app via GUI on LenovoX1 
     [Documentation]    Close Application via GUI test automation and verify related process stopped
     [Arguments]        ${app-vm}
     ...                ${app}
     ...                ${close_button}=./window-close.png
     ...                ${windows_to_close}=1
     ...                ${iterations}=5
+    ...                ${exact_match}=false
     Connect to netvm
     Connect to VM                             ${app-vm}
-    Check that the application was started    ${app}
+    Check that the application was started    ${app}  exact_match=${exact_match}
     Connect to VM                             ${GUI_VM}
-    Start ydotoold
     Log To Console                            Going to click the close button of the application window
     Locate and click                          ${close_button}  0.8  iterations=${iterations}
     Connect to VM                             ${app-vm}
-    ${status}           Run Keyword And Return Status  Check that the application is not running  ${app}  5
+    ${status}           Run Keyword And Return Status  Check that the application is not running  ${app}  5  ${exact_match}
     IF  "${windows_to_close}" != "1"
         # At first launch chrome opens window for selecting account.
         # If this window is closed the actual browser window still opens.
@@ -133,17 +197,14 @@ Close app via GUI on LenovoX1
             Connect to VM       ${GUI_VM}
             Locate and click    ${close_button}  0.8  5
             Connect to VM       ${app-vm}
-            ${status}           Run Keyword And Return Status  Check that the application is not running  ${app}  5
+            ${status}           Run Keyword And Return Status  Check that the application is not running  ${app}  5  ${exact_match}
         END
     END
     IF  '${status}' != 'True'
         FAIL  Failed to close the application
     END
     # In case closing the app via GUI failed
-    [Teardown]    Run Keywords    Kill process      @{APP_PIDS}
-    ...           AND             Connect to VM     ${GUI_VM}
-    ...           AND             Move cursor to corner
-    ...           AND             Stop ydotoold
+    [Teardown]      Run keywords   Connect to VM   ${app-vm}   AND   Kill process   @{APP_PIDS}
 
 Start app via GUI on Orin AGX
     [Documentation]    Start Application via GUI test automation and verify related process started
@@ -156,7 +217,7 @@ Start app via GUI on Orin AGX
     Start ydotoold
 
     Log To Console    Going to click the app menu icon
-    Locate and click  ${start_menu}  0.95  5
+    Locate and click  ${APP_MENU_LAUNCHER}  0.95  5
     Log To Console    Going to click the application launch icon
     Locate and click  ${launch_icon}  0.95  5
 
@@ -178,18 +239,3 @@ Close app via GUI on Orin AGX
     Locate and click  ${close_button}  0.999  5
 
     Check that the application is not running    ${app}   5
-
-    # In case closing the app via GUI failed
-    [Teardown]    Run Keywords    Kill process  @{APP_PIDS}
-    ...           AND             Move cursor to corner
-    ...           AND             Stop ydotoold
-
-GUI Apps Teardown
-    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Connect to netvm
-        Connect to VM       ${GUI_VM}
-    ELSE
-        Connect
-    END
-    Log journalctl
-    Close All Connections

--- a/Robot-Framework/test-suites/security-tests/ip_spoofing_test.robot
+++ b/Robot-Framework/test-suites/security-tests/ip_spoofing_test.robot
@@ -14,7 +14,7 @@ ${ip_server}
 
 Test IP spoofing
     [Documentation]   Test if it's possible to steal packets via ip spoofing
-    [Tags]            SP-T128   lenovo-x1   dell-7330   ipspoofing
+    [Tags]            SP-T128  ipspoofing  #lenovo-x1   dell-7330  tags commented out so that these are not included when running all tests
     Set Suite Variable                ${server_vm}   ${GALA_VM}
     Set Suite Variable                ${client_vm}   ${COMMS_VM}
     Set Suite Variable                ${stealer_vm}  ${CHROME_VM}

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -40,7 +40,8 @@ Automatic suspension
     Check screen brightness  ${dimmed_brightness}
 
     Wait     10
-    Check notification       The system will suspend soon due to inactivity.    ${last_id}
+
+    IF  $COMPOSITOR != 'cosmic'   Check notification   The system will suspend soon due to inactivity.    ${last_id}
     Check the screen state   on
 
     Wait     50
@@ -145,7 +146,11 @@ Get mako path
 Check the screen state
     [Arguments]         ${state}
     ${output}           Execute Command    ls /nix/store | grep wlopm | grep -v .drv
-    ${output}  ${err}   Execute Command    WAYLAND_DISPLAY=wayland-0 /nix/store/${output}/bin/wlopm    return_stderr=True
+    IF  $COMPOSITOR == 'cosmic' 
+        ${output}  ${err}   Execute Command    WAYLAND_DISPLAY=wayland-1 /nix/store/${output}/bin/wlopm    return_stderr=True
+    ELSE
+        ${output}  ${err}   Execute Command    WAYLAND_DISPLAY=wayland-0 /nix/store/${output}/bin/wlopm    return_stderr=True
+    END
     Log to console      Screen state: ${output}
     Should Contain      ${output}    ${state}
 
@@ -184,6 +189,4 @@ Suspension setup
     Connect to VM        ${GUI_VM}
     Save most common icons and paths to icons
     Create test user
-    Log in via GUI       stop_swayidle=False
-
-    Verify login
+    Log in, unlock and verify   stop_swayidle=False


### PR DESCRIPTION
Add support for running Lenovo-x1 tests on Cosmic. There should be no major changes when Labwc is in use. Compositor is detected automatically. 

### List of changes for Cosmic

* Use `Tab and enter` to navigate app menu & power menu instead of image recognition and clicking. Those menus don't recognize teleported mouse and clicking does not work.
    * I tried using wlrctl tool instead of ydotool, but Cosmic does not yet support zwlr_virtual_pointer_manager_v1.
* New keywords `Log in, unlock and verify` and `Log out and verify` that take care of the whole login/logout operation.
* `Log out via GUI` uses Super+Shift+Escape keyboard shortcut to log out.  It should be more robust than opening power menu and clicking from there. Power menu log out is tested in GUI tests. 
* `Verify logout` renamed to `Check if logged out`. It will now return boolean instead of setting global variable. `systemctl --user is-active ghaf-session.target` can be used to verify if user is logged in or not.
* No need to reset scaling anymore after logging in, with cosmic it is the same with both types of Gen11 laptops.
* Do not disturb needs to be turned on while running GUI tests. The X on notification is the same that the X on app window and the image recognition can't separate those.
* Gui-vm apps need display set to be able to launch, new argument for that added to `Start XDG application`
* For some Cosmic apps there are other processes for nearly same name running. New argument added for `Find pid name` to be able to grep the correct process.
* Removed unnecessary `Start ydotoold` commands. It needs to be restarted every time after Close all Connections or reboot, other than that it stays active.
* New teardown for GUI app tests. All connections are closed between test cases to limit the amount of active connections. It makes running the tests a bit slower but a lot more reliable.

### Test runs

* [Main pipeline run with Labwc](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/ghaf-main-pipeline/128/)
  * Dell did not boot, but separate test run can be found below
* [Lenovo-X1 Labwc - all tests](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1211/) (performance tests excluded)
* [Lenovo-X1 Cosmic - all tests](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1211/) (performance tests excluded)
* [Dell-7330 all tests](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1215/) (performance tests excluded)