### PR TITLE
Add Dell support (turning device on/off.)

### DIFF
--- a/Robot-Framework/test-suites/boot-test/boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/boot_test.robot
@@ -74,7 +74,7 @@ Turn OFF Device
     [Tags]            turnoff
     [Setup]     Run Keyword If  "${DEVICE_IP_ADDRESS}" == "NONE"    Get ethernet IP address
     Log To Console    ${\n}Turning device off...
-    IF  "${DEVICE_TYPE}" == "lenovo-x1"
+    IF  "${DEVICE_TYPE}" == "lenovo-x1" or "${DEVICE_TYPE}" == "dell-7330"
         Press Button      ${SWITCH_BOT}-OFF
     ELSE
         Turn Plug Off
@@ -91,7 +91,7 @@ Turn ON Device
     [Documentation]   Turn on device
     [Tags]            turnon
     Log To Console    ${\n}Turning device on...
-    IF  "${DEVICE_TYPE}" == "lenovo-x1"
+    IF  "${DEVICE_TYPE}" == "lenovo-x1" or "${DEVICE_TYPE}" == "dell-7330"
         Press Button      ${SWITCH_BOT}-ON
     ELSE
         Turn Plug On

--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -75,7 +75,7 @@ Turn OFF Device
     [Tags]            relay-turnoff
     [Setup]     Run Keyword If  "${DEVICE_IP_ADDRESS}" == "NONE"    Get ethernet IP address
     Log To Console    ${\n}Turning device off...
-    IF  "${DEVICE_TYPE}" == "lenovo-x1"
+    IF  "${DEVICE_TYPE}" == "lenovo-x1" or "${DEVICE_TYPE}" == "dell-7330"
         Press Button      ${SWITCH_BOT}-OFF
     ELSE
         Turn Relay Off    ${RELAY_NUMBER}
@@ -92,7 +92,7 @@ Turn ON Device
     [Documentation]   Turn on device
     [Tags]            relay-turnon
     Log To Console    ${\n}Turning device on...
-    IF  "${DEVICE_TYPE}" == "lenovo-x1"
+    IF  "${DEVICE_TYPE}" == "lenovo-x1" or "${DEVICE_TYPE}" == "dell-7330"
         Press Button      ${SWITCH_BOT}-ON
     ELSE
         Turn Relay On     ${RELAY_NUMBER}


### PR DESCRIPTION
Adding Dell support for turning device on/off (boot test suites).

Test result: 

- [831-dell](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/831)

- [832-lenovo](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/832)