### PR TITLE
Add 'test teardown' for failing  'OP-TEE xtest'.

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/optee.robot
+++ b/Robot-Framework/test-suites/bat-tests/optee.robot
@@ -34,6 +34,11 @@ OP-TEE xtest
        Log     ${stdout}
        Should Be Equal As Integers    ${rc}    0
 
+       # If test fails (gets stucked etc), take these steps to enable next test running.
+        [Teardown]  Run Keyword If Test Failed  Run Keywords
+        ...         Kill process and close connections   xtest -x 1008 -x 1033  AND
+        ...         Connect to ghaf host
+
 
 OP-TEE xtest 1008
     [Documentation]   Xtest 1008
@@ -167,3 +172,10 @@ Test Public Key usage
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${stdout}    Signature is valid
     Should Not Contain    ${stdout}    Invalid signature
+
+Kill process and close connections
+    [Documentation]  Checks if certain process running and kills it.
+    [Arguments]    ${process}=${EMPTY}
+    @{pid}=  Find pid by name  ${process}
+    Kill process  @{pid}
+    Close All Connections


### PR DESCRIPTION
For unknown reason 'OP-TEE' test started recently 'stuck' on Orin-NX in PROD and fails the rest of the tests after 10 minute timeout hits.
-> also teardown breaks and everything seems more or less failing

Example: [prod-4057](https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/job/ghaf-hw-test/4057/robot/report/bat/log.html)

In case of test failure, this PR implements a teardown for FAILING 'OP-TEE' test in such way that the next test should be possible to run after test 'freezing'.

Example with 'tampered 20s timeout' for 'OP-TEE xtest'. [dev-839](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/839/robot/report/log.html)

I'm not sure what really happens in real failure case, but this could help to debug the case.