### PR TITLE
Add skip for 2 known failures.

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/netvm.robot
+++ b/Robot-Framework/test-suites/bat-tests/netvm.robot
@@ -89,14 +89,16 @@ NetVM is wiped after restarting
     Connect to netvm
     Log To Console      Check if created file still exists
     Check file doesn't exist    /etc/test.txt
-    [Teardown]          Run Keywords   Close All Connections
+    [Teardown]          Run Keywords  Close All Connections   AND
+    ...                 Run Keyword If  "AGX" in "${DEVICE}"  Run Keyword If Test Failed     Skip    "Known issue: SSRCSP-6423"
 
 Verify NetVM PCI device passthrough
     [Documentation]     Verify that proper PCI devices have been passed through to the NetVM
     [Tags]              bat  SP-T96  nuc  orin-agx  orin-nx
     [Setup]             Connect to netvm
     Verify microvm PCI device passthrough    vmname=${NET_VM}
-    [Teardown]          Run Keywords   Close All Connections
+    [Teardown]          Run Keywords  Close All Connections   AND
+    ...                 Run Keyword If  "AGX" in "${DEVICE}"  Run Keyword If Test Failed     Skip    "Known issue: SSRCSP-6423"
 
 
 *** Keywords ***


### PR DESCRIPTION
On Orin-AGX netvm tests 
- NetVM is wiped after restarting & 
- Verify NetVM PCI device passthrough fails randomly.

Suspected reason is that the device gets into 'Unrecoverable error detected' -state.
If the mentioned tests (for mentioned HW fail), the skip is set with the bug's ticket ID.

Test result (no failures): [851](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/851/)
Test result (with failures): [853](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/853/)