### PR TITLE
Measure dynamic increase and decrease of memory

### DIFF
--- a/Robot-Framework/lib/ParseMemoryLogData.py
+++ b/Robot-Framework/lib/ParseMemoryLogData.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+import pandas as pd
+import logging
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+
+
+class ParseMemoryLogData:
+
+    def __init__(self, perf_data_dir):
+        self.perf_data_dir = perf_data_dir
+
+    def generate_graph(self, plot_dir, id):
+        data = pd.read_csv(self.perf_data_dir + "ballooning_" + id + ".csv")
+        start_time = 0
+        end_time = int(data['time'].values[data.index.max()])
+        step = int((end_time - start_time) / 20)
+        if step < 1:
+            step = 1
+        plt.figure(figsize=(20, 10))
+        plt.set_loglevel('WARNING')
+        plt.ticklabel_format(axis='y', style='plain')
+        plt.yticks(fontsize=14)
+        plt.plot(data['time'], data['total_mem'], marker='o', linestyle='-', color='b', label='total_mem')
+        plt.plot(data['time'], data['used_mem'], marker='o', linestyle='-', color='g', label='used_mem')
+        plt.plot(data['time'], data['available_mem'], marker='o', linestyle='-', color='r', label='avail_mem')
+        plt.title('Memory ballooning', loc='center', fontweight="bold", fontsize=16)
+        plt.ylabel('MegaBytes', fontsize=16)
+        plt.grid(True)
+        plt.xlabel('Time (s)', fontsize=16)
+        plt.legend(loc='upper left', fontsize=20)
+        plt.xticks(range(start_time, end_time, step), fontsize=14)
+        plt.savefig(plot_dir + f'mem_ballooning_{id}.png')
+        return
+
+
+

--- a/Robot-Framework/lib/ParsePowerData.py
+++ b/Robot-Framework/lib/ParsePowerData.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
 import pandas as pd

--- a/Robot-Framework/resources/power_meas_keywords.resource
+++ b/Robot-Framework/resources/power_meas_keywords.resource
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***

--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***

--- a/Robot-Framework/test-suites/performance-tests/ballooning.robot
+++ b/Robot-Framework/test-suites/performance-tests/ballooning.robot
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Settings ***
+Documentation       Testing performance of memory ballooning
+Force Tags          performance     ballooning
+Resource            ../../resources/ssh_keywords.resource
+Library             ../../lib/ParseMemoryLogData.py    ${PERF_DATA_DIR}
+Suite Setup         Connect to netvm
+Test Teardown       Ballooning Test Teardown
+Suite Teardown      Close All Connections
+
+
+*** Variables ***
+${test_status_file}      /tmp/ballooning_test_status
+
+
+*** Test Cases ***
+
+Test ballooning in chrome-vm
+    [Tags]                  ballooning_chrome_vm    lenovo-x1   SP-T255
+    Test ballooning in VM   vm=chrome-vm   expected_mem_at_inflate=11000    max_mem_wr=9000
+
+Test ballooning in business-vm
+    [Tags]                  ballooning_business_vm   lenovo-x1  SP-T256
+    Test ballooning in VM   vm=business-vm   expected_mem_at_inflate=11000    max_mem_wr=9000
+
+
+*** Keywords ***
+
+Test ballooning in VM
+    [Documentation]    Check if dynamic allocation of memory works when consuming a lot of memory.
+    [Arguments]        ${vm}    ${expected_mem_at_inflate}  ${max_mem_wr}
+
+    ${test_dir}=                      Set Variable  /tmp
+    ${inflate_passed}=                Set Variable  False
+    ${deflate_passed}=                Set Variable  False
+    ${timeout1}=                      Set Variable  140
+    ${timeout2}=                      Set Variable  20
+    ${timeout3}=                      Evaluate      int(${timeout1} + ${timeout2} + 20)
+    ${expected_mem_at_inflate}        Evaluate      int(${expected_mem_at_inflate})
+    ${consume_iterations}             Evaluate      int(${max_mem_wr} / 2)
+
+    Connect to VM                     ${vm}
+    Put File                          performance-tests/consume_memory           ${test_dir}
+    Put File                          performance-tests/log_memory               ${test_dir}
+    Execute Command                   chmod 777 ${test_dir}/consume_memory      sudo=True  sudo_password=${PASSWORD}
+    Execute Command                   chmod 777 ${test_dir}/log_memory          sudo=True  sudo_password=${PASSWORD}
+
+    Execute Command                   echo "stage0" > ${test_status_file}
+    Execute Command                   chmod 666 ${test_status_file}   sudo=True  sudo_password=${PASSWORD}
+    ${init_total_mem}=                Execute Command  free --mega | awk -F: 'NR==2 {print $2}' | awk '{print $1}'
+    Log                               Total memory at start ${init_total_mem}   console=True
+    ${expected_deflate_mem}           Evaluate      int(${init_total_mem} + 500)
+
+    Log To Console                    Starting memory logging script
+    Run Keyword And Ignore Error      Execute Command  -b timeout ${timeout3} ${test_dir}/log_memory ${test_dir} ${vm}_${BUILD_ID}  sudo=True  sudo_password=${PASSWORD}  timeout=1
+
+    Log To Console                    Starting memory consuming script
+    Run Keyword And Ignore Error      Execute Command  -b timeout ${timeout1} ${test_dir}/consume_memory ${consume_iterations} ${test_status_file}  sudo=True  sudo_password=${PASSWORD}  timeout=1
+
+    ${start_time}=                    Get Time	epoch
+    FOR    ${i}    IN RANGE    ${timeout1}
+        ${total_int}                  Read memory status
+        IF  $total_int > $expected_mem_at_inflate
+            Log To Console            Expected total memory increase detected
+            ${inflate_passed}=        Set Variable   True
+            Sleep   2
+            Execute Command           echo "stage1" > ${test_status_file}
+            BREAK
+        END
+        ${inflate_process_status}=    Execute Command   cat ${test_status_file}
+        IF  $inflate_process_status == 'stage1'
+            BREAK
+        END
+        ${diff}=                      Evaluate    int(time.time()) - int(${start_time})
+        IF   ${diff} < ${timeout1}
+            Sleep    1
+        ELSE
+            BREAK
+        END
+    END
+
+    Log To Console                    Releasing memory
+    Execute Command                   rm /dev/shm/test/*    sudo=True  sudo_password=${PASSWORD}
+    Execute Command                   rm -r /dev/shm/test   sudo=True  sudo_password=${PASSWORD}
+
+    ${start_time}=                    Get Time	epoch
+    FOR    ${i}    IN RANGE    ${timeout2}
+        ${total_int}                  Read memory status
+        IF  $total_int < $expected_deflate_mem
+            Log To Console            Expected total memory decrease detected
+            ${deflate_passed}=        Set Variable   True
+            Sleep   2
+            BREAK
+        END
+        ${diff}=                      Evaluate    int(time.time()) - int(${start_time})
+        IF   ${diff} < ${timeout2}
+            Sleep    1
+        ELSE
+            BREAK
+        END
+    END
+
+    Execute Command                   echo "stage2" > ${test_status_file}
+    Sleep                             2
+    Get memory logs                   ${test_dir}/ballooning_${vm}_${BUILD_ID}.csv
+    Generate ballooning plot          ${vm}_${BUILD_ID}
+
+    IF  $inflate_passed != 'True'
+        FAIL    Total memory did not inflate to expected level
+    END
+    IF  $deflate_passed != 'True'
+        FAIL    Total memory did not deflate to expected level
+    END
+
+Read memory status
+    ${total_mem}=                 Execute Command  free --mega | awk -F: 'NR==2 {print $2}' | awk '{print $1}'
+    ${available_mem}=             Execute Command  free --mega | awk -F: 'NR==2 {print $2}' | awk '{print $6}'
+    Log                           Total memory: ${total_mem} / Available memory: ${available_mem}  console=True
+    ${total_int}                  Evaluate    int(${total_mem})
+    RETURN                        ${total_int}
+
+Get memory logs
+    [Arguments]             ${path}
+    SSHLibrary.Get File     ${path}  ${PERF_DATA_DIR}
+
+Generate ballooning plot
+    [Arguments]             ${id}
+    Generate graph    ${PLOT_DIR}   ${id}
+    Log   <img src="${REL_PLOT_DIR}mem_ballooning_${id}.png" alt="Power plot" width="1200">    HTML
+
+Ballooning Test Teardown
+    Execute Command     rm -r /dev/shm/test         sudo=True  sudo_password=${PASSWORD}
+    Execute Command     rm ${test_status_file}      sudo=True  sudo_password=${PASSWORD}

--- a/Robot-Framework/test-suites/performance-tests/boot_time_test.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time_test.robot
@@ -15,6 +15,7 @@ Library             ../../lib/PerformanceDataProcessing.py  ${DEVICE}  ${BUILD_I
 Library             DateTime
 Library             Collections
 Suite Setup         Boot Time Test Setup
+Suite Teardown      Close All Connections
 
 
 *** Variables ***

--- a/Robot-Framework/test-suites/performance-tests/consume_memory
+++ b/Robot-Framework/test-suites/performance-tests/consume_memory
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+# Script for consuming memory of a virtual machine fast but not too fast,
+# giving ballooning monitor time to react and increase the available memory.
+# Speed of consuming the memory depends on the size of the copied source file.
+# Setting source file size to greater than 2,5MB can enable too fast memory
+# consumption causing the script to be killed before finishing.
+
+write_iterations=$1
+status_file="$2"
+
+# Create a 2MB source file
+mkdir /dev/shm/test
+for i in $(seq 80000); do
+    echo "fillthememorywiththisdata" >> /dev/shm/test/source
+done
+
+# Fill the memory by copying the source file
+for index in $(seq ${write_iterations}); do
+    cp /dev/shm/test/source /dev/shm/test/file${index}
+    if [[ $(cat ${status_file}) == "stage1" ]]
+    then
+        break
+    fi
+done
+
+sleep 1
+echo stage1 > ${status_file}

--- a/Robot-Framework/test-suites/performance-tests/log_memory
+++ b/Robot-Framework/test-suites/performance-tests/log_memory
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+test_dir="$1"
+id="$2"
+status_file="$3"
+
+echo "time,total_mem,used_mem,available_mem" > ${test_dir}/ballooning_${id}.csv
+start_time=$(date +%s.%3N)
+for i in $(seq 240); do
+    current_time=$(date +%s.%3N)
+    elapsed_time=$(awk "BEGIN {print $current_time - $start_time}")
+    total=$(free --mega | awk -F: 'NR==2 {print $2}' | awk '{print $1}')
+    used=$(free --mega | awk -F: 'NR==2 {print $2}' | awk '{print $2}')
+    avail=$(free --mega | awk -F: 'NR==2 {print $2}' | awk '{print $6}')
+    echo "${elapsed_time},${total},${used},${avail}" >> ${test_dir}/ballooning_${id}.csv
+    if [[ $(cat ${status_file}) == "stage2" ]]
+    then
+        break
+    fi
+    sleep 0.5
+done

--- a/Robot-Framework/test-suites/security-tests/__init__.robot
+++ b/Robot-Framework/test-suites/security-tests/__init__.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***

--- a/Robot-Framework/test-suites/security-tests/ip_spoofing_test.robot
+++ b/Robot-Framework/test-suites/security-tests/ip_spoofing_test.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***

--- a/Robot-Framework/test-suites/security-tests/nc_client
+++ b/Robot-Framework/test-suites/security-tests/nc_client
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
 # This will be automatically written to the file when running the test

--- a/Robot-Framework/test-suites/security-tests/nc_server
+++ b/Robot-Framework/test-suites/security-tests/nc_server
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
 sudo iptables -F

--- a/Robot-Framework/test-suites/security-tests/nc_stealer
+++ b/Robot-Framework/test-suites/security-tests/nc_stealer
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
 # These will be automatically written to the file when running the test


### PR DESCRIPTION
Ballooning monitor should allocate more memory for a VM when its available memory approaches 0. 

This test case is first consuming and then releasing a lot of memory while simultaneously logging total, used and available available memory of the VM. Test keyword is generic, can be used for any VM but suitable parameters have to be checked if applying to other VMs than those now applied.

All VMs don't have memory ballooning enabled. Other VMs can have different maximum limit for inflating total memory.

https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/979/


***
Checked that currently on ghaf side the default limit for memory ballooning has been set to 2 x vm initial memory:
(modules/microvm/appvm.nix)
```
            balloonRatio = mkOption {
              description = ''
                Amount of dynamic RAM for this AppVM as a multiple of ramMb
              '';
              type = types.number;
              default = 2;
            };
```

E.g. for chrome-vm the initial memory is set as
modules/reference/appvms/chromium.nix
`ramMb = 6144;`

If these parameters are tuned (decreased) on ghaf side ballooning test parameters need to be tuned respectively. 