### PR TITLE
Unify tags

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/audio.robot
+++ b/Robot-Framework/test-suites/bat-tests/audio.robot
@@ -24,7 +24,7 @@ ${AUDIO_DIR}    ${OUTPUT_DIR}/outputs/audio-temp
 Record Audio And Verify
     [Documentation]  Record short audio with pulseaudio tool. Verify audio clip is bigger than default empty file (40Kb)
     [Teardown]  Execute Command  rm /tmp/test*.wav  sudo=True  sudo_password=${PASSWORD}
-    [Tags]      SSRCSP-T247   lenovo-x1   dell-7330
+    [Tags]      SP-T247   lenovo-x1   dell-7330
     FOR  ${vm}  IN  ${CHROME_VM}  ${BUSINESS_VM}
         Connect to VM  ${vm}
         # Execute Command timeouts in business-vm, but it is executing the command
@@ -39,7 +39,7 @@ Record Audio And Verify
 
 Check Audio devices
     [Documentation]  List audio sinks and sources in business-vm and chrome-vm and check status is running
-    [Tags]      SSRCSP-T246   lenovo-x1   dell-7330
+    [Tags]      SP-T246   lenovo-x1   dell-7330
     FOR  ${vm}  IN  ${CHROME_VM}  ${BUSINESS_VM}
         Connect to VM  ${vm}
         ${sources}  Execute Command  pactl list sources   sudo=True  sudo_password=${PASSWORD}

--- a/Robot-Framework/test-suites/bat-tests/others.robot
+++ b/Robot-Framework/test-suites/bat-tests/others.robot
@@ -71,7 +71,7 @@ Check serial connection
 
 Check Memory status
     [Documentation]  Check that there is enough memory available
-    [Tags]  bat  lenovo-x1   dell-7330  SSRCSP-5321
+    [Tags]  bat  lenovo-x1   dell-7330  SP-5321
     ${lsblk}  Execute Command  lsblk
     log       ${lsblk}
     ${SSD}    run keyword and return status  should contain   ${lsblk}   sda

--- a/Robot-Framework/test-suites/performance-tests/network.robot
+++ b/Robot-Framework/test-suites/performance-tests/network.robot
@@ -30,7 +30,7 @@ ${PERF_TEST_TIME}  10
 *** Test Cases ***
 Measure TCP Throughput Small Packets
     [Documentation]  Start server on DUT. Send data from agent PC in reverse mode to get tx speed
-    [Tags]   tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SSRCSP-T227
+    [Tags]   tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T227
     &{speed_data}      Create Dictionary
     # DUT sends
     ${output1}         Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -f M -t ${PERF_TEST_TIME} -R    shell=True  timeout=${${PERF_TEST_TIME}+10}
@@ -48,7 +48,7 @@ Measure TCP Throughput Small Packets
 
 Measure TCP Bidir Throughput Small Packets
     [Documentation]  Start server on DUT. Send data from agent PC in bidir mode to get bi-directional speed
-    [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SSRCSP-T228
+    [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T228
     &{speed_data}       Create Dictionary
     ${output}           Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -f M -t ${PERF_TEST_TIME} --bidir  shell=True  timeout=${${PERF_TEST_TIME}+10}
     Log                 ${output.stdout}
@@ -62,7 +62,7 @@ Measure TCP Bidir Throughput Small Packets
 
 Measure TCP Throughput Big Packets
     [Documentation]  Start server on DUT. Send data from agent PC in reverse mode to get tx speed
-    [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SSRCSP-T229
+    [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T229
     &{speed_data}      Create Dictionary
     ${output1}         Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -M 9000 -f M -t ${PERF_TEST_TIME} -R   shell=True  timeout=${${PERF_TEST_TIME}+10}
     ${output2}         Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -M 9000 -f M -t ${PERF_TEST_TIME}   shell=True  timeout=${${PERF_TEST_TIME}+10}
@@ -77,7 +77,7 @@ Measure TCP Throughput Big Packets
 
 Measure TCP Bidir Throughput Big Packets
     [Documentation]  Start server on DUT. Send data from agent PC in bidir mode to get bi-directional speed
-    [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SSRCSP-T230
+    [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T230
     &{speed_data}      Create Dictionary
     ${output}          Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -M 9000 -f M -t ${PERF_TEST_TIME} --bidir  shell=True  timeout=${${PERF_TEST_TIME}+10}
     Log                ${output.stdout}
@@ -91,7 +91,7 @@ Measure TCP Bidir Throughput Big Packets
 
 Measure UDP TX Throughput Small Packets
     [Documentation]  Start server on DUT. Send data from agent PC in reverse mode to get tx speed
-    [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SSRCSP-T231
+    [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T231
     &{speed_data}      Create Dictionary
     ${output1}         Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -u -b 100G -f M -t ${PERF_TEST_TIME} -R    shell=True  timeout=${${PERF_TEST_TIME}+10}
     Log                ${output1.stdout}
@@ -107,7 +107,7 @@ Measure UDP TX Throughput Small Packets
 
 Measure UDP Bidir Throughput Small Packets
     [Documentation]  Start server on DUT. Send data from agent PC in bidir mode to get bi-directional speed
-    [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SSRCSP-T232
+    [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T232
     &{speed_data}      Create Dictionary
     ${output}          Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -u -b 100G -f M -t ${PERF_TEST_TIME} --bidir  shell=True  timeout=${${PERF_TEST_TIME}+10}
     Log                ${output.stdout}
@@ -121,7 +121,7 @@ Measure UDP Bidir Throughput Small Packets
 
 Measure UDP Throughput Big Packets
     [Documentation]  Start server on DUT. Send data from agent PC in reverse mode to get tx speed
-    [Tags]  udp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SSRCSP-T233
+    [Tags]  udp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T233
     &{speed_data}      Create Dictionary
     ${output1}         Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -l 9000 -u -b 100G -f M -t ${PERF_TEST_TIME} -R   shell=True  timeout=${${PERF_TEST_TIME}+10}
     Log                ${output1.stdout}
@@ -137,7 +137,7 @@ Measure UDP Throughput Big Packets
 
 Measure UDP Bidir Throughput Big Packets
     [Documentation]  Start server on DUT. Send data from agent PC in bidir mode to get bi-directional speed
-    [Tags]  udp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SSRCSP-T234
+    [Tags]  udp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T234
     &{speed_data}      Create Dictionary
     ${output}          Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -l 9000 -u -b 10000G -f M -t ${PERF_TEST_TIME} --bidir  shell=True  timeout=${${PERF_TEST_TIME}+10}
     Log                ${output.stdout}


### PR DESCRIPTION
We have agreed to use the short version of keys in tags (eg. SP-T247) . There was a few places where the long version (eg. SSRCSP-T247) was still used.