### PR TITLE
Fix typos

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -41,7 +41,7 @@ Check If Ping Fails
 Run journalctl recording
     ${output}     Execute Command    nohup journalctl -f >> /tmp/jrnl.txt 2>&1 &
 
-Log journctl
+Log journalctl
     ${jrnl_size}  Execute Command    ls -lh /tmp/jrnl.txt
     Log           ${jrnl_size}
     # Copy journal log file to Robot outputs
@@ -57,7 +57,7 @@ Check If Device Is Up
     FOR    ${i}    IN RANGE    ${range}
         ${ping}=    Ping Host   ${DEVICE_IP_ADDRESS}
         IF    ${ping}
-            Log To Console    Ping ${DEVICE_IP_ADDRESS} successfull
+            Log To Console    Ping ${DEVICE_IP_ADDRESS} successful
             BREAK
         END
         Sleep  1

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -180,7 +180,7 @@ Unlock
 
 Save most common icons and paths to icons
     [Documentation]         Save those icons by name which will be used in multiple test cases
-    ...                     Śave paths to icon packs in gui-vm nix store
+    ...                     Save paths to icon packs in gui-vm nix store
     ${icons}                Execute Command   find $(echo $XDG_DATA_DIRS | tr ':' ' ') -type d -name "icons" 2>/dev/null
     Set Global Variable     ${ICON_THEME}        ${icons}/Papirus
     Log To Console          Saving path to app icon-pack

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -14,7 +14,7 @@ Library             ../lib/output_parser.py
 
 Ping Host
     [Arguments]        ${hostname}  ${timeout}=10
-    [Documentation]    Ping the given hostname once and return boolen result
+    [Documentation]    Ping the given hostname once and return boolean result
     ${ping_output}=    Run Process   ping ${hostname} -c 1 -W ${timeout}   shell=True
     ${ping_success}    Run Keyword And Return Status    Should Contain    ${ping_output.stdout}    1 received
     Return From Keyword    ${ping_success}
@@ -73,7 +73,7 @@ Connect
         ${pass_status}  ${login_output}  Run Keyword And Ignore Error  Login with timeout    username=${LOGIN}    password=${PASSWORD}
         ${pass_status}  ${output}        Run Keyword And Ignore Error  Should Contain     ${login_output}   ${target_output}
         IF    $pass_status=='PASS'
-            Log To Console    Connected succesfully to ${target_output}
+            Log To Console    Connected successfully to ${target_output}
             IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}" or "Dell" in "${DEVICE}"
                 Set Global Variable  ${NETVM_SSH}    ${connection}
             END
@@ -226,7 +226,7 @@ Is process started
 
 Find pid by name
     [Arguments]   ${proc_name}
-    Log To Console    Looking for pids of the proccess ${proc_name}
+    Log To Console    Looking for pids of the process ${proc_name}
     ${output}=    Execute Command    sh -c 'ps aux | grep "${proc_name}" | grep -v grep'
     Log           ${output}
     @{pids}=      Find Pid    ${output}  ${proc_name}
@@ -427,7 +427,7 @@ Install sysbench tool
         ${command_output}=    Execute Command    nix-env --query --installed
         Log To Console    ${\n}Installed packages:${\n}${command_output}
         Should Contain    ${command_output}    sysbench    sysbench tool was not installed
-        Log To Console    sysbench tool was succesfully installed
+        Log To Console    sysbench tool was successfully installed
     ELSE
         Log To Console    ${\n}sysbench tool was already installed
     END
@@ -440,7 +440,7 @@ Install iperf tool
         ${command_output}=    Execute Command    nix-env --query --installed
         Log To Console    ${\n}Installed packages:${\n}${command_output}
         Should Contain    ${command_output}    iperf    iperf tool was not installed
-        Log To Console    iperf tool was succesfully installed
+        Log To Console    iperf tool was successfully installed
     ELSE
         Log To Console    ${\n}iperf tool was already installed
     END

--- a/Robot-Framework/test-suites/bat-tests/__init__.robot
+++ b/Robot-Framework/test-suites/bat-tests/__init__.robot
@@ -35,7 +35,7 @@ BAT tests setup
 BAT tests teardown
     [timeout]    5 minutes
     Connect to ghaf host
-    Log journctl
+    Log journalctl
     IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
         Log out
     END

--- a/Robot-Framework/test-suites/bat-tests/audio.robot
+++ b/Robot-Framework/test-suites/bat-tests/audio.robot
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***
-Documentation       Testing audio applicaton
+Documentation       Testing audio application
 Force Tags          audio   bat
 Resource            ../../__framework__.resource
 Resource            ../../resources/serial_keywords.resource

--- a/Robot-Framework/test-suites/bat-tests/netvm.robot
+++ b/Robot-Framework/test-suites/bat-tests/netvm.robot
@@ -27,7 +27,7 @@ Verify NetVM is started
     Check Network Availability      ${NETVM_IP}    expected_result=True    range=5
     [Teardown]              Close All Connections
 
-Wifi passthrought into NetVM (Orin-AGX)
+Wifi passthrough into NetVM (Orin-AGX)
     [Documentation]     Verify that wifi works inside netvm
     [Tags]              bat  SP-T111  orin-agx
     [Setup]             Connect to netvm
@@ -43,7 +43,7 @@ Wifi passthrought into NetVM (Orin-AGX)
     Sleep               1
     [Teardown]          Run Keywords  Remove Wifi configuration  ${TEST_WIFI_SSID}  AND  Close All Connections
 
-Wifi passthrought into NetVM (Lenovo-X1)
+Wifi passthrough into NetVM (Lenovo-X1)
     [Documentation]     Verify that wifi works inside netvm
     [Tags]              bat  SP-T101   lenovo-x1   dell-7330
     [Setup]             Connect to netvm
@@ -59,7 +59,7 @@ Wifi passthrought into NetVM (Lenovo-X1)
     Get wifi IP
     [Teardown]          Run Keywords  Remove Wifi configuration  ${TEST_WIFI_SSID}  AND  Close All Connections
 
-Wifi passthrought into NetVM (NUC)
+Wifi passthrough into NetVM (NUC)
     [Documentation]     Verify that wifi works inside netvm
     [Tags]              bat   SP-T111  nuc
     [Setup]             Connect to netvm

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -53,8 +53,8 @@ Start and close Calculator via GUI on LenovoX1
     Close app via GUI on LenovoX1   ${GUI_VM}  gnome-calculator  ./window-close.png
 
 Start and close Bluetooth Settings via GUI on LenovoX1
-    [Documentation]   Start Bluetooh via GUI test automation and verify related process started
-    ...               Close Blutooth via via GUI test automation and verify related process stopped
+    [Documentation]   Start Bluetooth via GUI test automation and verify related process started
+    ...               Close Bluetooth via via GUI test automation and verify related process stopped
     [Tags]            SP-T204  lenovo-x1
     Get icon   app  blueman.svg   crop=30
     Start app via GUI on LenovoX1   ${GUI_VM}  blueman-manager-wrapped-wrapped
@@ -199,5 +199,5 @@ GUI Apps Teardown
     ELSE
         Connect
     END
-    Log journctl
+    Log journalctl
     Close All Connections


### PR DESCRIPTION
One keyword names was changed `Log journctl `-> `Log journalctl`.

Most were in documentation or logs so fixing them should not break anything.