### PR TITLE
Refactor performance result analysis

### DIFF
--- a/Robot-Framework/lib/performance_thresholds.py
+++ b/Robot-Framework/lib/performance_thresholds.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 thresholds = {
+    # Baselines of a test will be automatically re-tuned if this number of deviations are detected in a row (to the same direction)
+    'wait_until_reset': 5,
     'cpu': {
         'multi': 700,
         'single': 40,
@@ -25,8 +27,8 @@ thresholds = {
         'rd_lenovo-x1': 420
     },
     'boot_time': {
-        'time_to_respond_to_ping': 10,
-        'time_to_desktop_after_reboot': 12
+        'response_to_ping': 10,
+        'time_to_desktop': 12
     },
     'iperf': 10
 }

--- a/Robot-Framework/resources/performance_keywords.resource
+++ b/Robot-Framework/resources/performance_keywords.resource
@@ -8,12 +8,39 @@ Library             Collections
 
 *** Keywords ***
 
-Create fail message
-    [Arguments]       ${stats}
-    ${fail_message}=  Set Variable   Significant deviation detected\nThreshold ${stats}[threshold]\nMeasurement result ${stats}[measurement]\nPrevious measurement ${stats}[prev_meas] (d: ${stats}[d_previous])\nFirst meas of the last stable period ${stats}[baseline1] (d: ${stats}[d_baseline1])\nMean of last stable period ${stats}[mean] (d: ${stats}[d_mean])\n
-    RETURN            ${fail_message}
+Create deviation message
+    [Arguments]       ${statistics}
+    ${word}           Set Variable    improvement
+    IF  ${statistics}[flag] < 0
+        ${word}       Set Variable    deviation
+    END
+    ${message}=       Set Variable   Significant ${word} detected\n${statistics}\n
+    RETURN            ${message}
 
-Create improved message
-    [Arguments]       ${stats}
-    ${improve_message}=  Set Variable   Significant improvement detected!\nThreshold ${stats}[threshold]\nMeasurement result ${stats}[measurement]\nPrevious measurement ${stats}[prev_meas] (d: ${stats}[d_previous])\nFirst meas of the last stable period ${stats}[baseline1] (d: ${stats}[d_baseline1])\nMean of last stable period ${stats}[mean] (d: ${stats}[d_mean])\n
-    RETURN            ${improve_message}
+Determine Test Status
+    [Documentation]         Determine if the test is passed or failed. Mention significant deviation in the test message field.
+    ...                     Argument as a dictionary of statistics dictionaries.
+    [Arguments]             ${statistics_dict}
+    ${keys}                 Get Dictionary Keys          ${statistics_dict}
+    ${msg}=                 Set Variable  ${EMPTY}
+    FOR   ${i}  IN  @{keys}
+        ${statistics}       Get From Dictionary      ${statistics_dict}    ${i}
+        IF  ${statistics}[flag] != 0
+            ${add_msg}      Create deviation message  ${statistics}
+            ${msg}          Set Variable  ${msg}${i}\n${add_msg}\n
+        END
+    END
+    IF  "deviation" in $msg
+        FAIL                ${msg}
+    END
+    IF  "improvement" in $msg
+        Pass Execution  ${msg}
+    END
+
+Output Dictionary First Value
+    [Documentation]         Argument as a dictionary of statistics dictionaries.
+    ...                     Outputs the value of the first dictionary key.
+    [Arguments]             ${statistics_dict}
+    ${keys}                 Get Dictionary Keys          ${statistics_dict}
+    ${output}               Get From Dictionary          ${statistics_dict}    ${keys}[0]
+    RETURN                  ${output}

--- a/Robot-Framework/test-suites/performance-tests/boot_time_test.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time_test.robot
@@ -86,49 +86,21 @@ Get Boot times
     Connect to netvm
     Connect to VM  ${GUI_VM}
 
-    ${time_from_reboot_to_desktop_available}  Run Keyword And Continue On Failure
+    ${time_to_desktop}  Run Keyword And Continue On Failure
     ...  Wait Until Keyword Succeeds  ${SEARCH_TIMEOUT1}s  1s  Check Time To Notification  ${freedesktop_line}   ${start_time_epoc}
 
-    IF  $time_from_reboot_to_desktop_available == 'False'
-        ${time_from_reboot_to_desktop_available}  Run Keyword And Continue On Failure
+    IF  $time_to_desktop == 'False'
+        ${time_to_desktop}  Run Keyword And Continue On Failure
         ...  Wait Until Keyword Succeeds  ${SEARCH_TIMEOUT2}s  1s  Check Time To Notification  ${testuser_line}   ${start_time_epoc}
-        Skip If   $time_from_reboot_to_desktop_available == 'False'  Skipping. The searched journalctl line is sometimes (randomly) not there. Didn't find it this time.
+        Skip If   $time_to_desktop == 'False'  Skipping. The searched journalctl line is sometimes (randomly) not there. Didn't find it this time.
     END
-    Log                     Boot time to login screen measured: ${time_from_reboot_to_desktop_available}   console=True
+    Log                     Boot time to login screen measured: ${time_to_desktop}   console=True
     &{final_results}        Create Dictionary
-    Set To Dictionary       ${final_results}  time_from_reboot_to_desktop_available  ${time_from_reboot_to_desktop_available}
+    Set To Dictionary       ${final_results}  time_to_desktop  ${time_to_desktop}
     Set To Dictionary       ${final_results}  response_to_ping  ${ping_response_seconds}
     &{statistics}           Save Boot time Data   ${TEST NAME}  ${final_results}
     Log  <img src="${DEVICE}_${TEST NAME}.png" alt="${plot_name}" width="1200">    HTML
-
-    &{statistics_desktop}  Get From Dictionary   ${statistics}   statistics_desktop
-    &{statistics_ping}     Get From Dictionary   ${statistics}   statistics_ping
-
-    ${fail_msg}=  Set Variable  ${EMPTY}
-    IF  "${statistics_desktop}[flag]" == "1"
-        ${add_msg}      Create fail message  ${statistics_desktop}
-        ${fail_msg}=    Set Variable  Time to desktop:\n${add_msg}
-    END
-    IF  "${statistics_ping}[flag]" == "1"
-        ${add_msg}      Create fail message  ${statistics_ping}
-        ${fail_msg}=    Set Variable  ${fail_msg}\nTime to ping response:\n${add_msg}
-    END
-    IF  "${statistics_desktop}[flag]" == "1" or "${statistics_ping}[flag]" == "1"
-        FAIL            ${fail_msg}
-    END
-
-    ${pass_msg}=  Set Variable  ${EMPTY}
-    IF  "${statistics_desktop}[flag]" == "-1"
-        ${add_msg}      Create improved message  ${statistics_desktop}
-        ${pass_msg}=    Set Variable  Time to desktop:\n${add_msg}
-    END
-    IF  "${statistics_ping}[flag]" == "-1"
-        ${add_msg}      Create improved message  ${statistics_ping}
-        ${pass_msg}=    Set Variable  ${pass_msg}\nTime to ping response:\n${add_msg}
-    END
-    IF  "${statistics_desktop}[flag]" == "-1" or "${statistics_ping}[flag]" == "-1"
-        Pass Execution    ${pass_msg}
-    END
+    Determine Test Status   ${statistics}
 
 Check Time To Notification
     [Documentation]  Check that correct notification is available in journalctl

--- a/Robot-Framework/test-suites/performance-tests/network.robot
+++ b/Robot-Framework/test-suites/performance-tests/network.robot
@@ -31,123 +31,123 @@ ${PERF_TEST_TIME}  10
 Measure TCP Throughput Small Packets
     [Documentation]  Start server on DUT. Send data from agent PC in reverse mode to get tx speed
     [Tags]   tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T227
-    &{speed_data}      Create Dictionary
+    &{speed_data}           Create Dictionary
     # DUT sends
-    ${output1}         Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -f M -t ${PERF_TEST_TIME} -R    shell=True  timeout=${${PERF_TEST_TIME}+10}
-    Log                ${output1.stdout}
+    ${output1}              Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -f M -t ${PERF_TEST_TIME} -R    shell=True  timeout=${${PERF_TEST_TIME}+10}
+    Log                     ${output1.stdout}
     # DUT receives
-    ${output2}         Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -f M -t ${PERF_TEST_TIME}    shell=True  timeout=${${PERF_TEST_TIME}+10}
-    Log                ${output2.stdout}
+    ${output2}              Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -f M -t ${PERF_TEST_TIME}    shell=True  timeout=${${PERF_TEST_TIME}+10}
+    Log                     ${output2.stdout}
     Check iperf3 got results     ${output1}  ${output2}
-    ${bps_tx}          Get Throughput Values  ${output1.stdout}
-    ${bps_rx}          Get Throughput Values  ${output2.stdout}  direction=receiver
-    Set To Dictionary  ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
-    Log                <img src="${DEVICE}_${TEST NAME}.png" alt="TCP Transfer Small Packets" width="1200">    HTML
-    ${statistics}      Save Speed Data   ${TEST NAME}  ${speed_data}
-    Report Statistics  ${statistics}
+    ${bps_tx}               Get Throughput Values  ${output1.stdout}
+    ${bps_rx}               Get Throughput Values  ${output2.stdout}  direction=receiver
+    Set To Dictionary       ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
+    Log                     <img src="${DEVICE}_${TEST NAME}.png" alt="TCP Transfer Small Packets" width="1200">    HTML
+    ${statistics}           Save Speed Data   ${TEST NAME}  ${speed_data}
+    Determine Test Status   ${statistics}
 
 Measure TCP Bidir Throughput Small Packets
     [Documentation]  Start server on DUT. Send data from agent PC in bidir mode to get bi-directional speed
     [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T228
-    &{speed_data}       Create Dictionary
-    ${output}           Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -f M -t ${PERF_TEST_TIME} --bidir  shell=True  timeout=${${PERF_TEST_TIME}+10}
-    Log                 ${output.stdout}
+    &{speed_data}           Create Dictionary
+    ${output}               Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -f M -t ${PERF_TEST_TIME} --bidir  shell=True  timeout=${${PERF_TEST_TIME}+10}
+    Log                     ${output.stdout}
     Check iperf3 got results     ${output}
-    ${bps_tx}           Get Throughput Values  ${output.stdout}  bidir=True
-    ${bps_rx}           Get Throughput Values  ${output.stdout}  direction=receiver  bidir=True
-    Set To Dictionary   ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
-    Log                 <img src="${DEVICE}_${TEST NAME}.png" alt="TCP Bidir Transfer Small Packets" width="1200">    HTML
-    ${statistics}       Save Speed Data   ${TEST NAME}  ${speed_data}
-    Report Statistics   ${statistics}
+    ${bps_tx}               Get Throughput Values  ${output.stdout}  bidir=True
+    ${bps_rx}               Get Throughput Values  ${output.stdout}  direction=receiver  bidir=True
+    Set To Dictionary       ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
+    Log                     <img src="${DEVICE}_${TEST NAME}.png" alt="TCP Bidir Transfer Small Packets" width="1200">    HTML
+    ${statistics}           Save Speed Data   ${TEST NAME}  ${speed_data}
+    Determine Test Status   ${statistics}
 
 Measure TCP Throughput Big Packets
     [Documentation]  Start server on DUT. Send data from agent PC in reverse mode to get tx speed
     [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T229
-    &{speed_data}      Create Dictionary
-    ${output1}         Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -M 9000 -f M -t ${PERF_TEST_TIME} -R   shell=True  timeout=${${PERF_TEST_TIME}+10}
-    ${output2}         Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -M 9000 -f M -t ${PERF_TEST_TIME}   shell=True  timeout=${${PERF_TEST_TIME}+10}
-    Log                ${output1.stdout}
+    &{speed_data}           Create Dictionary
+    ${output1}              Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -M 9000 -f M -t ${PERF_TEST_TIME} -R   shell=True  timeout=${${PERF_TEST_TIME}+10}
+    ${output2}              Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -M 9000 -f M -t ${PERF_TEST_TIME}   shell=True  timeout=${${PERF_TEST_TIME}+10}
+    Log                     ${output1.stdout}
     Check iperf3 got results     ${output1}  ${output2}
-    ${bps_tx}          Get Throughput Values  ${output1.stdout}
-    ${bps_rx}          Get Throughput Values  ${output2.stdout}  direction=receiver
-    Set To Dictionary  ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
-    Log                <img src="${DEVICE}_${TEST NAME}.png" alt="TCP Transfer Big Packets" width="1200">    HTML
-    ${statistics}      Save Speed Data   ${TEST NAME}  ${speed_data}
-    Report Statistics  ${statistics}
+    ${bps_tx}               Get Throughput Values  ${output1.stdout}
+    ${bps_rx}               Get Throughput Values  ${output2.stdout}  direction=receiver
+    Set To Dictionary       ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
+    Log                     <img src="${DEVICE}_${TEST NAME}.png" alt="TCP Transfer Big Packets" width="1200">    HTML
+    ${statistics}           Save Speed Data   ${TEST NAME}  ${speed_data}
+    Determine Test Status   ${statistics}
 
 Measure TCP Bidir Throughput Big Packets
     [Documentation]  Start server on DUT. Send data from agent PC in bidir mode to get bi-directional speed
     [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T230
-    &{speed_data}      Create Dictionary
-    ${output}          Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -M 9000 -f M -t ${PERF_TEST_TIME} --bidir  shell=True  timeout=${${PERF_TEST_TIME}+10}
-    Log                ${output.stdout}
+    &{speed_data}           Create Dictionary
+    ${output}               Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -M 9000 -f M -t ${PERF_TEST_TIME} --bidir  shell=True  timeout=${${PERF_TEST_TIME}+10}
+    Log                     ${output.stdout}
     Check iperf3 got results     ${output}
-    ${bps_tx}          Get Throughput Values  ${output.stdout}  bidir=True
-    ${bps_rx}          Get Throughput Values  ${output.stdout}  direction=receiver  bidir=True
-    Set To Dictionary  ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
-    Log                <img src="${DEVICE}_${TEST NAME}.png" alt="TCP Bidir Transfer Big Packets" width="1200">    HTML
-    ${statistics}      Save Speed Data   ${TEST NAME}  ${speed_data}
-    Report Statistics  ${statistics}
+    ${bps_tx}               Get Throughput Values  ${output.stdout}  bidir=True
+    ${bps_rx}               Get Throughput Values  ${output.stdout}  direction=receiver  bidir=True
+    Set To Dictionary       ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
+    Log                     <img src="${DEVICE}_${TEST NAME}.png" alt="TCP Bidir Transfer Big Packets" width="1200">    HTML
+    ${statistics}           Save Speed Data   ${TEST NAME}  ${speed_data}
+    Determine Test Status   ${statistics}
 
 Measure UDP TX Throughput Small Packets
     [Documentation]  Start server on DUT. Send data from agent PC in reverse mode to get tx speed
     [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T231
-    &{speed_data}      Create Dictionary
-    ${output1}         Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -u -b 100G -f M -t ${PERF_TEST_TIME} -R    shell=True  timeout=${${PERF_TEST_TIME}+10}
-    Log                ${output1.stdout}
-    ${output2}         Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -u -b 100G -f M -t ${PERF_TEST_TIME}   shell=True  timeout=${${PERF_TEST_TIME}+10}
-    Log                ${output2.stdout}
+    &{speed_data}           Create Dictionary
+    ${output1}              Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -u -b 100G -f M -t ${PERF_TEST_TIME} -R    shell=True  timeout=${${PERF_TEST_TIME}+10}
+    Log                     ${output1.stdout}
+    ${output2}              Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -u -b 100G -f M -t ${PERF_TEST_TIME}   shell=True  timeout=${${PERF_TEST_TIME}+10}
+    Log                     ${output2.stdout}
     Check iperf3 got results     ${output1}  ${output2}
-    ${bps_tx}          Get Throughput Values  ${output1.stdout}
-    ${bps_rx}          Get Throughput Values  ${output2.stdout}  direction=receiver
-    Set To Dictionary  ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
-    Log                <img src="${DEVICE}_${TEST NAME}.png" alt="UDP Transfer Small Packets" width="1200">    HTML
-    ${statistics}      Save Speed Data   ${TEST NAME}  ${speed_data}
-    Report Statistics  ${statistics}
+    ${bps_tx}               Get Throughput Values  ${output1.stdout}
+    ${bps_rx}               Get Throughput Values  ${output2.stdout}  direction=receiver
+    Set To Dictionary       ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
+    Log                     <img src="${DEVICE}_${TEST NAME}.png" alt="UDP Transfer Small Packets" width="1200">    HTML
+    ${statistics}           Save Speed Data   ${TEST NAME}  ${speed_data}
+    Determine Test Status   ${statistics}
 
 Measure UDP Bidir Throughput Small Packets
     [Documentation]  Start server on DUT. Send data from agent PC in bidir mode to get bi-directional speed
     [Tags]  tcp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T232
-    &{speed_data}      Create Dictionary
-    ${output}          Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -u -b 100G -f M -t ${PERF_TEST_TIME} --bidir  shell=True  timeout=${${PERF_TEST_TIME}+10}
-    Log                ${output.stdout}
+    &{speed_data}           Create Dictionary
+    ${output}               Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -u -b 100G -f M -t ${PERF_TEST_TIME} --bidir  shell=True  timeout=${${PERF_TEST_TIME}+10}
+    Log                     ${output.stdout}
     Check iperf3 got results     ${output}
-    ${bps_tx}          Get Throughput Values  ${output.stdout}  bidir=True
-    ${bps_rx}          Get Throughput Values  ${output.stdout}  direction=receiver  bidir=True
-    Set To Dictionary  ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
-    Log                <img src="${DEVICE}_${TEST NAME}.png" alt="UDP" Bidir Transfer Small Packets" width="1200">    HTML
-    ${statistics}      Save Speed Data   ${TEST NAME}  ${speed_data}
-    Report Statistics  ${statistics}
+    ${bps_tx}               Get Throughput Values  ${output.stdout}  bidir=True
+    ${bps_rx}               Get Throughput Values  ${output.stdout}  direction=receiver  bidir=True
+    Set To Dictionary       ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
+    Log                     <img src="${DEVICE}_${TEST NAME}.png" alt="UDP" Bidir Transfer Small Packets" width="1200">    HTML
+    ${statistics}           Save Speed Data   ${TEST NAME}  ${speed_data}
+    Determine Test Status   ${statistics}
 
 Measure UDP Throughput Big Packets
     [Documentation]  Start server on DUT. Send data from agent PC in reverse mode to get tx speed
     [Tags]  udp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T233
-    &{speed_data}      Create Dictionary
-    ${output1}         Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -l 9000 -u -b 100G -f M -t ${PERF_TEST_TIME} -R   shell=True  timeout=${${PERF_TEST_TIME}+10}
-    Log                ${output1.stdout}
-    ${output2}         Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -l 9000 -u -b 100G -f M -t ${PERF_TEST_TIME}   shell=True  timeout=${${PERF_TEST_TIME}+10}
-    Log                ${output2.stdout}
+    &{speed_data}           Create Dictionary
+    ${output1}              Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -l 9000 -u -b 100G -f M -t ${PERF_TEST_TIME} -R   shell=True  timeout=${${PERF_TEST_TIME}+10}
+    Log                     ${output1.stdout}
+    ${output2}              Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -l 9000 -u -b 100G -f M -t ${PERF_TEST_TIME}   shell=True  timeout=${${PERF_TEST_TIME}+10}
+    Log                     ${output2.stdout}
     Check iperf3 got results     ${output1}  ${output2}
-    ${bps_tx}          Get Throughput Values  ${output1.stdout}
-    ${bps_rx}          Get Throughput Values  ${output2.stdout}  direction=receiver
-    Set To Dictionary  ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
-    Log                <img src="${DEVICE}_${TEST NAME}.png" alt="UDP Transfer Big Packets" width="1200">    HTML
-    ${statistics}      Save Speed Data   ${TEST NAME}  ${speed_data}
-    Report Statistics  ${statistics}
+    ${bps_tx}               Get Throughput Values  ${output1.stdout}
+    ${bps_rx}               Get Throughput Values  ${output2.stdout}  direction=receiver
+    Set To Dictionary       ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
+    Log                     <img src="${DEVICE}_${TEST NAME}.png" alt="UDP Transfer Big Packets" width="1200">    HTML
+    ${statistics}           Save Speed Data   ${TEST NAME}  ${speed_data}
+    Determine Test Status   ${statistics}
 
 Measure UDP Bidir Throughput Big Packets
     [Documentation]  Start server on DUT. Send data from agent PC in bidir mode to get bi-directional speed
     [Tags]  udp  nuc  orin-agx  riscv  lenovo-x1   dell-7330  SP-T234
-    &{speed_data}      Create Dictionary
-    ${output}          Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -l 9000 -u -b 10000G -f M -t ${PERF_TEST_TIME} --bidir  shell=True  timeout=${${PERF_TEST_TIME}+10}
-    Log                ${output.stdout}
+    &{speed_data}           Create Dictionary
+    ${output}               Run Process  iperf3 -c ${DEVICE_IP_ADDRESS} -l 9000 -u -b 10000G -f M -t ${PERF_TEST_TIME} --bidir  shell=True  timeout=${${PERF_TEST_TIME}+10}
+    Log                     ${output.stdout}
     Check iperf3 got results     ${output}
-    ${bps_tx}          Get Throughput Values  ${output.stdout}  bidir=True
-    ${bps_rx}          Get Throughput Values  ${output.stdout}  direction=receiver  bidir=True
-    Set To Dictionary  ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
-    Log                <img src="${DEVICE}_${TEST NAME}.png" alt="UDP Bidir Transfer Big Packets" width="1200">    HTML
-    ${statistics}      Save Speed Data   ${TEST NAME}  ${speed_data}
-    Report Statistics  ${statistics}
+    ${bps_tx}               Get Throughput Values  ${output.stdout}  bidir=True
+    ${bps_rx}               Get Throughput Values  ${output.stdout}  direction=receiver  bidir=True
+    Set To Dictionary       ${speed_data}  tx  ${bps_tx}  rx  ${bps_rx}
+    Log                     <img src="${DEVICE}_${TEST NAME}.png" alt="UDP Bidir Transfer Big Packets" width="1200">    HTML
+    ${statistics}           Save Speed Data   ${TEST NAME}  ${speed_data}
+    Determine Test Status   ${statistics}
 
 *** Keywords ***
 Select network connection to use
@@ -239,37 +239,3 @@ Get Throughput Values
         Log      Failed to get the result from ${TEST NAME}   console=yes
     END
     RETURN  ${MBps}[0]
-
-Report statistics
-    [Documentation]  Check deviation of iperf results
-    [Arguments]  ${statistics}
-    ${statistics_tx}  Get From Dictionary  ${statistics}  tx
-    ${statistics_rx}  Get From Dictionary  ${statistics}  rx
-
-    ${fail_msg}=  Set Variable  ${EMPTY}
-    IF  "${statistics_tx}[flag]" == "-1"
-        ${add_msg}     Create fail message  ${statistics_tx}
-        ${fail_msg}=  Set Variable  TX:\n${add_msg}
-    END
-    IF  "${statistics_rx}[flag]" == "-1"
-        ${add_msg}     Create fail message  ${statistics_rx}
-        ${fail_msg}=  Set Variable  ${fail_msg}RX:\n${add_msg}
-    END
-    IF  "${statistics_tx}[flag]" == "-1" or "${statistics_rx}[flag]" == "-1"
-        FAIL    ${fail_msg}
-    END
-
-    ${pass_msg}=  Set Variable  ${EMPTY}
-    IF  "${statistics_tx}[flag]" == "1"
-        ${add_msg}     Create improved message  ${statistics_tx}
-        ${pass_msg}=  Set Variable  TX:\n${add_msg}
-    END
-    IF  "${statistics_rx}[flag]" == "1"
-        ${add_msg}     Create improved message  ${statistics_rx}
-        ${pass_msg}=  Set Variable  ${pass_msg}\nRX:\n${add_msg}
-    END
-    IF  "${statistics_tx}[flag]" == "1" or "${statistics_rx}[flag]" == "1"
-        Pass Execution    ${pass_msg}
-    END
-
-

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -38,122 +38,80 @@ nvpmodel check test
     END
 
 CPU One thread test
-    [Documentation]     Run a CPU benchmark using Sysbench with a duration of 10 seconds and a SINGLE thread.
-    ...                 The benchmark records to csv CPU events per second, events per thread, and latency data.
-    ...                 Create visual plots to represent these metrics comparing to previous tests.
-    [Tags]              cpu  SP-T61-1  nuc  orin-agx  orin-nx  lenovo-x1   dell-7330
-    ${output}           Execute Command    sysbench cpu --time=10 --threads=1 --cpu-max-prime=20000 run
-    Log                 ${output}
-    &{cpu_data}         Parse Cpu Results   ${output}
-    &{statistics}       Save Cpu Data       ${TEST NAME}  ${cpu_data}
-    Log                 <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="CPU Plot" width="1200">    HTML
-    IF  "${statistics}[flag]" == "-1"
-        ${fail_msg}     Create fail message  ${statistics}
-        FAIL            ${fail_msg}
-    END
-    IF  "${statistics}[flag]" == "1"
-        ${pass_msg}     Create improved message  ${statistics}
-        Pass Execution            ${pass_msg}
-    END
+    [Documentation]         Run a CPU benchmark using Sysbench with a duration of 10 seconds and a SINGLE thread.
+    ...                     The benchmark records to csv CPU events per second, events per thread, and latency data.
+    ...                     Create visual plots to represent these metrics comparing to previous tests.
+    [Tags]                  cpu  SP-T61-1  nuc  orin-agx  orin-nx  lenovo-x1   dell-7330
+    ${output}               Execute Command    sysbench cpu --time=10 --threads=1 --cpu-max-prime=20000 run
+    Log                     ${output}
+    &{cpu_data}             Parse Cpu Results   ${output}
+    &{statistics}           Save Cpu Data       ${TEST NAME}  ${cpu_data}
+    Log                     <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="CPU Plot" width="1200">    HTML
+    Determine Test Status   ${statistics}
 
 CPU multimple threads test
-    [Documentation]     Run a CPU benchmark using Sysbench with a duration of 10 seconds and MULTIPLE threads.
-    ...                 The benchmark records to csv CPU events per second, events per thread, and latency data.
-    ...                 Create visual plots to represent these metrics comparing to previous tests.
-    [Tags]              cpu  SP-T61-2  nuc  orin-agx  orin-nx  lenovo-x1   dell-7330
-    ${output}           Execute Command    sysbench cpu --time=10 --threads=${threads_number} --cpu-max-prime=20000 run
-    Log                 ${output}
-    &{cpu_data}         Parse Cpu Results   ${output}
-    &{statistics}       Save Cpu Data       ${TEST NAME}  ${cpu_data}
-    Log                 <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="CPU Plot" width="1200">    HTML
-    IF  "${statistics}[flag]" == "-1"
-        ${fail_msg}     Create fail message  ${statistics}
-        FAIL            ${fail_msg}
-    END
-    IF  "${statistics}[flag]" == "1"
-        ${pass_msg}     Create improved message  ${statistics}
-        Pass Execution            ${pass_msg}
-    END
+    [Documentation]         Run a CPU benchmark using Sysbench with a duration of 10 seconds and MULTIPLE threads.
+    ...                     The benchmark records to csv CPU events per second, events per thread, and latency data.
+    ...                     Create visual plots to represent these metrics comparing to previous tests.
+    [Tags]                  cpu  SP-T61-2  nuc  orin-agx  orin-nx  lenovo-x1   dell-7330
+    ${output}               Execute Command    sysbench cpu --time=10 --threads=${threads_number} --cpu-max-prime=20000 run
+    Log                     ${output}
+    &{cpu_data}             Parse Cpu Results   ${output}
+    &{statistics}           Save Cpu Data       ${TEST NAME}  ${cpu_data}
+    Log                     <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="CPU Plot" width="1200">    HTML
+    Determine Test Status   ${statistics}
 
 Memory Read One thread test
-    [Documentation]     Run a memory benchmark using Sysbench for 60 seconds with a SINGLE thread.
-    ...                 The benchmark records Operations Per Second, Data Transfer Speed, Average Events per Thread,
-    ...                 and Latency for READ operations.
-    ...                 Create visual plots to represent these metrics comparing to previous tests.
-    [Tags]              memory  SP-T61-3  nuc  orin-agx  orin-nx  lenovo-x1   dell-7330
-    ${output}           Execute Command    sysbench memory --time=60 --memory-oper=read --threads=1 run
-    Log                 ${output}
-    &{mem_data}         Parse Memory Results   ${output}
-    &{statistics}       Save Memory Data       ${TEST NAME}  ${mem_data}
-    Log                 <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
-    IF  "${statistics}[flag]" == "-1"
-        ${fail_msg}     Create fail message  ${statistics}
-        FAIL            ${fail_msg}
-    END
-    IF  "${statistics}[flag]" == "1"
-        ${pass_msg}     Create improved message  ${statistics}
-        Pass Execution            ${pass_msg}
-    END
+    [Documentation]         Run a memory benchmark using Sysbench for 60 seconds with a SINGLE thread.
+    ...                     The benchmark records Operations Per Second, Data Transfer Speed, Average Events per Thread,
+    ...                     and Latency for READ operations.
+    ...                     Create visual plots to represent these metrics comparing to previous tests.
+    [Tags]                  memory  SP-T61-3  nuc  orin-agx  orin-nx  lenovo-x1   dell-7330
+    ${output}               Execute Command    sysbench memory --time=60 --memory-oper=read --threads=1 run
+    Log                     ${output}
+    &{mem_data}             Parse Memory Results   ${output}
+    &{statistics}           Save Memory Data       ${TEST NAME}  ${mem_data}
+    Log                     <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
+    Determine Test Status   ${statistics}
 
 Memory Write One thread test
-    [Documentation]     Run a memory benchmark using Sysbench for 60 seconds with a SINGLE thread.
-    ...                 The benchmark records Operations Per Second, Data Transfer Speed, Average Events per Thread,
-    ...                 and Latency for WRITE operations.
-    ...                 Create visual plots to represent these metrics comparing to previous tests.
-    [Tags]              memory  SP-T61-4  nuc  orin-agx  orin-nx  lenovo-x1   dell-7330
-    ${output}           Execute Command    sysbench memory --time=60 --memory-oper=write --threads=1 run
-    Log                 ${output}
-    &{mem_data}         Parse Memory Results   ${output}
-    &{statistics}       Save Memory Data       ${TEST NAME}  ${mem_data}
-    Log                 <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
-    IF  "${statistics}[flag]" == "-1"
-        ${fail_msg}     Create fail message  ${statistics}
-        FAIL            ${fail_msg}
-    END
-    IF  "${statistics}[flag]" == "1"
-        ${pass_msg}     Create improved message  ${statistics}
-        Pass Execution            ${pass_msg}
-    END
+    [Documentation]         Run a memory benchmark using Sysbench for 60 seconds with a SINGLE thread.
+    ...                     The benchmark records Operations Per Second, Data Transfer Speed, Average Events per Thread,
+    ...                     and Latency for WRITE operations.
+    ...                     Create visual plots to represent these metrics comparing to previous tests.
+    [Tags]                  memory  SP-T61-4  nuc  orin-agx  orin-nx  lenovo-x1   dell-7330
+    ${output}               Execute Command    sysbench memory --time=60 --memory-oper=write --threads=1 run
+    Log                     ${output}
+    &{mem_data}             Parse Memory Results   ${output}
+    &{statistics}           Save Memory Data       ${TEST NAME}  ${mem_data}
+    Log                     <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
+    Determine Test Status   ${statistics}
 
 Memory Read multimple threads test
-    [Documentation]     Run a memory benchmark using Sysbench for 60 seconds with MULTIPLE threads.
-    ...                 The benchmark records Operations Per Second, Data Transfer Speed, Average Events per Thread,
-    ...                 and Latency for READ operations.
-    ...                 Create visual plots to represent these metrics comparing to previous tests.
-    [Tags]              memory  SP-T61-5  nuc  orin-agx  orin-nx  lenovo-x1   dell-7330
-    ${output}           Execute Command    sysbench memory --time=60 --memory-oper=read --threads=${threads_number} run
-    Log                 ${output}
-    &{mem_data}         Parse Memory Results   ${output}
-    ${statistics}       Save Memory Data       ${TEST NAME}  ${mem_data}
-    Log                 <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
-    IF  "${statistics}[flag]" == "-1"
-        ${fail_msg}     Create fail message  ${statistics}
-        FAIL            ${fail_msg}
-    END
-    IF  "${statistics}[flag]" == "1"
-        ${pass_msg}     Create improved message  ${statistics}
-        Pass Execution            ${pass_msg}
-    END
+    [Documentation]         Run a memory benchmark using Sysbench for 60 seconds with MULTIPLE threads.
+    ...                     The benchmark records Operations Per Second, Data Transfer Speed, Average Events per Thread,
+    ...                     and Latency for READ operations.
+    ...                     Create visual plots to represent these metrics comparing to previous tests.
+    [Tags]                  memory  SP-T61-5  nuc  orin-agx  orin-nx  lenovo-x1   dell-7330
+    ${output}               Execute Command    sysbench memory --time=60 --memory-oper=read --threads=${threads_number} run
+    Log                     ${output}
+    &{mem_data}             Parse Memory Results   ${output}
+    ${statistics}           Save Memory Data       ${TEST NAME}  ${mem_data}
+    Log                     <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
+    Determine Test Status   ${statistics}
 
 Memory Write multimple threads test
-    [Documentation]     Run a memory benchmark using Sysbench for 60 seconds with MULTIPLE threads.
-    ...                 The benchmark records Operations Per Second, Data Transfer Speed, Average Events per Thread,
-    ...                 and Latency for WRITE operations.
-    ...                 Create visual plots to represent these metrics comparing to previous tests.
-    [Tags]              memory  SP-T61-6  nuc  orin-agx  orin-nx  lenovo-x1   dell-7330
-    ${output}           Execute Command    sysbench memory --time=60 --memory-oper=write --threads=${threads_number} run
-    Log                 ${output}
-    &{mem_data}         Parse Memory Results   ${output}
-    &{statistics}       Save Memory Data       ${TEST NAME}  ${mem_data}
-    Log                 <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
-    IF  "${statistics}[flag]" == "-1"
-        ${fail_msg}     Create fail message  ${statistics}
-        FAIL            ${fail_msg}
-    END
-    IF  "${statistics}[flag]" == "1"
-        ${pass_msg}     Create improved message  ${statistics}
-        Pass Execution            ${pass_msg}
-    END
+    [Documentation]         Run a memory benchmark using Sysbench for 60 seconds with MULTIPLE threads.
+    ...                     The benchmark records Operations Per Second, Data Transfer Speed, Average Events per Thread,
+    ...                     and Latency for WRITE operations.
+    ...                     Create visual plots to represent these metrics comparing to previous tests.
+    [Tags]                  memory  SP-T61-6  nuc  orin-agx  orin-nx  lenovo-x1   dell-7330
+    ${output}               Execute Command    sysbench memory --time=60 --memory-oper=write --threads=${threads_number} run
+    Log                     ${output}
+    &{mem_data}             Parse Memory Results   ${output}
+    &{statistics}           Save Memory Data       ${TEST NAME}  ${mem_data}
+    Log                     <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
+    Determine Test Status   ${statistics}
 
 FileIO test
     [Documentation]     Run a fileio benchmark using Sysbench for 30 seconds with MULTIPLE threads.
@@ -204,41 +162,20 @@ FileIO test
     Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_read.png" alt="Mem Plot" width="1200">    HTML
     Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_write.png" alt="Mem Plot" width="1200">   HTML
 
-    ${fail_msg}=  Set Variable  ${EMPTY}
-    IF  "${statistics_rd}[flag]" == "-1"
-        ${add_msg}     Create fail message  ${statistics_rd}
-        ${fail_msg}=    Set Variable  READ:\n${add_msg}
-    END
-    IF  "${statistics_wr}[flag]" == "-1"
-        ${add_msg}      Create fail message  ${statistics_wr}
-        ${fail_msg}=    Set Variable  ${fail_msg}\nWRITE:\n${add_msg}
-    END
-    IF  "${statistics_rd}[flag]" == "-1" or "${statistics_wr}[flag]" == "-1"
-        FAIL            ${fail_msg}
-    END
-
-    ${pass_msg}=  Set Variable  ${EMPTY}
-    IF  "${statistics_rd}[flag]" == "1"
-        ${add_msg}     Create improved message  ${statistics_rd}
-        ${pass_msg}=    Set Variable  READ:\n${add_msg}
-    END
-    IF  "${statistics_wr}[flag]" == "1"
-        ${add_msg}      Create improved message  ${statistics_wr}
-        ${pass_msg}=    Set Variable  ${pass_msg}\nWRITE:\n${add_msg}
-    END
-    IF  "${statistics_rd}[flag]" == "1" or "${statistics_wr}[flag]" == "1"
-        Pass Execution    ${pass_msg}
-    END
+    ${stats_rd}             Output Dictionary First Value   ${statistics_rd}
+    ${stats_wr}             Output Dictionary First Value   ${statistics_wr}
+    &{stats_dict}    	    Create Dictionary    read=${stats_rd}  write=${stats_wr}
+    Determine Test Status   ${stats_dict}
 
 Sysbench test in NetVM
     [Documentation]      Run CPU and Memory benchmark using Sysbench in NetVM.
     [Tags]               SP-T61-8    nuc  orin-agx  orin-nx
 
     Transfer Sysbench Test Script To NetVM
-    ${output}            Execute Command    /tmp/sysbench_test 1   sudo=True  sudo_password=${PASSWORD}
+    ${output}               Execute Command    /tmp/sysbench_test 1   sudo=True  sudo_password=${PASSWORD}
 
-    &{threads}    	            Create Dictionary	 net-vm=1
-    Save sysbench results       net-vm   _1thread
+    &{threads}    	        Create Dictionary	 net-vm=1
+    Save sysbench results   net-vm   _1thread
 
     &{statistics_cpu}       Read CPU csv and plot  net-vm_${TEST NAME}_cpu_1thread
     &{statistics_mem_rd}    Read Mem csv and plot  net-vm_${TEST NAME}_memory_read_1thread
@@ -248,37 +185,8 @@ Sysbench test in NetVM
     Log    <img src="${REL_PLOT_DIR}${DEVICE}_net-vm_${TEST NAME}_memory_read_1thread.png" alt="Mem Plot" width="1200">    HTML
     Log    <img src="${REL_PLOT_DIR}${DEVICE}_net-vm_${TEST NAME}_memory_write_1thread.png" alt="Mem Plot" width="1200">    HTML
 
-    ${msg}=  Set Variable  ${EMPTY}
-    IF  "${statistics_cpu}[flag]" == "-1"
-        ${add_msg}      Create fail message  ${statistics_cpu}
-        ${msg}=    Set Variable  CPU:\n${add_msg}
-    END
-    IF  "${statistics_cpu}[flag]" == "1"
-        ${add_msg}      Create improved message  ${statistics_cpu}
-        ${msg}=    Set Variable  CPU:\n${add_msg}
-    END
-    IF  "${statistics_mem_rd}[flag]" == "-1"
-        ${add_msg}      Create fail message  ${statistics_mem_rd}
-        ${fail_msg}=    Set Variable  ${msg}\nMEM READ:\n${add_msg}
-    END
-    IF  "${statistics_mem_rd}[flag]" == "1"
-        ${add_msg}      Create improved message  ${statistics_mem_rd}
-        ${msg}=    Set Variable  ${msg}\nMEM READ:\n${add_msg}
-    END
-    IF  "${statistics_mem_wr}[flag]" == "-1"
-        ${add_msg}      Create fail message  ${statistics_mem_wr}
-        ${fail_msg}=    Set Variable  ${msg}\nMEM WRITE:\n${add_msg}
-    END
-    IF  "${statistics_mem_wr}[flag]" == "1"
-        ${add_msg}      Create improved message  ${statistics_mem_wr}
-        ${msg}=    Set Variable  ${msg}\nMEM WRITE:\n${add_msg}
-    END
-    IF  "${statistics_cpu}[flag]" == "-1" or "${statistics_mem_rd}[flag]" == "-1" or "${statistics_mem_wr}[flag]" == "-1"
-        FAIL  ${msg}
-    END
-    IF  "${statistics_cpu}[flag]" == "1" or "${statistics_mem_rd}[flag]" == "1" or "${statistics_mem_wr}[flag]" == "1"
-        Pass Execution    ${msg}
-    END
+    ${stats_dict}           Evaluate      dict(${statistics_cpu}, **${statistics_mem_rd}, **${statistics_mem_wr})
+    Determine Test Status   ${stats_dict}
 
 Sysbench test in VMs on LenovoX1
     [Documentation]      Run CPU and Memory benchmark using Sysbench in Virtual Machines
@@ -392,11 +300,11 @@ Transfer Sysbench Test Script To VM
 
 Save cpu results
     [Arguments]        ${test}=cpu  ${host}=ghaf_host
-
-    ${output}          Execute Command       cat /tmp/sysbench_results/${test}_report
-    Log                ${output}
-    &{data}            Parse Cpu Results     ${output}
-    &{statistics}      Save Cpu Data         ${host}_${TEST NAME}_${test}  ${data}
+    ${output}           Execute Command       cat /tmp/sysbench_results/${test}_report
+    Log                 ${output}
+    &{data}             Parse Cpu Results     ${output}
+    &{statistics_dict}  Save Cpu Data         ${host}_${TEST NAME}_${test}  ${data}
+    ${statistics}       Output Dictionary First Value   ${statistics_dict}
     IF  "${statistics}[flag]" == "-1"
         Append To List     ${FAILED_VM_TESTS}        ${host}_${test}
         Log to console     Deviation detected in test: ${host}_${test}
@@ -409,10 +317,11 @@ Save cpu results
 Save memory results
     [Arguments]        ${test}=memory_read  ${host}=ghaf_host
 
-    ${output}          Execute Command       cat /tmp/sysbench_results/${test}_report
-    Log                ${output}
-    &{data}            Parse Memory Results  ${output}
-    &{statistics}      Save Memory Data      ${host}_${TEST NAME}_${test}  ${data}
+    ${output}           Execute Command       cat /tmp/sysbench_results/${test}_report
+    Log                 ${output}
+    &{data}             Parse Memory Results  ${output}
+    &{statistics_dict}  Save Memory Data      ${host}_${TEST NAME}_${test}  ${data}
+    ${statistics}       Output Dictionary First Value   ${statistics_dict}
     IF  "${statistics}[flag]" == "-1"
         Append To List     ${FAILED_VM_TESTS}        ${host}_${test}
         Log to console     Deviation detected in test: ${host}_${test}
@@ -424,6 +333,7 @@ Save memory results
 
 Save sysbench results
     [Arguments]       ${host}    ${1thread}=${EMPTY}
+    Log                   Saving and analyzing sysbench${1thread} results from ${host}  console=True
     Save cpu results      test=cpu${1thread}           host=${host}
     Save memory results   test=memory_read${1thread}   host=${host}
     Save memory results   test=memory_write${1thread}  host=${host}


### PR DESCRIPTION
Modified the performance result analysis and baseline tuning so that it switches to new baselines only after defined number of deviations in a row (to the same direction: increase/decrease). The threshold for number of successive deviations is defined as `'wait_until_reset'` in `Robot-Framework/lib/performance_thresholds.py`. Any opinions if 5 is good number are welcome.
![Baseline_autotune](https://github.com/user-attachments/assets/57916469-1a83-42db-a468-2af1a45b94fe)


Also did major reformations for `Robot-Framework/lib/PerformanceDataProcessing.py` and `Robot-Framework/test-suites/performance-tests/performance.robot`, and touched few other files too.
- Created `calculate_statistics` function which handles statistics calculations for every test case (except for `Sysbench test in VMs on LenovoX1`). For now every test case have had those things done in their `read_***_csv_and_plot` functions.
- calculate_statistics became somewhat complicated because some test cases monitor multiple measurement results, some only one. Some test cases have separate thresholds for separate monitored results, on the other hand iperf tests have single threshold. Added commenting to make it understandable.
- Created `Determine Test Status` keyword for doing the checks necessary for every performance test case.
- With the help of adding stuff to reused functions and keywords number of code lines drop more than 200.
- Moved riscv (already removed from the test setups) related functions to the end of `Robot-Framework/lib/PerformanceDataProcessing.py`. Should we archive these to some branch or carry them along? 