### PR TITLE
fix: breaking change in python3Packages handling

### DIFF
--- a/drcontrol/drcontrol.nix
+++ b/drcontrol/drcontrol.nix
@@ -1,11 +1,10 @@
 {
-  lib,
-  python3Packages,
-  libftdi,
+  buildPythonApplication,
+  pylibftdi,
 }:
-python3Packages.buildPythonApplication {
+buildPythonApplication {
   pname = "drcontrol";
   version = "0.13";
-  propagatedBuildInputs = [python3Packages.pylibftdi];
+  propagatedBuildInputs = [ pylibftdi ];
   src = ./.;
 }

--- a/drcontrol/flake.nix
+++ b/drcontrol/flake.nix
@@ -16,7 +16,7 @@
     ];
   in
     flake-utils.lib.eachSystem systems (system: {
-      packages.drcontrol = nixpkgs.legacyPackages.${system}.callPackage ./drcontrol.nix {};
+      packages.drcontrol = nixpkgs.legacyPackages.${system}.python3Packages.callPackage ./drcontrol.nix {};
       packages.default = self.packages.${system}.drcontrol;
       formatter = nixpkgs.legacyPackages.${system}.alejandra;
     });

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,7 @@
               pytz
               pandas
               pyscreeze
-              python3Packages.opencv4
+              opencv4
               paramiko
             ]))
         ];


### PR DESCRIPTION
NixOS/nixpkgs#394838

This forces the correct inclusion of the packages that a derivation needs without relying on the namespace inclusion. Ultimately fixes override and improves cross-compilation.