### PR TITLE
Remove Falcon AI test cases

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/bat-tests/gui-vm.robot
@@ -46,12 +46,6 @@ Start File Manager on LenovoX1
     Start XDG application  'File Manager'
     Check that the application was started    pcmanfm
 
-Start Falcon AI on LenovoX1
-    [Documentation]   Start Falcon AI and verify process started
-    [Tags]            falcon_ai  SP-T223-1
-    Start XDG application  'Falcon AI'
-    Check that the application was started    alpaca-wrapped
-
 *** Keywords ***
 
 Gui-vm Apps Test Setup

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -76,16 +76,6 @@ Start and close File Manager via GUI on LenovoX1
     Start app via GUI on LenovoX1   ${GUI_VM}  pcmanfm
     Close app via GUI on LenovoX1   ${GUI_VM}  pcmanfm  ./window-close-neg.png
 
-Start and close Falcon AI via GUI on LenovoX1
-    [Documentation]   Start Falcon AI via GUI test automation and verify related process started
-    ...               Close Falcon AI via GUI test automation and verify related process stopped
-    ...               Clicks the icon and some Alpaca window is opened.
-    [Tags]            SP-T223-2  lenovo-x1
-    Get icon   ghaf-artwork  falcon-icon.svg   crop=30
-    Start app via GUI on LenovoX1   ${GUI_VM}  alpaca-wrapped
-    Close app via GUI on LenovoX1   ${GUI_VM}  alpaca-wrapped  ./window-close.png   iterations=10
-    [Teardown]    Run Keyword If Test Failed     Skip    "Known issue: SSRCSP-6482"
-
 Start and close Firefox via GUI on Orin AGX
     [Documentation]   Passing this test requires that display is connected to the target device
     ...               Start Firefox via GUI test automation and verify related process started


### PR DESCRIPTION
Should be merged before https://github.com/tiiuae/ghaf/pull/1154

Falcon AI app does not open directly from the icon anymore. Instead it starts downloading the Falcon3 model and only opens after the download has finished. Testing this should be added as a separate test case.