### PR TITLE
Add boot time measurement for Orins

### DIFF
--- a/Robot-Framework/lib/ParseMemoryLogData.py
+++ b/Robot-Framework/lib/ParseMemoryLogData.py
@@ -34,6 +34,3 @@ class ParseMemoryLogData:
         plt.xticks(range(start_time, end_time, step), fontsize=14)
         plt.savefig(plot_dir + f'mem_ballooning_{id}.png')
         return
-
-
-

--- a/Robot-Framework/resources/performance_keywords.resource
+++ b/Robot-Framework/resources/performance_keywords.resource
@@ -9,24 +9,32 @@ Library             Collections
 *** Keywords ***
 
 Create deviation message
-    [Arguments]       ${statistics}
+    [Arguments]       ${statistics}     ${inverted}
     ${word}           Set Variable    improvement
-    IF  ${statistics}[flag] < 0
-        ${word}       Set Variable    deviation
+    IF  ${inverted} < 1
+        IF  ${statistics}[flag] < 0
+            ${word}       Set Variable    deviation
+        END
+    ELSE
+        IF  ${statistics}[flag] > 0
+            ${word}       Set Variable    deviation
+        END
     END
     ${message}=       Set Variable   Significant ${word} detected\n${statistics}\n
     RETURN            ${message}
 
 Determine Test Status
-    [Documentation]         Determine if the test is passed or failed. Mention significant deviation in the test message field.
-    ...                     Argument as a dictionary of statistics dictionaries.
-    [Arguments]             ${statistics_dict}
+    [Documentation]         Determine if the test is passed or failed. Add notification of significant deviation or improvement to the test message field.
+    ...                     Give statistics argument as a dictionary of statistics dictionaries.
+    ...                     Inverted argument can be set to 1 for notifying significant decrease of result value as improvement
+    ...                     and significant increase of result value as deviation/FAIL.
+    [Arguments]             ${statistics_dict}  ${inverted}=0
     ${keys}                 Get Dictionary Keys          ${statistics_dict}
     ${msg}=                 Set Variable  ${EMPTY}
     FOR   ${i}  IN  @{keys}
         ${statistics}       Get From Dictionary      ${statistics_dict}    ${i}
         IF  ${statistics}[flag] != 0
-            ${add_msg}      Create deviation message  ${statistics}
+            ${add_msg}      Create deviation message  ${statistics}     ${inverted}
             ${msg}          Set Variable  ${msg}${i}\n${add_msg}\n
         END
     END


### PR DESCRIPTION
For now measure only time to ping response on Orins. Measuring time to desktop would require display connected.

Added 'inverted' argument to Determine Test Status for test cases where decrease in test result value would mean improvement and vice versa.

Test runs

orin-nx:
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1194/

lenovo-x1:
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1198/