### PR TITLE
Fix power measurements

### DIFF
--- a/Robot-Framework/resources/power_meas_keywords.resource
+++ b/Robot-Framework/resources/power_meas_keywords.resource
@@ -27,9 +27,9 @@ Start power measurement
     [Documentation]    Connect to the measurement agent and run script to start collecting measurement results
     [Arguments]        ${id}=power_data   ${timeout}=200
     ${availability}            Check variable availability
+    Set Global Variable   ${SSH_MEASUREMENT}  ${EMPTY}
     IF  ${availability}==False
         Log To Console    Power measurement agent IP address not defined. Ignoring all power measurement related keywords.
-        Set Global Variable   ${SSH_MEASUREMENT}  ${EMPTY}
         RETURN
     END
     ${status}  ${connection}   Run Keyword And Ignore Error   Connect to measurement agent
@@ -45,12 +45,6 @@ Start power measurement
 Connect to measurement agent
     [Documentation]         Set up SSH connection to the measurement agent
     [Arguments]             ${IP}=${RPI_IP_ADDRESS}    ${PORT}=22    ${target_output}=ghaf@raspberrypi
-    # Use existing connection if available
-    ${status}  ${output}    Run Keyword And Ignore Error  Switch Connection       ${SSH_MEASUREMENT}
-    IF  '${status}'=='PASS'
-        Log To Console          Switched connection to measurement agent.
-        RETURN                  ${SSH_MEASUREMENT}
-    END
     Log To Console          Connecting to measurement agent
     ${connection}=          Open Connection    ${IP}    port=${PORT}    prompt=\$    timeout=15
     ${output}=              Login     username=${LOGIN_PI}    password=${PASSWORD_PI}
@@ -104,7 +98,6 @@ Generate power plot
         RETURN
     END
     ${end_timestamp}                  Get current timestamp
-    Connect to measurement agent
     Get power record                  ${id}.csv
     Save power measurement interval   ${id}.csv  '${start_timestamp}'  '${end_timestamp}'
     Generate graph                    power_interval.csv  ${test_name}

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -31,6 +31,9 @@ Automatic suspension
     Check the screen state   on
     Check screen brightness  ${max_brightness}
 
+    Start power measurement       ${BUILD_ID}   timeout=180
+    Set start timestamp
+
     Wait     240
     Check screen brightness  ${dimmed_brightness}
 
@@ -47,7 +50,6 @@ Automatic suspension
 
     Wait     450
     Check if device was suspended
-    Start power measurement       ${BUILD_ID}   timeout=180
 
     Wait     300
     Wake up device


### PR DESCRIPTION
Global variable SSH_MEASUREMENT was not reset to EMPTY after 'GUI Suspend and wake up' test although its
Teardown runs Close All Connections. When power measurement was implemented to another test case it switched to a non-existent ssh connection at 'Connect to measurement agent', SSH_MEASUREMENT index being left over from the previous power measurement.

Prevent this by forcing SSH_MEASUREMENT to EMPTY in the beginning of 'Start power measurement' and not using Switch Connection at all for power measurement agent. Then the power measurement tooling will allow continuous measurements even over multiple test cases if required.

Also moved 'Start power measurement' to the beginning of 'Automatic suspension' test and added
'Set start timestamp' which is necessary for getting start time when extracting power data from the csv file (which may include measurements also from
other tests).