### PR TITLE
Re-establish 'normal' connection after connecting to RPI in PROD

### DIFF
--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -32,6 +32,8 @@ Automatic suspension
     Check screen brightness  ${max_brightness}
 
     Start power measurement       ${BUILD_ID}   timeout=180
+    Connect
+    Connect to VM    ${GUI_VM}  ${USER_LOGIN}  ${USER_PASSWORD}
     Set start timestamp
 
     Wait     240


### PR DESCRIPTION
Reconnecting device in case of power measurement usage in PROD.
The test worked fine in DEV since the RPI connection is not  used there.

Test result(PROD): https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/180/ 
Test result (DEV): https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1224/