### PR TITLE
Give enough time for the power measurement script

### DIFF
--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -31,7 +31,7 @@ Automatic suspension
     Check the screen state   on
     Check screen brightness  ${max_brightness}
 
-    Start power measurement       ${BUILD_ID}   timeout=180
+    Start power measurement       ${BUILD_ID}   timeout=1500
     Connect
     Connect to VM    ${GUI_VM}  ${USER_LOGIN}  ${USER_PASSWORD}
     Set start timestamp


### PR DESCRIPTION
The timeout used to launch the power measurement script on the measurement agent was only 180 sec but according to the test report logs the Automatic suspension test lasts around 20 min 30 sec. Increase the timeout well beyond the duration of the test case, to 1500 sec.

Then we will see power plot over the full automated suspension and wake up, not just 3 min from the beginning when suspension hasn't yet kicked in.