### PR TITLE
Fix Orin-NX connection issues.

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -58,7 +58,7 @@ Login with timeout
 
 Connect
     [Documentation]   Set up the SSH connection to the device
-    [Arguments]       ${IP}=${DEVICE_IP_ADDRESS}    ${PORT}=22    ${target_output}=None   ${iterations}=1
+    [Arguments]       ${IP}=${DEVICE_IP_ADDRESS}    ${PORT}=22    ${target_output}=None   ${iterations}=3
     IF  '${target_output}' != 'None'
         Log To Console    Expecting ${target_output} target output
     ELSE IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}" or "Dell" in "${DEVICE}"

--- a/Robot-Framework/test-suites/performance-tests/boot_time_test.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time_test.robot
@@ -52,6 +52,7 @@ Measure Orin Soft Boot Time
     Soft Reboot Device
     Wait Until Keyword Succeeds  35s  2s  Check If Ping Fails
     Get Time To Ping
+    IF  "NX" in "${DEVICE}"      Sleep    30
 
 Measure Orin Hard Boot Time
     [Documentation]  Measure how long it takes to device to boot up with hard reboot
@@ -63,6 +64,7 @@ Measure Orin Hard Boot Time
     Log to console                Booting the device by switching the power on
     Turn Relay On                 ${RELAY_NUMBER}
     Get Time To Ping              plot_name=Hard Boot Times
+    IF  "NX" in "${DEVICE}"       Sleep    30
 
 
 *** Keywords ***


### PR DESCRIPTION
Orin-NX performance tests had failed to execute, the setup keyword had failed.
When checking this, it was noticed that connection to 'net-vm' was not established but connected tartget was still 'ghaf@ghaf-host'
There was just one  'open connection'  trial set as default for loop, that was increased to be '3' and now the connection seem to take place.

Failed run: [perf-5930](https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/job/ghaf-hw-test/5930/artifact/Robot-Framework/test-suites/performance/log.html)

With fixes [dev-1231](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1231/robot/report/log.html)
