### PR TITLE
Do not fail if Ghaf session is inactive

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -243,7 +243,8 @@ Wait for Ghaf session activation
         END
         Sleep   0.5
     END
-    FAIL    Ghaf session did not activate
+    Log To Console    Failed
+    Log To Console    Ghaf session did not activate
     [Teardown]    Connect to VM   ${GUI_VM}
 
 Get icon


### PR DESCRIPTION
Sometimes on Labwc `Wait for Ghaf session activation `  fails because Ghaf session takes over a minute to start. There is no need to wait for it, `Verify desktop availability` will confirm if login worked or not.

`Wait for Ghaf session activation` was added because with Cosmic taking a screenshot before desktop is available causes issues. On Cosmic Ghaf session does not have the same dependencies so it starts faster and more reliably. Just like with Labwc, `Verify desktop availability` will confirm if login worked or not.

Example of a fail in [prod main pipeline ](https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/job/ghaf-hw-test/5969/).

I did not manage to reproduce the issue in dev setup in a few tries. On my desk it did happen and I was able to verify that this works as intended.

```
Connecting to gui-vm as milla...Connected and logged in.
Waiting for the Ghaf session to start...0.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.16.17.18.19.20.21.22.23.24.25.26.27.28.29.Failed
Ghaf session did not activate
Connecting to gui-vm as ghaf...Connected and logged in.
Trying to reset scaling
Connecting to gui-vm as milla...Connected and logged in.
Auto scaling reset succeeded
Verifying login by trying to detect the launcher icon
Connecting to gui-vm as milla...Connected and logged in.
Taking grim screenshot
Locating image ./launcher.png on screenshot
Coordinates: {'x': 13, 'y': 7}
```
