### PR TITLE
Enable usage of relative threshold values

### DIFF
--- a/Robot-Framework/lib/PerformanceDataProcessing.py
+++ b/Robot-Framework/lib/PerformanceDataProcessing.py
@@ -100,6 +100,11 @@ class PerformanceDataProcessing:
             # Calculate mean, omitting the values which are labeled deviations
             mean = (sum(data_column_cut) - sum_deviations) / (len(data_column_cut) - len(deviations))
 
+            # In case of relative threshold (string type including '%' character) calculate the absolute threshold as percentage from mean value
+            if type(threshold) == str:
+                threshold_float = mean * float(threshold[:-1]) / 100
+                threshold = self.truncate([threshold_float], 3)[0]
+
             # Calculate standard deviation, omitting the values which are labeled deviations
             # Find also the last non-deviated measurement result
             data_sum = 0

--- a/Robot-Framework/lib/performance_thresholds.py
+++ b/Robot-Framework/lib/performance_thresholds.py
@@ -1,8 +1,25 @@
 # SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
+'''
+Threshold values for performance test cases
+
+If a measurement differs more than threshold from any of the baselines:
+- previous measurement
+- mean of last baseline period
+- first measurement of last baseline period
+it is labeled as deviation/improvement.
+
+Threshold can be given as absolute values (int/float)
+or as relative values (string including int/float and '%' at the end).
+In case of relative threshold the absolute threshold will be calculated as a percentage from the mean of the last baseline period.
+
+Parameter 'wait_until_reset':
+Baselines of a test will be automatically re-tuned if this number of
+deviations are detected in a row (to the same direction)
+'''
+
 thresholds = {
-    # Baselines of a test will be automatically re-tuned if this number of deviations are detected in a row (to the same direction)
     'wait_until_reset': 5,
     'cpu': {
         'multi': 700,
@@ -30,5 +47,5 @@ thresholds = {
         'response_to_ping': 10,
         'time_to_desktop': 12
     },
-    'iperf': 10
+    'iperf': "40%"
 }


### PR DESCRIPTION
Allow both absolute (int/float) and relative (string including value and '%' character) thresholds.

Set relative 40% threshold for iperf tests.

Add some clarifying doc lines to performance_thresholds.py.

Test run of x1 performance suite
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1267/