### PR TITLE
Small fixes after Cosmic change

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -149,6 +149,7 @@ Locate image on screen
     ${mouse_x}  Get From Dictionary   ${coordinates}  x
     ${mouse_y}  Get From Dictionary   ${coordinates}  y
     RETURN  ${mouse_x}  ${mouse_y}
+    [Teardown]    Connect to VM   ${GUI_VM}
 
 Locate and click
     [Arguments]   ${image_to_be_searched}  ${confidence}=0.99  ${iterations}=5
@@ -195,6 +196,7 @@ Verify desktop availability
     Locate image on screen  ${APP_MENU_LAUNCHER}  0.95  10
 
 Move cursor
+    Log To Console    Moving cursor to random location
     ${x}    Evaluate  random.randint(50, 500)  modules=random
     ${y}    Evaluate  random.randint(50, 500)  modules=random
     Execute Command   ydotool mousemove --absolute -x ${x} -y ${y}  sudo=True  sudo_password=${PASSWORD}
@@ -343,12 +345,14 @@ Try to reset scaling
             Log To Console   Auto scaling reset failed
         END
     END
+    [Teardown]    Connect to VM   ${GUI_VM}
 
 Stop swayidle
     [Documentation]    Stop swayidle to prevent automatic suspension
     Log To Console    Disabling automated lock and suspend
     Connect to VM     ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
     Execute Command   systemctl --user stop swayidle
+    [Teardown]    Connect to VM   ${GUI_VM}
 
 Set do not disturb state
     [Documentation]   Set do not disturb to true or false (cosmic only)
@@ -358,6 +362,7 @@ Set do not disturb state
         Connect to VM     ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
         Execute Command   echo ${state} > ~/.config/cosmic/com.system76.CosmicNotifications/v1/do_not_disturb
     END
+    [Teardown]    Connect to VM   ${GUI_VM}
 
 Set compositor
     [Documentation]   Set compositor to cosmic if cosmic process is running. By default compositor is set labwc.

--- a/Robot-Framework/test-suites/bat-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/bat-tests/gui-vm.robot
@@ -25,8 +25,12 @@ Start Calculator on LenovoX1
 Start Sticky Notes on LenovoX1
     [Documentation]   Start Sticky Notes and verify process started
     [Tags]            sticky_notes  SP-T201-1
-    Start XDG application  'Sticky Notes'  gui_vm_app=true
-    Check that the application was started    sticky-wrapped
+    IF  $COMPOSITOR == 'cosmic'
+        Skip   App not available in Cosmic
+    ELSE
+        Start XDG application  'Sticky Notes'  gui_vm_app=true
+        Check that the application was started    sticky-wrapped
+    END
 
 Start Ghaf Control Panel on LenovoX1
     [Documentation]   Start Ghaf Control Panel and verify process started

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -62,13 +62,11 @@ Automatic suspension
 *** Keywords ***
 
 Test setup
-
-    ${guivm_connection}  Connect to VM    ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
     Get mako path
     ${last_id}           Get last notification id
     Set Suite Variable   ${last_id}    ${last_id}
     Move cursor
-    Switch Connection    ${guivm_connection}
+    Connect to VM    ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
     Get expected brightness values
 
 Wait
@@ -88,11 +86,13 @@ Get expected brightness values
     Set Test Variable  ${dimmed_brightness}  ${dimmed}
 
 Check screen brightness
-    [Arguments]       ${brightness}    ${timeout}=10
+    [Arguments]       ${brightness}    ${timeout}=60
+    # 10 second timeout should be enough, but for some reason sometimes dimming the screen takes longer.
+    # To prevent unnecessary fails timeout has been increased.
     FOR  ${i}  IN RANGE  ${timeout}
         ${output}     Execute Command    ls /nix/store | grep brightnessctl | grep -v .drv
         ${output}     Execute Command    /nix/store/${output}/bin/brightnessctl get
-        Log to console    Brightness is ${output}
+        Log to console    Check ${i}: Brightness is ${output}
         ${status}     Run Keyword And Return Status  Should be Equal As Numbers   ${output}  ${brightness}
         IF  ${status}
             BREAK
@@ -187,6 +187,7 @@ Suspension setup
 
     Initialize Variables, Connect And Start Logging
     Connect to VM        ${GUI_VM}
+    Set compositor
     Save most common icons and paths to icons
     Create test user
     Log in, unlock and verify   stop_swayidle=False


### PR DESCRIPTION
**List of changes**
1. `[Teardown] Connect to VM ${GUI_VM}` added for all keywords that login to testuser in gui_keywords.resources. For most of them it already is there. Makes it a lot easier to keep track where the connection is. (This cased the suspension test to fail - it was accidentally connected to testuser and not to ghaf after login)
2. Skip `Start Sticky Notes on LenovoX1` on Cosmic, the app is not available. Skip already exists for the GUI version but this was forgotten.
3. Increase `Check screen brightness` timeout 10s -> 60s. Sometimes dimming the screen just takes longer with Labwc. We could not find out why that is with Kajus. Since there is no strict requirement about the suspend times this solution will do for now. With Cosmic it is hopefully more reliable.

**Test runs**
- Lenovo-X1 Labwc [all tests](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1258/) (performance excluded)
- Lenovo-X1 Labwc [suspension test](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1257/) - longer timeout for checking the dimmed brightness was needed in this run
- Lenovo-X1 Cosmic I tested locally, all seemed to be good there.
