### PR TITLE
Set Wi-Fi on for AGX in timesync -test.

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/timesync.robot
+++ b/Robot-Framework/test-suites/bat-tests/timesync.robot
@@ -5,6 +5,7 @@
 Documentation       Testing time synchronization
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../config/variables.robot
+Resource            ../../resources/connection_keywords.resource
 Library             ../../lib/TimeLibrary.py
 Suite Teardown      Close All Connections
 
@@ -19,7 +20,15 @@ ${original_time}    ${EMPTY}
 Time synchronization
     [Documentation]   Stop timesyncd, change time on ghaf host and check that time was changed
     ...               Start timesyncd and check that time was synchronized
+    ...               Note!
+    ...               - ORIN-AGX: 
+    ...                  - Ghaf-host is directly connected to net if wire directly connected to the HW.
+    ...                      -Net-vm is not connected to net.
+    ...                  - Ghaf-host is connected to net via Net-VM if adapter is used!.
+    ...                  - In this test we expect adapter is not used -> Set Wi-Fi ON to enable net-vm to address net.
     [Tags]            bat   SP-T97   nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1   dell-7330
+
+    IF  "AGX" in "${DEVICE}"  Set Wifi passthrough into NetVM
 
     ${host}  Connect
     Check that time is correct  timezone=UTC
@@ -30,6 +39,8 @@ Time synchronization
 
     Start timesync daemon
     Check that time is correct
+
+    IF  "AGX" in "${DEVICE}"  Disable Wifi passthrough from NetVM
 
     [Teardown]        Run Keywords
     ...               Connect  AND  Set RTC from system clock  AND  Start timesync daemon
@@ -59,6 +70,8 @@ Check that time is correct
         END
         Sleep    1
     END
+    Log               ${output}
+    Run Keyword If    not ${is_synchronized}    FAIL   Time was not synchronized!
 
     ${current_time}   Get current time   ${timezone}
     Log To Console    Comparing device time: ${universal_time} and real time ${current_time}
@@ -102,3 +115,20 @@ Set RTC from system clock
     [Documentation]   Set the Hardware Clock from the System Clock
     ${output}         Execute Command    hwclock -w  sudo=True  sudo_password=${PASSWORD}
     ${output}         Execute Command    timedatectl -a
+
+Set Wifi passthrough into NetVM
+    [Documentation]     Verify that wifi works inside netvm.
+    ...              ORIN-AGX: Ghaf-host is directly connected to net if No internet adapter used!
+    ...                        Ghaf-host is connected to net via net-vm if internet adapter is used!
+    ...              Normally: Ghaf-host is connected to net via Net-VM
+    Connect to netvm
+    Configure wifi      ${NETVM_SSH}  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
+    Get wifi IP
+    Check Network Availability    8.8.8.8   expected_result=True
+
+Disable Wifi passthrough from NetVM
+    Check Network Availability    8.8.8.8   expected_result=True
+    Turn OFF WiFi       ${TEST_WIFI_SSID}
+    Check Network Availability    8.8.8.8   expected_result=False
+    Sleep               1
+    Remove Wifi configuration  ${TEST_WIFI_SSID}


### PR DESCRIPTION
Orin-AGX HW in test setups is connected directly to network cable -> ghaf is having connection, netvm is not.
In order to get 'time synchronization from net' to work netvm should also have connection to net. 

In test case the Wifi connection is enabled for netvm to get synch done. Another way would be include network adapters to all test setups, but there might be some mac address etc issues around. 

Added also check that the syncronization info gets verified after the check loop.   

Test result: [dev #1312](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1312/)