### PR TITLE
Give more time for timesync

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/timesync.robot
+++ b/Robot-Framework/test-suites/bat-tests/timesync.robot
@@ -62,7 +62,7 @@ Check that time is correct
     [Arguments]       ${timezone}=UTC
 
     ${is_synchronized} =   Set Variable    False
-    FOR    ${i}    IN RANGE    3
+    FOR    ${i}    IN RANGE    20
         ${output}      Execute Command    timedatectl -a
         ${local_time}  ${universal_time}  ${rtc_time}  ${device_time_zone}  ${is_synchronized}   Parse time info  ${output}
         IF    ${is_synchronized}


### PR DESCRIPTION
Sometimes it requires more than currently set 3 sec. Let's set it to 20 sec.

Example of failing to get the time synchronized in 3 sec after switching timesync service on:
https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/job/ghaf-hw-test/6186/artifact/Robot-Framework/test-suites/bat/log.html#s1-s1-s10-t1