### PR TITLE
Add skip for Labwc Sticky Notes test cases

### DIFF
--- a/Robot-Framework/test-suites/bat-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/bat-tests/gui-vm.robot
@@ -31,6 +31,7 @@ Start Sticky Notes on LenovoX1
         Start XDG application  'Sticky Notes'  gui_vm_app=true
         Check that the application was started    sticky-wrapped
     END
+    [Teardown]  Run Keyword If Test Failed     Skip    "Known issue: SSRCSP-6624"
 
 Start Ghaf Control Panel on LenovoX1
     [Documentation]   Start Ghaf Control Panel and verify process started

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -58,6 +58,7 @@ Start and close Sticky Notes via GUI on LenovoX1
         Start app via GUI on LenovoX1   ${GUI_VM}  sticky-wrapped
         Close app via GUI on LenovoX1   ${GUI_VM}  sticky-wrapped  ./window-close.png
     END
+    [Teardown]  Run Keyword If Test Failed     Skip    "Known issue: SSRCSP-6624"
 
 Start and close Calculator via GUI on LenovoX1
     [Documentation]   Start Calculator via GUI test automation and verify related process started


### PR DESCRIPTION
https://github.com/tiiuae/ghaf/pull/1158 bumped Sticky Notes to a version that does not currently open in Ghaf with Labwc.

Let's skip the Sticky Notes test cases until the fix is ready.

[Testrun](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1402/)