### PR TITLE
Add std threshold and handle zero results

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -62,7 +62,7 @@ Set Variables
     Set Global Variable  ${ZATHURA_VM}         zathura-vm
     Set Global Variable  @{VMS}                ${ADMIN_VM}  ${AUDIO_VM}  ${BUSINESS_VM}  ${CHROME_VM}  ${COMMS_VM}  ${GALA_VM}  ${GUI_VM}  ${ZATHURA_VM}
     Set Global Variable  ${COMPOSITOR}         labwc
-    Set Global Variable  ${PERF_LOW_LIMIT}     0.1
+    Set Global Variable  ${PERF_LOW_LIMIT}     1
 
     Set Log Level       NONE
 

--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -62,6 +62,7 @@ Set Variables
     Set Global Variable  ${ZATHURA_VM}         zathura-vm
     Set Global Variable  @{VMS}                ${ADMIN_VM}  ${AUDIO_VM}  ${BUSINESS_VM}  ${CHROME_VM}  ${COMMS_VM}  ${GALA_VM}  ${GUI_VM}  ${ZATHURA_VM}
     Set Global Variable  ${COMPOSITOR}         labwc
+    Set Global Variable  ${PERF_LOW_LIMIT}     0.1
 
     Set Log Level       NONE
 

--- a/Robot-Framework/lib/performance_thresholds.py
+++ b/Robot-Framework/lib/performance_thresholds.py
@@ -10,9 +10,15 @@ If a measurement differs more than threshold from any of the baselines:
 - first measurement of last baseline period
 it is labeled as deviation/improvement.
 
-Threshold can be given as absolute values (int/float)
-or as relative values (string including int/float and '%' at the end).
+Threshold can be given as
+- absolute value (int/float)
+- relative value (string including int/float and '%' at the end)
+- multiple of population standard deviation (string including int/float and 'std' at the end)
+
 In case of relative threshold the absolute threshold will be calculated as a percentage from the mean of the last baseline period.
+
+Threshold can be defined as multiple of standard deviation when the test case has accumulated some measurement result history.
+Threshold is limited to 1/3 of mean at maximum when using this std method.
 
 Parameter 'wait_until_reset':
 Baselines of a test will be automatically re-tuned if this number of
@@ -39,9 +45,9 @@ thresholds = {
         }
     },
     'fileio': {
-        'wr': 20,
-        'rd': 40,
-        'rd_lenovo-x1': 420
+        'wr': "3std",
+        'rd': "3std",
+        'rd_lenovo-x1': "3std"
     },
     'boot_time': {
         'response_to_ping': 10,

--- a/Robot-Framework/resources/performance_keywords.resource
+++ b/Robot-Framework/resources/performance_keywords.resource
@@ -33,6 +33,9 @@ Determine Test Status
     ${msg}=                 Set Variable  ${EMPTY}
     FOR   ${i}  IN  @{keys}
         ${statistics}       Get From Dictionary      ${statistics_dict}    ${i}
+        IF  ${statistics}[measurement] < ${PERF_LOW_LIMIT}
+            FAIL            Measurement result is zero or too close to zero.\n\n${statistics}
+        END
         IF  ${statistics}[flag] != 0
             ${add_msg}      Create deviation message  ${statistics}     ${inverted}
             ${msg}          Set Variable  ${msg}${i}\n${add_msg}\n

--- a/Robot-Framework/test-suites/performance-tests/boot_time_test.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time_test.robot
@@ -11,7 +11,8 @@ Resource            ../../resources/device_control.resource
 Resource            ../../resources/performance_keywords.resource
 Resource            ../../config/variables.robot
 Variables           ../../lib/performance_thresholds.py
-Library             ../../lib/PerformanceDataProcessing.py  ${DEVICE}  ${BUILD_ID}  ${COMMIT_HASH}  ${JOB}  ${PERF_DATA_DIR}  ${CONFIG_PATH}  ${PLOT_DIR}
+Library             ../../lib/PerformanceDataProcessing.py  ${DEVICE}  ${BUILD_ID}  ${COMMIT_HASH}  ${JOB}
+...                 ${PERF_DATA_DIR}  ${CONFIG_PATH}  ${PLOT_DIR}  ${PERF_LOW_LIMIT}
 Library             DateTime
 Library             Collections
 Suite Setup         Boot Time Test Setup

--- a/Robot-Framework/test-suites/performance-tests/network.robot
+++ b/Robot-Framework/test-suites/performance-tests/network.robot
@@ -12,7 +12,8 @@ Resource            ../../resources/performance_keywords.resource
 Resource            ../../resources/connection_keywords.resource
 Library             ../../lib/output_parser.py
 Library             Process
-Library             ../../lib/PerformanceDataProcessing.py  ${DEVICE}  ${BUILD_ID}  ${COMMIT_HASH}  ${JOB}  ${PERF_DATA_DIR}  ${CONFIG_PATH}   ${PLOT_DIR}
+Library             ../../lib/PerformanceDataProcessing.py  ${DEVICE}  ${BUILD_ID}  ${COMMIT_HASH}  ${JOB}
+...                 ${PERF_DATA_DIR}  ${CONFIG_PATH}  ${PLOT_DIR}  ${PERF_LOW_LIMIT}
 Library             Collections
 Library             JSONLibrary
 Suite Setup         Run keywords  Initialize Variables And Connect

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -11,7 +11,8 @@ Resource            ../../resources/performance_keywords.resource
 Resource            ../../resources/connection_keywords.resource
 Library             ../../lib/output_parser.py
 Library             ../../lib/parse_perfbench.py
-Library             ../../lib/PerformanceDataProcessing.py  ${DEVICE}  ${BUILD_ID}  ${COMMIT_HASH}  ${JOB}  ${PERF_DATA_DIR}  ${CONFIG_PATH}   ${PLOT_DIR}
+Library             ../../lib/PerformanceDataProcessing.py  ${DEVICE}  ${BUILD_ID}  ${COMMIT_HASH}  ${JOB}
+...                 ${PERF_DATA_DIR}  ${CONFIG_PATH}  ${PLOT_DIR}  ${PERF_LOW_LIMIT}
 Library             Collections
 Library             DateTime
 Suite Setup         Initialize Variables And Connect


### PR DESCRIPTION
Allow defining threshold as multiple of standard deviation. For now set only fileio threshold as multiple of standard deviations.

Fail the test always in case of zero result and omit zeros in statistics calculations. 

Label zero results with flag: -100

Test runs:
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1475/
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1493/


![image](https://github.com/user-attachments/assets/e1eee7c8-31c9-41e9-9dab-90786761b84c)

![image](https://github.com/user-attachments/assets/cb186b17-3219-4d86-bdb0-1e85696e06a8)
