### PR TITLE
Refactor Falcon AI test for Cosmic

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -96,3 +96,13 @@ Get mako path
     ${output}            Execute Command     ls /nix/store | grep mako | grep -v .drv
     ${result}            Extract mako path   ${output}
     Set Global Variable  ${MAKO_PATH}    ${result}
+
+Get Falcon LLM Name
+    ${output}            Execute Command     cat '/run/current-system/sw/share/applications/Falcon AI.desktop'
+    ${line}              Get Lines Containing String  ${output}  Exec=
+    ${path}              Set Variable  ${line[5:]}
+    ${llm_name_raw}      Execute Command  cat ${path} | grep LLM_NAME | head -n 1
+    # LLM_NAME="falcon3:10b" -> falcon3:10b
+    ${tmp}               Fetch From Right  ${llm_name_raw}  =
+    ${LLM_NAME}          Set Variable  ${tmp[1:-1]}
+    Set Global Variable  ${LLM_NAME}

--- a/Robot-Framework/test-suites/bat-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/bat-tests/gui-vm.robot
@@ -77,11 +77,18 @@ Start COSMIC Text Editor on LenovoX1
 Start Falcon AI on LenovoX1
     [Documentation]   Start Falcon AI and verify process started
     [Tags]            falcon_ai  SP-T223-1
-    Get mako path
-    Start XDG application  'Falcon AI'
-    Wait Until Download Is 100 Percent
-    Wait Until Download Complete
-    Check that the application was started    alpaca    range=20
+    IF  $COMPOSITOR == 'cosmic'
+        Get Falcon LLM Name
+        Start XDG application  'Falcon AI'
+        Wait Until Falcon Download Complete (Cosmic)
+        Check that the application was started    alpaca    range=20
+    ELSE
+        Get mako path
+        Start XDG application  'Falcon AI'
+        Wait Until Download Is 100 Percent
+        Wait Until Download Complete
+        Check that the application was started    alpaca    range=20
+    END
 
 *** Keywords ***
 
@@ -147,3 +154,11 @@ Check If Download Completed
 
 Wait Until Download Complete
     Wait Until Keyword Succeeds    30s    3s     Check If Download Completed
+
+Wait Until Falcon Download Complete (Cosmic)
+    FOR  ${i}  IN RANGE   100
+        ${output}          Execute Command  ollama list
+        ${download_done}   Run Keyword And Return Status  Should contain   ${output}  ${LLM_NAME}
+        IF  ${download_done}  BREAK
+        Sleep  3
+    END


### PR DESCRIPTION
Notifications of Cosmic cannot be read (those are in some memory we cannot access.

Input from developer:
```
"You can run >>ollama list  and wait until "falcon3:10b" appears in the list
Alternatively you can run >>ollama pull falcon3:10b , but only after launching Falcon AI app, meaning the download should already be in progress. This will start showing the current progress in the terminal

If you want to fetch the LLM name programatically instead of hardcoding it, you may be able to:
>>ls /run/current-system/sw/share/applications  and find "Falcon AI.desktop"

cat it and check the Exec= value, it should point to a script in the nix store
cat the script and grep for the first appearance of "LLM_NAME", e.g. cat /nix/store/abcdefg123456/bin/falcon-launcher | grep LLM_NAME | head -n 1

That's probably the betst approach in case we change the default LLM in the future, you won't need to track down any developer to have it work in test automation"
```
The test was implemented as described above.

Test Results:
-X1 Cosmic: [Dev 1519](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1519/)
-X1 ':Normal': [Dev 1520](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1520/)