### PR TITLE
Show marginals in preformance plots

### DIFF
--- a/Robot-Framework/lib/performance_thresholds.py
+++ b/Robot-Framework/lib/performance_thresholds.py
@@ -39,15 +39,15 @@ thresholds = {
         },
         'single': {
             'wr': 350,
-            'rd': 250,
+            'rd': 350,
             'wr_nuc': 800,
             'rd_nuc': 800
         }
     },
     'fileio': {
-        'wr': "3std",
-        'rd': "3std",
-        'rd_lenovo-x1': "3std"
+        'wr': "5std",
+        'rd': "5std",
+        'rd_lenovo-x1': "5std"
     },
     'boot_time': {
         'response_to_ping': 10,

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -118,7 +118,6 @@ Connect to netvm
 Connect to VM
     [Documentation]      Connect to any VM or ghaf-host over internal virtual network
     [Arguments]          ${vm_name}    ${user}=${LOGIN}   ${pw}=${PASSWORD}   ${timeout}=60
-    ${connected}   Check ssh connection status   net-vm
     Log To Console       Connecting to ${vm_name} as ${user}...   no_newline=true
     Check if ssh is ready on vm        ${vm_name}
     ${failed_connection}  Set variable  True


### PR DESCRIPTION
Plot limits for 'PASS range' as dashed lines along with the monitored measurement results to make automated development of the actual marginals visible and to make it more obvious why the test has failed or passed. (See the plots of test runs.)

'upper_marginal' is calculated as
min(baseline_start, mean) + threshold

'lower_marginal' is calculated as
max(baseline_start, mean) - threshold

Don't use anymore previous measurement as a baseline for threshold comparisons because it is not relevant,
contrary to the first measurement of the baseline and mean. Comparing measurement to previous measurement could also easily lead to deviation judgement although measurement results would just vary within the threshold around the mean value.

Tune few performance thresholds.

Remove unnecessary line from ssh_keywords.resource

**Test runs:**

lenovo-x1 (fileio thresholds at 4std, after this switched to 5std)
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1552/

orin-agx
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1556/