### PR TITLE
Improvement to Check if ssh is ready

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -421,31 +421,11 @@ Save log
     Log  ${output}
     Close All Connections
 
-Check if ssh is ready on netvm
-    [Arguments]    ${timeout}=60
-    ${start_time}  Get Time	epoch
-    FOR    ${i}    IN RANGE    ${timeout}
-        ${output}  ${rc}    Execute Command    nc -zvw3 ${NETVM_IP} 22    return_rc=True
-        ${status}    Run Keyword And Return Status
-        ...          Should Be Equal As Integers    ${rc}    0
-        IF  ${status}
-            BREAK
-        END
-        ${diff}=    Evaluate    int(time.time()) - int(${start_time})
-        IF   ${diff} < ${timeout}
-            Sleep    1
-            CONTINUE
-        ELSE
-            BREAK
-        END
-    END
-    IF   ${status} == False    FAIL    Port 22 of NetVM is not ready after ${timeout}
-
 Check if ssh is ready on vm
     [Arguments]    ${vm}  ${timeout}=30
     ${start_time}  Get Time	epoch
     FOR    ${i}    IN RANGE    ${timeout}
-        ${output}  ${rc}    Execute Command    nc -zvw3 ${vm} 22    return_rc=True
+        ${output}  ${rc}    Execute Command    nc -zvw3 ${vm} 22    return_rc=True   timeout=10
         ${status}    Run Keyword And Return Status
         ...          Should Be Equal As Integers    ${rc}    0
         IF  ${status}
@@ -584,7 +564,7 @@ Restart VM
     Stop VM  ${vm_name}
     Sleep  ${delay}
     Start VM  ${vm_name}
-    Check if ssh is ready on netvm
+    Check if ssh is ready on vm   ${vm_name}
 
 Check External SSD Size
     [Documentation]  Check the size of ssd used in setup

--- a/Robot-Framework/test-suites/bat-tests/netvm.robot
+++ b/Robot-Framework/test-suites/bat-tests/netvm.robot
@@ -110,7 +110,7 @@ Restart NetVM
     Stop NetVM
     Sleep  ${delay}
     Start NetVM
-    Check if ssh is ready on netvm
+    Check if ssh is ready on vm   ${NET_VM}
 
 Stop NetVM
     [Documentation]     Ensure that NetVM is started, stop it and check the status.


### PR DESCRIPTION
`Check if ssh is ready on vm` keyword gets sometimes stuck on `nc -zvw3 ${vm} 22` and the execution times out instead of trying again like it should. This has often happened to me locally and I have been using the timeout for already some time. Now for the first time I am also seeing it [in the lab](https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/job/ghaf-hw-test/6853/robot/report/pre-merge/log.html#s1-s1-s1-t1
).

I also removed the `Check if ssh is ready on netvm` keyword and changed the two occasions that used it to use `Check if ssh is ready on vm`. These keywords were basically identical, I see no reason to have separate one for netvm (there might be some historical reason on why it ended up like this :)).

