### PR TITLE
Try additional nc timeout

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -431,9 +431,13 @@ Save log
 
 Check if ssh is ready on vm
     [Arguments]    ${vm}  ${timeout}=30
-    ${start_time}  Get Time	epoch
+    ${already_connected}            Check ssh connection status     ${vm}
+    IF  ${already_connected}
+        RETURN
+    END
+    ${start_time}                   Get Time	epoch
     FOR    ${i}    IN RANGE    ${timeout}
-        ${output}  ${rc}    Execute Command    nc -zvw3 ${vm} 22    return_rc=True   timeout=10
+        ${output}  ${rc}    Execute Command    timeout 6 nc -zvw3 ${vm} 22    return_rc=True   timeout=10
         ${status}    Run Keyword And Return Status
         ...          Should Be Equal As Integers    ${rc}    0
         IF  ${status}


### PR DESCRIPTION
Due to repeating problems in nc getting stuck let's try this additional timeout. 

Tested manually that if the command hit's this timeout the return code is 124.

nc command has got stuck especially when robot is already connected to gui-vm as ghaf and then before connecting to gui-vm as testuser robot tries to check if the ssh is ready on gui-vm. Well, of course it is ready if robot has already an established ssh connection to gui-vm. Added check if robot is already connected to the vm and if so ignore the keyword.

gui tests run on X1
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1622/