### PR TITLE
Refactor systemctl check

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -160,7 +160,7 @@ Connect to VM
     RETURN  ${connection}
 
 Verify Systemctl status
-    [Arguments]    ${range}=60  ${close_conn}=true
+    [Arguments]    ${range}=60
     [Documentation]    Check is systemctl running with given loop ${range}
     ${start_time}=    Get Time	epoch
     FOR    ${i}    IN RANGE    ${range}
@@ -171,7 +171,7 @@ Verify Systemctl status
         ${data_failed_units}   Execute Command    systemctl list-units --state=failed
         Log  ${data_failed_units}
         ${failed_units}  Get failed units  ${data_failed_units}
-        Log To Console   Failed units: ${failed_units}
+        Log   ${failed_units}
 
         IF  '${status}' not in ['running', 'starting']
             Log To Console   Systemctl status is ${status}
@@ -179,14 +179,12 @@ Verify Systemctl status
         ELSE IF    '${status}' == 'running'
             ${diff}=    Evaluate    int(time.time()) - int(${start_time})
             Log To Console   Systemctl status is ${status} after ${diff} sec
-            Log To Console   --> Possible failed processes?: ${failed_units}
             RETURN
         END
         Sleep    1
     END
     ${diff}=    Evaluate    int(time.time()) - int(${start_time})
     FAIL    Systemctl is not running after ${diff} sec! Status is ${status}. Failed processes?: ${failed_units}
-    [Teardown]       Run Keyword If  $close_conn == 'true'  Close All Connections
 
 Start application
     [Arguments]      ${app_name}

--- a/Robot-Framework/test-suites/functional-tests/vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/vm.robot
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***
-Documentation       Internet tests
-Force Tags          internet
+Documentation       Tests that are run in every VM
+Force Tags          vms
 Resource            ../../__framework__.resource
 Resource            ../../resources/ssh_keywords.resource
 Suite Setup         Connect to netvm
@@ -11,7 +11,7 @@ Suite Teardown      Close All Connections
 
 *** Test Cases ***
 
-Check all VMs have internet connection
+Check internet connection in every VM
     [Documentation]    Pings google from every vm.
     [Tags]             bat  regression  SP-T257  lenovo-x1  dell-7330
     ${failed_vms}=    Create List
@@ -26,3 +26,22 @@ Check all VMs have internet connection
         END
     END
     IF  ${failed_vms} != []    FAIL    VMs with no internet connection: ${failed_vms}
+
+
+Check systemctl status in every VM
+    [Documentation]    Check that systemctl status is running in every vm.
+    [Tags]             bat  regression  SP-T98-2  lenovo-x1  dell-7330
+    ${failed_vms}=    Create List
+    FOR  ${vm}  IN  @{VMS}
+        Connect to VM    ${vm}
+        ${status}=       Run Keyword And Ignore Error   Verify Systemctl status
+        Log              ${status}
+        IF    $status[0]=='FAIL'
+            Log To Console    ${vm}: ${status}[1]
+            Append To List    ${failed_vms}    ${vm}
+        END
+        Sleep    1
+    END
+    # This test case has been added to collect information about failed services.
+    # If no service is routinely failing it can be changed from Skip to Fail.
+    IF  ${failed_vms} != []    Skip    VMs with non-running systemctl status: ${failed_vms}

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -1,27 +1,26 @@
 # Add/Remove info when changes in SKIPs/Tags Added/Removed
 
 ## Active SKIPS
-| DATE SET   | TEST CASE                                     | TICKET / Additional Data.
-|------------|-----------------------------------------------| ---
-| 27.05.2025 | TimeSynch (AGX)                               | SSRCSP-6423. Unrecoverable error detected. #PR333
-| 08.05.2025 | GUI Reboot (Cosmic)                           | The X1 in the lab gets stuck when a reboot is attempted. Needs further investigation.
-| 08.05.2025 | GUI Suspend and wake up  (Cosmic)             | The X1 in the lab gets stuck when a suspension is attempted. Needs further investigation.
-|            | Measure Hard Boot Time                        | The searched journalctl line is sometimes (randomly) not there. Didn't find it this time
-|            | Measure Soft Boot Time -Dell                  | The searched journalctl line is sometimes (randomly) not there. Didn't find it this time.
-|            | OP-TEE xtest 1033 -orin-agx & orin-nx         | Known issue encountered, skipping the test
-|            | OP-TEE xtest 1008 -orin-agx & orin-nx         | Known issue encountered, skipping the test
-|            | Verify NetVM PCI device passthrough -Orin AGX | SSRCSP-5662, SSRCSP-6423
-|            | NetVM is wiped after restarting  -Orin AGX    | SSRCSP-5662,SSRCSP-6423
-|            | Check systemctl status -Generic               | SSRCSP-4632
-|            | Check systemctl status -Orin AGX              | SSRCSP-6303
-|            | Check systemctl status -DELL                  | SSRCSP-6450
-|            | Check Camera Application -DELL                | SSRCSP-6450
-|            | Start Gala on LenovoX1 -DELL & LenovoX1       | SSRCSP-6434
 
-
+| DATE SET   | TEST CASE                                     | TICKET / Additional Data.                                                                       |
+| ---------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| 02.06.2025 | Check systemctl status in every VM            | Added for information collecting. Skip should be removed in the future.                         |
+| 27.05.2025 | TimeSynch (AGX)                               | SSRCSP-6423. Unrecoverable error detected. #PR333                                               |
+| 08.05.2025 | GUI Reboot (Cosmic)                           | The X1 in the lab gets stuck when a reboot is attempted. Needs further investigation.           |
+| 08.05.2025 | GUI Suspend and wake up (Cosmic)              | The X1 in the lab gets stuck when a suspension is attempted. Needs further investigation.       |
+|            | Measure Hard Boot Time                        | The searched journalctl line is sometimes (randomly) not there. Didn't find it this time        |
+|            | Measure Soft Boot Time -Dell                  | The searched journalctl line is sometimes (randomly) not there. Didn't find it this time.       |
+|            | OP-TEE xtest 1033 -orin-agx & orin-nx         | Known issue encountered, skipping the test                                                      |
+|            | OP-TEE xtest 1008 -orin-agx & orin-nx         | Known issue encountered, skipping the test                                                      |
+|            | Verify NetVM PCI device passthrough -Orin AGX | SSRCSP-5662, SSRCSP-6423                                                                        |
+|            | NetVM is wiped after restarting -Orin AGX     | SSRCSP-5662,SSRCSP-6423                                                                         |
+|            | Check systemctl status                        | [Full list of skips in the test case](/Robot-Framework/test-suites/functional-tests/host.robot) |
+|            | Check Camera Application -DELL                | SSRCSP-6450                                                                                     |
+|            | Start Gala on LenovoX1 -DELL & LenovoX1       | SSRCSP-6434                                                                                     |
 
 ## TAGs removed
-| DATE SET | TEST CASE    | TICKET / Additional Data.
-|------------------------------------------------|-----------------------------------------------| ---
-| 03/2025   | Performance Network.robot - ‘orin-nx’ | SSRCSP-6372 - Works locally but problems when Jenkins used, fails all..
-| 22.1.2025 | Start Firefox - ‘nuc, orin-agx        | Firefox is temporarily disabled from SW
+
+| DATE SET  | TEST CASE                             | TICKET / Additional Data.                                               |
+| --------- | ------------------------------------- | ----------------------------------------------------------------------- |
+| 03/2025   | Performance Network.robot - ‘orin-nx’ | SSRCSP-6372 - Works locally but problems when Jenkins used, fails all.. |
+| 22.1.2025 | Start Firefox - ‘nuc, orin-agx        | Firefox is temporarily disabled from SW                                 |


### PR DESCRIPTION
Changes
1. Only skip the ghaf-host systemctl check (`Check systemctl status`) if the failed process is one of the known ones. **Note:** This _will_ cause failures that have previously been skipped. We should create bugs for the regularly failing services and then add  a skip with that ticket number.
2. New test case systemctl status on every VM for Lenovo-X1 and Dell-7330 (
`Check systemctl status in every VM`). **Note**: This test will always be skipped if it fails. Multiple services are currently failing across multiple VMs. Let’s collect some data for now and create bugs later.
3. Removed the unused `${close_conn}` argument from `Verify Systemctl status`

[Lenovo-X1 test run](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1661/)
[Dell-7330 test run](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1664/)
[Orin-AGX test run](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1659/)