### PR TITLE
Improve systemctl known issues check

### DIFF
--- a/Robot-Framework/lib/output_parser.py
+++ b/Robot-Framework/lib/output_parser.py
@@ -287,3 +287,13 @@ def parse_notifications(text):
     matches = re.findall(pattern, text)
     notifications_dict = {int(num): msg for num, msg in matches}
     return notifications_dict
+
+
+def parse_services_to_list(output):
+    match = re.search(r"\[([^\]]+)\]", output)
+    if not match:
+        print("No list of failed services found in the output.")
+        return []
+    raw_items = match.group(1).split(',')
+    parsed_list = [item.strip(" '\"") for item in raw_items if item.strip()]
+    return parsed_list

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -186,6 +186,38 @@ Verify Systemctl status
     ${diff}=    Evaluate    int(time.time()) - int(${start_time})
     FAIL    Systemctl is not running after ${diff} sec! Status is ${status}. Failed processes?: ${failed_units}
 
+Check systemctl status for known issues
+    [Arguments]    ${known_issues_list}   ${failing_services}
+    [Documentation]    Check if failing services contain issues that are not listed as known
+    ${old_issues}=    Create List
+    ${new_issues}=    Create List
+    FOR    ${failing_service}    IN    @{failing_services}
+        ${known}=    Set Variable    False
+        FOR    ${entry}    IN    @{known_issues_list}
+            ${parts}=    Split String    ${entry}    |
+            ${list_device}=    Set Variable    ${parts[0]}
+            ${service}=   Set Variable    ${parts[1]}
+            ${issue}=     Set Variable    ${parts[2]}
+
+            ${device_match}=     Run Keyword And Return Status    Should Contain    ${DEVICE}    ${list_device}
+            ${service_match}=    Run Keyword And Return Status    Should Contain    ${failing_service}    ${service}
+
+            IF   '${device_match}' == 'True' and ('${service}' == 'ANY' or '${service_match}') == 'True'
+                ${known}=     Set Variable    True
+            END
+        END
+        IF    ${known}   
+            Append To List    ${old_issues}    ${failing_service}
+        ELSE
+            Append To List    ${new_issues}    ${failing_service}
+        END
+    END
+    IF   ${new_issues} != []
+        Fail    Unexpected failed services: ${new_issues}, known failed services: ${old_issues}
+    ELSE
+        Skip    Known failed services: ${old_issues}
+    END
+
 Start application
     [Arguments]      ${app_name}
     Log To Console   ${\n}Starting ${app_name}

--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -31,31 +31,22 @@ Check QSPI version
     Check QSPI Version is up to date
 
 Check systemctl status
-    [Documentation]    Verify systemctl status is running
+    [Documentation]    Verify systemctl status is running on host
     [Tags]             bat  regression   pre-merge  SP-T98  nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1   dell-7330
     ${status}   ${output}   Run Keyword And Ignore Error    Verify Systemctl status
+    Log   ${output}
 
     IF    '${status}' == 'FAIL'
+        ${failing_services}    Parse Services To List    ${output}
+
         ${known_issues}=    Create List
         ...    NUC|ANY|SSRCSP-4632
         ...    NX|nvfancontrol.service|SSRCSP-6303
         ...    AGX|nvfancontrol.service|SSRCSP-6303
         ...    AGX|systemd-rfkill.service|SSRCSP-6303
-        ...    Dell|autovt@ttyUSB0.service|SSRCSP-6450
+        ...    Dell|autovt@ttyUSB0.service|SSRCSP-6667
 
-        FOR    ${entry}    IN    @{known_issues}
-            ${parts}=    Split String    ${entry}    |
-            ${list_device}=    Set Variable    ${parts[0]}
-            ${service}=   Set Variable    ${parts[1]}
-            ${issue}=     Set Variable    ${parts[2]}
-
-            ${device_match}=    Run Keyword And Return Status    Should Contain    ${DEVICE}    ${list_device}
-            Run Keyword If    '${device_match}' == 'True' and '${service}' == 'ANY'    Skip    Known issue: ${issue}
-
-            ${service_match}=    Run Keyword And Return Status    Should Contain    ${output}    ${service}
-            Run Keyword If    '${device_match}' == 'True' and '${service_match}' == 'True'    Skip    Known issue: ${issue}
-        END
-        FAIL    ${output}
+        Check systemctl status for known issues    ${known_issues}   ${failing_services}
     END
 
 Check all VMs are running


### PR DESCRIPTION
Separated `Check systemctl status for known issues` to its own keyword, this keyword can also be used for the VM checks and gui-vm user check. Improved error handling in situations where multiple services have failed. Fixed one issue number.

[Orin-AGX](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1697/) testrun => skipped
[Lenovo-X1](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1698/) testrun => passed
[Dell-7330](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1700/) testrun => passed
[Dell-7330](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1705/) testrun => failed (used different [branch](https://github.com/milva-unikie/ci-test-automation/tree/update-systemctl-skips-test) to make it fail)