### PR TITLE
Fix Verify Systemctl status

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -160,10 +160,10 @@ Connect to VM
     RETURN  ${connection}
 
 Verify Systemctl status
-    [Arguments]    ${range}=60    ${user}=false
+    [Arguments]    ${range}=60    ${user}=False
     [Documentation]    Check is systemctl running with given loop ${range}
 
-    IF    $user
+    IF    ${user}
         ${cmd}               Set Variable   systemctl status --user
         ${failed_units_cmd}  Set Variable   systemctl list-units --state=failed --user
     ELSE

--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -93,7 +93,7 @@ Start Falcon AI on LenovoX1
 Check user systemctl status
     [Documentation]   Verify systemctl status --user is running
     [Tags]            bat   SP-T260
-    Verify Systemctl status    range=3   user=true
+    Verify Systemctl status    range=3   user=True
 
 *** Keywords ***
 

--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -41,8 +41,7 @@ Check systemctl status
 
         ${known_issues}=    Create List
         ...    NUC|ANY|SSRCSP-4632
-        ...    NX|nvfancontrol.service|SSRCSP-6303
-        ...    AGX|nvfancontrol.service|SSRCSP-6303
+        ...    Orin|nvfancontrol.service|SSRCSP-6303
         ...    AGX|systemd-rfkill.service|SSRCSP-6303
         ...    Dell|autovt@ttyUSB0.service|SSRCSP-6667
 


### PR DESCRIPTION
`IF   $user` was always evaluated as true.

[Orin-AGX](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1723/)
[Lenovo-X1](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1724)