### PR TITLE
Logout before GUI tests on Cosmic

### DIFF
--- a/Robot-Framework/test-suites/gui-tests/__init__.robot
+++ b/Robot-Framework/test-suites/gui-tests/__init__.robot
@@ -23,6 +23,13 @@ GUI Tests Setup
         Save most common icons and paths to icons
         Create test user
         Log in, unlock and verify   enable_dnd=True
+
+        # There's a bug that occasionally causes the app menu to freeze on Cosmic, especially on the first login. 
+        # Logging out once before running tests helps reduce the chances of it happening. (SSRCSP-6684)
+        IF  $COMPOSITOR == 'cosmic'
+            Log out and verify   disable_dnd=True
+            Log in, unlock and verify   enable_dnd=True
+        END
     END
 
 GUI Tests Teardown


### PR DESCRIPTION
There's a bug that occasionally causes the app menu to freeze on Cosmic, especially on the first login. Logging out once before running GUI tests helps reduce the chances of it happening.

[Run without this PR](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1725/)
[Run with this PR](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1728/)