### PR TITLE
Skip for known issue (Measure UDP Bidir Throughput Big Packets(AGX))

### DIFF
--- a/Robot-Framework/test-suites/performance-tests/network.robot
+++ b/Robot-Framework/test-suites/performance-tests/network.robot
@@ -150,6 +150,8 @@ Measure UDP Bidir Throughput Big Packets
     ${statistics}           Save Speed Data   ${TEST NAME}  ${speed_data}
     Determine Test Status   ${statistics}
 
+    [Teardown]   Run Keyword If   "AGX" in "${DEVICE}"   Run Keyword If Test Failed   Skip   "Known issue: SSRCSP-6623 (AGX)"
+
 *** Keywords ***
 Select network connection to use
     [Documentation]  Select the connection to be used. This cannot be done in Keyword 'Initialize Variables And Connect'

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -3,7 +3,8 @@
 ## Active SKIPS
 
 | DATE SET   | TEST CASE                                     | TICKET / Additional Data.                                                                       |
-| ---------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| ---------- | --------------------------------------------- |-------------------------------------------------------------------------------------------------|
+| 05.06.2025 | Measure UDP Bidir Throughput Big Packets(AGX) | SSRCSP-6623                                                                                     |
 | 02.06.2025 | Check systemctl status in every VM            | Added for information collecting. Skip should be removed in the future.                         |
 | 27.05.2025 | TimeSynch (AGX)                               | SSRCSP-6423. Unrecoverable error detected. #PR333                                               |
 | 08.05.2025 | GUI Reboot (Cosmic)                           | The X1 in the lab gets stuck when a reboot is attempted. Needs further investigation.           |


### PR DESCRIPTION
AGX is failing the Measure UDP Bidir Throughput Big Packets -test (gets Flat RX in iperf test)
There is an open ticket SSRCSP-6623: Bidirectional iperf test results drop on Orin with 6.6 kernel
Set 'Skip' for test failure until the problem gets solved.

Test Result: [Dev#1746](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1746/)