### PR TITLE
Update suspension test

### DIFF
--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -41,19 +41,23 @@ Automatic suspension
 
     Wait     10
 
-    IF  $COMPOSITOR != 'cosmic'   Check notification   The system will suspend soon due to inactivity.    ${last_id}
-    Check the screen state   on
+    IF  $COMPOSITOR == 'cosmic'
+        Check the screen state   on
+        Wait    50
+        ${locked}         Check if locked
+        Should Be True    ${locked}
+        Wait     630
+    ELSE
+        Check notification   The system will suspend soon due to inactivity.    ${last_id}
+        Check the screen state   on
+        Wait     50
+        # to do: check that screen is locked
+        Wait     150
+        Check the screen state   off
+        Wait     450
+    END
 
-    Wait     50
-
-    # to do: check that screen is locked
-
-    Wait     150
-    Check the screen state   off
-
-    Wait     450
     Check if device was suspended
-
     Wait     300
     Wake up device
     Generate power plot           ${BUILD_ID}   ${TEST NAME}


### PR DESCRIPTION
https://github.com/tiiuae/ghaf/pull/1217 slightly changed the suspension timings on Cosmic. Adapted to that and added a screen lock check for Cosmic.

Testruns:
- [Lenovo-X1 Cosmic](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1821/)
- [Lenovo-X1 Labwc](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/1824/) - This no longer needs to be supported, but the test run had already started before Cosmic was merged.