### PR TITLE
Reduce power icon identification's confidence -level

### DIFF
--- a/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
@@ -136,7 +136,7 @@ Select power menu option
     [Arguments]        ${icon_name}=""   ${index}=0   ${confirmation}=false
     IF  $COMPOSITOR == 'cosmic'
         Log To Console     Opening power menu
-        Locate and click   ./power.png  0.95  5
+        Locate and click   ./power.png  0.55  5
         Tab and enter      tabs=${index}
         # Some options have a separate confirmation window that needs to be clicked.
         IF  '${confirmation}' == 'true'   Tab and enter   tabs=2


### PR DESCRIPTION
Icon seems to be slightly different, identified when confidence lowered 0.95 -> 0.55.

Test: [Dev#2042](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2042)