### PR TITLE
Gui refactoring

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -4,10 +4,38 @@
 *** Settings ***
 Resource            ../config/variables.robot
 Resource            ../resources/gui_keywords.resource
+Resource            ../resources/connection_keywords.resource
 Library             ../lib/output_parser.py
 
 
 *** Keywords ***
+
+Prepare Test Environment
+    [Arguments]    ${stop_swayidle}=True   ${enable_dnd}=False
+    Initialize Variables And Connect
+    Log versions
+    Run journalctl recording
+
+    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
+        Switch to gui-vm as ghaf
+        Set compositor
+        Save most common icons and paths to icons
+        Create test user
+        Start ydotoold
+        Log in, unlock and verify   ${stop_swayidle}   ${enable_dnd}
+    END
+
+Clean Up Test Environment
+    [Arguments]   ${disable_dnd}=False
+    Connect to ghaf host
+    Log journalctl
+    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
+        Switch to gui-vm as ghaf
+        Start ydotoold
+        Log out and verify   ${disable_dnd}
+        Stop ydotoold
+    END
+    Close All Connections
 
 Check that the application was started
     [Arguments]          ${app_name}  ${range}=2  ${exact_match}=false

--- a/Robot-Framework/resources/connection_keywords.resource
+++ b/Robot-Framework/resources/connection_keywords.resource
@@ -44,8 +44,3 @@ Initialize Variables And Connect
     END
     ${CONNECTION}        Connect to ghaf host
     Set Global Variable  ${CONNECTION}
-
-Initialize Variables, Connect And Start Logging
-    Initialize Variables And Connect
-    Log versions
-    Run journalctl recording

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***
+Documentation       Keywords for gui tests. Note: These keywords assume the connection is to the gui-vm,
+...                 as the ghaf user. If a keyword requires the user account, it will handle switching to
+...                 the user and switch back to the ghaf user during teardown.
 Resource            ../config/variables.robot
 Library             ../lib/GuiTesting.py    ${OUTPUT_DIR}/outputs/gui-temp/
 Library             Collections
@@ -20,7 +23,6 @@ ${GUI_TEMP_DIR}        ${OUTPUT_DIR}/outputs/gui-temp/
 Log in, unlock and verify
     [Documentation]   Open desktop by logging in or unlocking. Verify that desktop is available.
     [Arguments]       ${stop_swayidle}=True  ${enable_dnd}=False
-    Start ydotoold
     ${logout_status}    Check if logged out   1
     IF  ${logout_status}
         Log in via GUI
@@ -30,7 +32,21 @@ Log in, unlock and verify
         IF  ${lock}   Unlock
     END
     Try to reset scaling
-    Verify desktop availability
+
+    # This is a workaround for a cosmic-greeter bug https://github.com/pop-os/cosmic-greeter/issues/135.
+    # If the laptop did not login on the first attempt tries to press Tab to select the password field
+    # and then attempts to log in again.
+    ${status}   ${output}   Run Keyword And Ignore Error   Verify desktop availability
+    IF   $status == 'FAIL'
+        Log To Console    There was maybe a bug with the cosmic-greeter, let's try logging in again
+        Log To Console    Pressing Tab to activate the password field
+        Execute Command    ydotool key 15:1 15:0  sudo=True  sudo_password=${PASSWORD}
+        Log in via GUI
+        Wait for Ghaf session activation
+        Try to reset scaling
+        Verify desktop availability
+    END
+
     IF  ${stop_swayidle}   Stop swayidle
     IF  ${enable_dnd}      Set do not disturb state   true
 
@@ -44,14 +60,12 @@ Log out and verify
         RETURN
     END
     IF  ${disable_dnd}   Set do not disturb state   false
-    Start ydotoold
     ${logout_status}      Check if logged out    1
     IF  not ${logout_status}
         Log out via GUI
         ${logout_status}  Check if logged out
         IF  not ${logout_status}    FAIL  Failed to log out.
     END
-    Stop ydotoold
 
 Log in via GUI
     [Documentation]   Log in by typing username (labwc) and password (labwc&cosmic).
@@ -89,7 +103,6 @@ Log out via GUI
 
 Type string and press enter
     [Arguments]    ${string}=${EMPTY}  ${confidential}=False
-    Connect to VM   ${GUI_VM}
     IF  ${confidential} 
         Log To Console    Typing password
     ELSE
@@ -103,14 +116,13 @@ Type string and press enter
 
 Tab and enter
     [Arguments]    ${tabs}=1
-    Connect to VM       ${GUI_VM}
     Log To Console      Pressing Tab ${tabs} times and then Enter to select
     ${command}=    Set Variable    ${EMPTY}
     FOR  ${i}  IN RANGE  ${tabs}
         ${command}=    Set Variable  ${command} 15:1 15:0
     END
-    ${command}=    Set Variable  ${command} 28:1 28:0
     Execute Command    ydotool key ${command}  sudo=True  sudo_password=${PASSWORD}
+    Execute Command    ydotool key 28:1 28:0  sudo=True  sudo_password=${PASSWORD}
 
 Locate image on screen
     [Documentation]    Take a screenshot. Locate given image on the screenshot.
@@ -118,7 +130,7 @@ Locate image on screen
     [Arguments]        ${image_to_be_searched}  ${confidence}=0.999   ${iterations}=5
     ${coordinates}=        Set Variable  ${EMPTY}
     ${pass_status}=        Set Variable  FAIL
-    Connect to VM           ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
+    Switch to gui-vm as user
     IF  $COMPOSITOR == 'cosmic'
         Execute Command        mkdir test-images
         FOR   ${i}   IN RANGE  ${iterations}
@@ -152,22 +164,16 @@ Locate image on screen
     ${mouse_x}  Get From Dictionary   ${coordinates}  x
     ${mouse_y}  Get From Dictionary   ${coordinates}  y
     RETURN  ${mouse_x}  ${mouse_y}
-    [Teardown]    Connect to VM   ${GUI_VM}
+    [Teardown]    Switch to gui-vm as ghaf
 
 Locate and click
     [Arguments]   ${image_to_be_searched}  ${confidence}=0.99  ${iterations}=5
     ${mouse_x}  ${mouse_y}  Locate image on screen  ${image_to_be_searched}  ${confidence}  ${iterations}
-    Connect to VM     ${GUI_VM}
     Execute Command   ydotool mousemove --absolute -x ${mouse_x} -y ${mouse_y}  sudo=True  sudo_password=${PASSWORD}
     Execute Command   ydotool click 0xC0  sudo=True  sudo_password=${PASSWORD}
 
 Start ydotoold
     [Documentation]    Start ydotool daemon if it is not already running.
-    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Connect to VM    ${GUI_VM}
-    ELSE
-        Connect
-    END
     ${ydotoold_state}=    Execute Command    sh -c 'ps aux | grep ydotoold | grep -v grep'
     IF  $ydotoold_state == '${EMPTY}'
         Log To Console    Starting ydotool daemon
@@ -180,11 +186,6 @@ Start ydotoold
 
 Stop ydotoold
     [Documentation]    Kill ydotool daemon
-    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Connect to VM    ${GUI_VM}
-    ELSE
-        Connect
-    END
     Log To Console    Stopping ydotool daemon
     Execute Command   pkill ydotoold  sudo=True  sudo_password=${PASSWORD}
 
@@ -207,7 +208,7 @@ Move cursor
 Check if logged out
     [Documentation]    Check if system is in logged out state
     [Arguments]        ${iterations}=10
-    Connect to VM      ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
+    Switch to gui-vm as user
     FOR   ${i}   IN RANGE  ${iterations}
         IF  $COMPOSITOR == 'cosmic'
             ${activity}=       Execute Command    systemctl --user is-active ghaf-session.target  return_stdout=True
@@ -231,11 +232,11 @@ Check if logged out
         Sleep  1
     END
     RETURN    ${False}
-    [Teardown]    Connect to VM   ${GUI_VM}
+    [Teardown]    Switch to gui-vm as ghaf
 
 Wait for Ghaf session activation
     [Documentation]    Wait until ghaf session is in active state
-    Connect to VM      ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
+    Switch to gui-vm as user
     Log To Console     Waiting for the Ghaf session to start...  no_newline=true 
     FOR   ${i}   IN RANGE  30
         ${activity}=       Execute Command    systemctl --user is-active ghaf-session.target  return_stdout=True
@@ -250,7 +251,7 @@ Wait for Ghaf session activation
     END
     Log To Console    Failed
     Log To Console    Ghaf session did not activate
-    [Teardown]    Connect to VM   ${GUI_VM}
+    [Teardown]    Switch to gui-vm as ghaf
 
 Get icon
     [Documentation]    Copy icon svg file to test agent machine. Crop and convert the svg file to png.
@@ -279,7 +280,7 @@ Check if locked
             Get icon           ${ICON_THEME}/symbolic/actions  view-reveal-symbolic.svg  background=black
             Type string and press enter
         END
-        ${status}   ${output}      Run Keyword And Ignore Error   Locate image on screen  icon.png  0.95  3
+        ${status}   ${output}      Run Keyword And Ignore Error   Locate image on screen  icon.png  0.95  1
         IF  '${status}' == 'PASS'
             Log To Console    Screen is locked
             RETURN    ${True}
@@ -290,7 +291,6 @@ Check if locked
 
 Unlock
     [Documentation]    Unlock the screen be typing password
-    Connect to VM      ${GUI_VM}
     IF  $COMPOSITOR == 'cosmic'
         # Make sure that password field is active by clicking it
         Locate and click   ${LOCK_ICON}   0.95  5
@@ -332,7 +332,7 @@ Try to reset scaling
     [Documentation]    Disable hidpi-auto-scaling (labwc only)
     IF  $COMPOSITOR != 'cosmic'
         Log To Console     Trying to reset scaling
-        Connect to VM      ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
+        Switch to gui-vm as user
         FOR   ${i}   IN RANGE  5
             Execute Command   systemctl --user start hidpi-auto-scaling-reset
             ${output}         Execute Command   journalctl --since "5 seconds ago" --user -u hidpi-auto-scaling-reset
@@ -348,24 +348,24 @@ Try to reset scaling
             Log To Console   Auto scaling reset failed
         END
     END
-    [Teardown]    Connect to VM   ${GUI_VM}
+    [Teardown]    Switch to gui-vm as ghaf
 
 Stop swayidle
     [Documentation]    Stop swayidle to prevent automatic suspension
     Log To Console    Disabling automated lock and suspend
-    Connect to VM     ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
+    Switch to gui-vm as user
     Execute Command   systemctl --user stop swayidle
-    [Teardown]    Connect to VM   ${GUI_VM}
+    [Teardown]    Switch to gui-vm as ghaf
 
 Set do not disturb state
     [Documentation]   Set do not disturb to true or false (cosmic only)
     [Arguments]       ${state}
     IF  $COMPOSITOR == 'cosmic'
         Log To Console    Setting Do Not Disturb to ${state}
-        Connect to VM     ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
+        Switch to gui-vm as user
         Execute Command   echo ${state} > ~/.config/cosmic/com.system76.CosmicNotifications/v1/do_not_disturb
     END
-    [Teardown]    Connect to VM   ${GUI_VM}
+    [Teardown]    Switch to gui-vm as ghaf
 
 Set compositor
     [Documentation]   Set compositor to cosmic if cosmic process is running. By default compositor is set labwc.

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -10,6 +10,10 @@ Library             Process
 Library             String
 Library             ../lib/output_parser.py
 
+*** Variables ***
+
+${GUI_VM_GHAF_SSH}     ${EMPTY}
+${GUI_VM_USER_SSH}     ${EMPTY}
 
 *** Keywords ***
 
@@ -489,9 +493,9 @@ Check if ssh is ready on vm
     END
     ${start_time}                   Get Time	epoch
     FOR    ${i}    IN RANGE    ${timeout}
-        ${output}  ${rc}    Execute Command    timeout 6 nc -zvw3 ${vm} 22    return_rc=True   timeout=10
+        ${status}  ${output}    Run Keyword And Ignore Error   Execute Command    timeout 6 nc -zvw3 ${vm} 22    return_rc=True   timeout=10
         ${status}    Run Keyword And Return Status
-        ...          Should Be Equal As Integers    ${rc}    0
+        ...          Should Be Equal As Integers    ${output}[1]   0
         IF  ${status}
             BREAK
         END
@@ -670,19 +674,49 @@ Connect to VM if not already connected
         Connect to VM   ${vm_name}
     END
 
-Detect first boot
-    [Documentation]    Determine desktop state after boot by attempting login to gui-vm as testuser
-    Connect
-    Log To Console          Detecting if this is first boot by trying test user credentials
-    Verify service status   range=15  service=microvm@gui-vm.service  expected_status=active  expected_state=running
-    Connect to netvm
-    ${status}   ${output}   Run Keyword And Ignore Error   Connect to VM   ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
-    IF   $status=='PASS'
-        Log To Console          Test user exists
-        RETURN  ${False}
-    END
-    RETURN   ${True}
-
 Create test user
     Log To Console      Creating test user
     Execute Command     systemctl start setup-test-user.service  sudo=True  sudo_password=${password}
+
+Switch to gui-vm as ghaf     
+    [Documentation]   Switches the ssh connection to the gui-vm using the user account
+
+    ${status}   Try to switch to active gui-vm connection   ${GUI_VM_GHAF_SSH}   ghaf
+
+    IF   ${status}
+        Log To Console    Switched to gui-vm as ghaf
+    ELSE
+        ${GUI_VM_GHAF_SSH}   Connect to VM       ${GUI_VM}
+        Set Global Variable    ${GUI_VM_GHAF_SSH}
+    END
+
+Switch to gui-vm as user
+    [Documentation]   Switches the ssh connection to the gui-vm using the ghaf user
+
+    ${status}   Try to switch to active gui-vm connection   ${GUI_VM_USER_SSH}   ${USER_LOGIN}
+
+    IF   ${status}
+        Log To Console    Switched to gui-vm as user
+    ELSE
+        ${GUI_VM_USER_SSH}   Connect to VM       ${GUI_VM}  ${USER_LOGIN}  ${USER_PASSWORD}
+        Set Global Variable    ${GUI_VM_USER_SSH}
+    END
+
+Try to switch to active gui-vm connection
+    [Arguments]        ${ssh_connection}   ${user} 
+
+    ${connection_status}  ${new_connection}   Run Keyword And Ignore Error    Switch Connection   ${ssh_connection}
+
+    ${status}   ${output_user}    Run Keyword And Ignore Error   Execute Command    whoami
+    Log    ${output_user}
+    ${user_status}    Run Keyword And Return Status    Should Be Equal    ${output_user}    ${user}
+
+    ${status}   ${output_host}    Run Keyword And Ignore Error   Execute Command    hostname
+    Log    ${output_host}
+    ${host_status}    Run Keyword And Return Status    Should Be Equal    ${output_host}    gui-vm
+
+    IF   $connection_status=='FAIL' or not ${user_status} or not ${host_status}
+        RETURN   False
+    ELSE
+        RETURN   True
+    END

--- a/Robot-Framework/test-suites/functional-tests/__init__.robot
+++ b/Robot-Framework/test-suites/functional-tests/__init__.robot
@@ -21,21 +21,9 @@ ${DISABLE_LOGOUT}     ${EMPTY}
 
 Functional tests setup
     [timeout]    5 minutes
-    Initialize Variables, Connect And Start Logging
-    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Connect to VM         ${GUI_VM}
-        Set compositor
-        Save most common icons and paths to icons
-        Create test user
-        Log in, unlock and verify
-    END
+    Prepare Test Environment
     Switch Connection    ${CONNECTION}
 
 Functional tests teardown
     [timeout]    5 minutes
-    Connect to ghaf host
-    Log journalctl
-    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Log out and verify
-    END
-    Close All Connections
+    Clean Up Test Environment

--- a/Robot-Framework/test-suites/gui-tests/__init__.robot
+++ b/Robot-Framework/test-suites/gui-tests/__init__.robot
@@ -8,7 +8,7 @@ Resource            ../../resources/gui_keywords.resource
 Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/connection_keywords.resource
 Library             ../../lib/GuiTesting.py   ${OUTPUT_DIR}/outputs/gui-temp/
-Test Timeout        10 minutes
+Test Timeout        5 minutes
 Suite Setup         GUI Tests Setup
 Suite Teardown      GUI Tests Teardown
 
@@ -16,26 +16,14 @@ Suite Teardown      GUI Tests Teardown
 *** Keywords ***
 
 GUI Tests Setup
-    Initialize Variables, Connect And Start Logging
-    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Connect to VM       ${GUI_VM}
-        Set compositor
-        Save most common icons and paths to icons
-        Create test user
-        Log in, unlock and verify   enable_dnd=True
+    Prepare Test Environment   enable_dnd=True
 
-        # There's a bug that occasionally causes the app menu to freeze on Cosmic, especially on the first login. 
-        # Logging out once before running tests helps reduce the chances of it happening. (SSRCSP-6684)
-        IF  $COMPOSITOR == 'cosmic'
-            Log out and verify   disable_dnd=True
-            Log in, unlock and verify   enable_dnd=True
-        END
+    # There's a bug that occasionally causes the app menu to freeze on Cosmic, especially on the first login. 
+    # Logging out once before running tests helps reduce the chances of it happening. (SSRCSP-6684)
+    IF  $COMPOSITOR == 'cosmic'
+        Log out and verify   disable_dnd=True
+        Log in, unlock and verify   enable_dnd=True
     END
 
 GUI Tests Teardown
-    Connect to ghaf host
-    Log journalctl
-    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Log out and verify   disable_dnd=True
-    END
-    Close All Connections
+    Clean Up Test Environment   disable_dnd=True

--- a/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
@@ -11,7 +11,6 @@ Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/power_meas_keywords.resource
 Library             ../../lib/SwitchbotLibrary.py  ${SWITCH_TOKEN}  ${SWITCH_SECRET}
 Test Setup          GUI Power Test Setup
-Test Teardown       Close All Connections
 
 *** Test Cases ***
 
@@ -27,7 +26,7 @@ GUI Suspend and wake up
     Set start timestamp
     # Connect back to gui-vm after power measurement has been started
     Connect to netvm
-    Connect to VM                 ${GUI_VM}
+    Switch to gui-vm as ghaf
     IF  $COMPOSITOR == 'cosmic'
         Skip   The X1 in the lab gets stuck when a suspension is attempted. Needs further investigation.
         # Select power menu option   index=4
@@ -100,14 +99,10 @@ GUI Reboot
         Log To Console            Device started
     END
     Sleep  30
-    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        ${NETVM_SSH}              Connect   iterations=10
-        Connect to VM             ${GUI_VM}
-    ELSE
-        Connect to ghaf host
-    END
-    ${logout_status}     Check if logged out
-    IF   not ${logout_status}  FAIL  Desktop detected. Device failed to boot to login screen.
+    Connect   iterations=10
+    Switch to gui-vm as ghaf
+    Start ydotoold
+    Log in, unlock and verify   enable_dnd=True
 
 GUI Log out and log in
     [Documentation]   Logout via GUI power menu icon and verify logged out state.
@@ -120,14 +115,13 @@ GUI Log out and log in
     END
     ${logout_status}            Check if logged out
     IF  not ${logout_status}    FAIL  Logout failed.
-    Log in via GUI
-    Verify desktop availability
+    Log in, unlock and verify
 
 *** Keywords ***
 
 GUI Power Test Setup
     Connect to netvm
-    Connect to VM       ${GUI_VM}
+    Switch to gui-vm as ghaf
     Log in, unlock and verify
 
 Select power menu option

--- a/Robot-Framework/test-suites/gui-tests/input_control.robot
+++ b/Robot-Framework/test-suites/gui-tests/input_control.robot
@@ -6,7 +6,6 @@ Documentation       Tests for input-related GUI functionality
 Force Tags          gui
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/gui_keywords.resource
-Test Setup          GUI Input Test Setup
 
 *** Test Cases ***
 
@@ -21,11 +20,3 @@ Change brightness with keyboard shortcuts
     Increase brightness
     ${h_brightness}     Get screen brightness
     Should Be True      ${h_brightness} > ${l_brightness}
-
-
-*** Keywords ***
-
-GUI Input Test Setup
-    Connect to netvm
-    Connect to VM       ${GUI_VM}
-    Log in, unlock and verify

--- a/Robot-Framework/test-suites/suspension-test/__init__.robot
+++ b/Robot-Framework/test-suites/suspension-test/__init__.robot
@@ -3,6 +3,7 @@
 
 *** Settings ***
 Documentation       Suspension test
+Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../config/variables.robot
 Suite Setup         Set Variables   ${DEVICE}

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -183,9 +183,4 @@ Suspension setup
     Sleep  30
     Connect   iterations=10
 
-    Initialize Variables, Connect And Start Logging
-    Connect to VM        ${GUI_VM}
-    Set compositor
-    Save most common icons and paths to icons
-    Create test user
-    Log in, unlock and verify   stop_swayidle=False
+    Prepare Test Environment   stop_swayidle=False


### PR DESCRIPTION
Note: Let's not merge this before the release is done.

### List of changes
- Two new keywords added, `Prepare Test Environment` and `Clean Up Test Environment`
   - Now that gui login is required for 3 separate suites (functional, gui & suspension) it made sense to combine the needed commands into a shared keyword.
   - `Prepare Test Environment` replaces the old `Initialize Variables, Connect And Start Logging` and now also includes gui preparations & login.
   - `Clean Up Test Environment` is a new keyword. It finishes logging and logs out.
- `Connect to VM` keywords replaced with  `Switch to gui-vm as ghaf` and `Switch to gui-vm as user` in gui tests.
- Removed unnecessary new connections in the setups & tests.
- Removed unused `Detect first boot` keyword.

### Some stats
  -  The runtime for `gui` tests dropped from 11:00 minutes to 08:14 minutes.
  -  The number of ssh connections for a one single gui app test was reduced from over 50 to just a few.

### Next steps
These will be addressed in the following PRs
- Change the suspension test teardown to use `Clean Up Test Environment` instead of `Close All Connections`. `Log out and verify` needs to be changed so that it can handle locked out state before that.
- Remove resources that are not needed, especially from the `__init__` files.
- Check if some of the switches can still be removed.

### Testruns
- [Main pipeline](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/ghaf-main-pipeline/139/) (Dell got stuck for some reason. Separate Dell run also attached)
- [Lenovo-X1](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2217/) (all tests except performance)
- [Dell-7330](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2184/)