### PR TITLE
Test keyboard layouts

### DIFF
--- a/Robot-Framework/lib/output_parser.py
+++ b/Robot-Framework/lib/output_parser.py
@@ -288,7 +288,6 @@ def parse_notifications(text):
     notifications_dict = {int(num): msg for num, msg in matches}
     return notifications_dict
 
-
 def parse_services_to_list(output):
     match = re.search(r"\[([^\]]+)\]", output)
     if not match:
@@ -298,9 +297,18 @@ def parse_services_to_list(output):
     parsed_list = [item.strip(" '\"") for item in raw_items if item.strip()]
     return parsed_list
 
-
 def parse_known_issue(output):
     parts = output.split('|')
     if len(parts) != 3:
         raise ValueError(f"Invalid known issue format: {output}")
     return parts[0].strip(), parts[1].strip(), parts[2].strip()
+
+def parse_keyboard_layout(layout_row):
+    if not "layout" in layout_row:
+        return False
+    current_layout = layout_row.split("\"")[1].split(",")
+    for i in range(len(current_layout)):
+        if current_layout[i] == "us":
+            # Return the current order of layouts and the placement of 'us' in the list
+            return [current_layout, i]
+    return False

--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -140,3 +140,11 @@ Get Falcon LLM Name
     ${tmp}               Fetch From Right  ${llm_name_raw}  =
     ${LLM_NAME}          Set Variable  ${tmp[1:-1]}
     Set Global Variable  ${LLM_NAME}
+
+Launch Cosmic Term
+    IF  $COMPOSITOR == 'cosmic'
+        Start XDG application   com.system76.CosmicTerm  gui_vm_app=true
+        Check that the application was started    cosmic-term  exact_match=true
+    ELSE
+        Skip   App only available in Cosmic
+    END

--- a/Robot-Framework/resources/connection_keywords.resource
+++ b/Robot-Framework/resources/connection_keywords.resource
@@ -36,6 +36,7 @@ Turn ON WiFi
 
 Initialize Variables And Connect
     [Documentation]  Initialize variables. Connect to device and start logging
+    Close All Connections
     Set Variables   ${DEVICE}
     Run Keyword If  "${DEVICE_IP_ADDRESS}" == "NONE"    Get ethernet IP address
     ${port_22_is_available}     Check if ssh is ready on device   timeout=60

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -102,7 +102,7 @@ Log out via GUI
     END
 
 Type string and press enter
-    [Arguments]    ${string}=${EMPTY}  ${confidential}=False
+    [Arguments]    ${string}=${EMPTY}  ${confidential}=False  ${enter}=True
     IF  ${confidential} 
         Log To Console    Typing password
     ELSE
@@ -111,8 +111,12 @@ Type string and press enter
     IF  $string != '${EMPTY}'
         Execute Command   ydotool type ${string}  sudo=True  sudo_password=${PASSWORD}
     END
-    Log To Console    Pressing Enter
-    Execute Command   ydotool key 28:1 28:0  sudo=True  sudo_password=${PASSWORD}
+    IF  ${enter}
+        Log To Console    Pressing Enter
+        Execute Command   ydotool key 28:1 28:0  sudo=True  sudo_password=${PASSWORD}
+    ELSE
+        Log To Console    Skipping Enter
+    END
 
 Tab and enter
     [Arguments]    ${tabs}=1
@@ -409,3 +413,8 @@ Get gui-vm user journalctl log
     [Setup]      Switch to gui-vm as user
     Get user journalctl log   gui-vm-user.log
     [Teardown]   Switch to gui-vm as ghaf
+
+Switch keyboard layout
+    [Documentation]   Toggle layout between English, Arabic and Finnish
+    Log To Console    Pressing Alt+Shift, shortcut for switching keyboard layout
+    Execute Command   ydotool key 56:1 42:1 42:0 56:0  sudo=True  sudo_password=${PASSWORD}

--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -70,6 +70,11 @@ Start COSMIC Text Editor on LenovoX1
         Skip   App only available in Cosmic
     END
 
+Start COSMIC Terminal on LenovoX1
+    [Documentation]   Start Cosmic Terminal and verify process started
+    [Tags]            bat   cosmic_term  SP-T263
+    Launch Cosmic Term
+
 Start Falcon AI on LenovoX1
     [Documentation]   Start Falcon AI and verify process started
     [Tags]            falcon_ai  SP-T223-1

--- a/Robot-Framework/test-suites/gui-tests/input_control.robot
+++ b/Robot-Framework/test-suites/gui-tests/input_control.robot
@@ -3,16 +3,19 @@
 
 *** Settings ***
 Documentation       Tests for input-related GUI functionality
-Force Tags          gui
+Force Tags          gui  gui-input
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/gui_keywords.resource
+Resource            ../../resources/common_keywords.resource
+Library             Collections
+Library             ../../lib/output_parser.py
+
 
 *** Test Cases ***
 
 Change brightness with keyboard shortcuts
     [Documentation]     Change brightness with ydotool by clicking F5/F6 buttons
     [Tags]              lenovo-x1   SP-T140
-
     ${init_brightness}  Get screen brightness
     Decrease brightness
     ${l_brightness}     Get screen brightness
@@ -20,3 +23,63 @@ Change brightness with keyboard shortcuts
     Increase brightness
     ${h_brightness}     Get screen brightness
     Should Be True      ${h_brightness} > ${l_brightness}
+
+Change keyboard layout
+    [Documentation]     Change keyboard layout with Alt+Shift shortcut
+    [Tags]              lenovo-x1   SP-T138
+    Check cosmic config current layout value
+    Launch Cosmic Term
+    Switch to gui-vm as ghaf
+    Type string and press enter                "echo "  enter=False
+    Type apostrophe
+    Press test key and switch keyboard layout  repeat=3
+    Type apostrophe
+    Type string and press enter                " > /tmp/key_check.txt"
+    ${key_check}                               Execute Command  cat /tmp/key_check.txt
+    Execute Command                            rm /tmp/key_check.txt  sudo=True  sudo_password=${PASSWORD}
+    IF  $key_check != ';كö'
+        FAIL    Failed to get the expected keyboard input ';كö'\nKeyboard input received: ${key_check}
+    END
+    [Teardown]  Kill gui-vm apps
+
+
+*** Keywords ***
+
+Press test key and switch keyboard layout
+    [Documentation]           Press a key which produces different output depending on the keyboard layout:
+    ...                       English ; / Arabic ك / Finnish ö
+    [Arguments]               ${repeat}=1
+    FOR   ${i}   IN RANGE  ${repeat}
+        Execute Command           ydotool key 39:1 39:0  sudo=True  sudo_password=${PASSWORD}
+        Switch keyboard layout
+    END
+
+Type apostrophe
+    Log To Console            Typing apostrophe ' (English keyboard layout required)
+    Execute Command           ydotool key 40:1 40:0  sudo=True  sudo_password=${PASSWORD}
+
+Check cosmic config current layout value
+    [Documentation]           Check the value of current layout in the xkb_config file.
+    ...                       If the current value is not 'us' toggle until it is set to 'us'.
+    Log To Console            Checking current keyboard layout
+    Switch to gui-vm as user
+    ${output}  ${rc}=         Execute Command  cat .config/cosmic/com.system76.CosmicComp/v1/xkb_config | grep -w layout  return_rc=True
+    # If the keyboard layout has never been toggled the file doesn't exist and command fails with rc 1
+    # Then we assume default keyboard layout: 'us'
+    IF  $rc != 0
+        Log To Console    Keyboard layout has not been changed, assuming us
+    ELSE
+        ${current_layout}   Parse keyboard layout  ${output}
+        Log                 ${current_layout}   console=True
+        ${placement}        Get From List   ${current_layout}   1
+        Switch to gui-vm as ghaf
+        FOR   ${i}   IN RANGE  ${placement}
+            Sleep   0.5
+            Switch keyboard layout
+        END
+    END
+    [Teardown]    Switch to gui-vm as user
+
+Kill gui-vm apps
+    Switch to gui-vm as ghaf
+    Kill process        @{APP_PIDS}


### PR DESCRIPTION
Add test for reading keyboard input with different keyboard layouts.

Since terminal window was needed in this test added also missing test case for terminal launch.

Close all connections in the beginning of test runs at Initialize Variables And Connect, just in case
there were some hanging connections from previous (manual) runs.

Tested locally on Lenovo-X1, both with fresh image with no keyboard layout switch history, and after manually switching to other than default (us) keyboard layout.

Terminal launch test on Dell:
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2315/

I was about to add Change keyboard layout test also for Dell target. In test it turned out that it has only "us" keyboard layout defined in .config/cosmic/com.system76.CosmicComp/v1/xkb_config.
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2316/