### PR TITLE
Fix for Ballooning test  (Set timeout for a keyword)

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -119,7 +119,7 @@ Connect to VM
     [Documentation]      Connect to any VM or ghaf-host over internal virtual network
     [Arguments]          ${vm_name}    ${user}=${LOGIN}   ${pw}=${PASSWORD}   ${timeout}=60
     Log To Console       Connecting to ${vm_name} as ${user}...   no_newline=true
-    Check if ssh is ready on vm        ${vm_name}
+    Check if ssh is ready on vm        ${vm_name}   ${timeout}
     ${failed_connection}  Set Variable  True
     ${start_time}  Get Time	epoch
     IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}" or "Dell" in "${DEVICE}"


### PR DESCRIPTION
Ballooning test started to fail frequently. Investigated this and noticed that 30s timeout for 'Check if ssh is ready on vm' was no more  enough. Took the default timeout(60) set on actual keyword 'connect to vm' into use. 

Tests:
Without the fix: [Dev#2264](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2264/artifact/Robot-Framework/test-suites/lenovo-x1ANDSP-T255/log.html)

With the fix: [Dev#2263](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2263/artifact/Robot-Framework/test-suites/lenovo-x1ANDSP-T255/log.html)
