### PR TITLE
Search for power icon, save journalctl log if launcher icon was not found

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -79,6 +79,12 @@ Log journalctl
     @{pid}        Find pid by name   journalctl
     Kill process  @{pid}
 
+Get user journalctl log
+    [Arguments]   ${filename}
+    Execute Command    journalctl --user > /tmp/${filename}
+    SSHLibrary.Get file   /tmp/${filename}   ${OUTPUT_DIR}/${filename}
+    OperatingSystem.File Should Exist     ${OUTPUT_DIR}/${filename}
+
 Check If Device Is Up
     [Arguments]    ${range}=20
     Set Global Variable    ${IS_AVAILABLE}       False

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -197,7 +197,16 @@ Move cursor to corner
 Verify desktop availability
     [Documentation]         Check that launcher icon is available on desktop
     Log To Console          Verifying login by trying to detect the launcher icon
-    Locate image on screen  ${APP_MENU_LAUNCHER}  0.95  10
+    #Locate image on screen  ${APP_MENU_LAUNCHER}  0.95  10
+
+    # This is a workaround for launcher icon missing sometimes. If launcher icon can't be found tries to search
+    # for the power menu icon. Gui-vm user log is saved to help debugging.
+    ${status}   ${output}   Run Keyword And Ignore Error   Locate image on screen  ${APP_MENU_LAUNCHER}  0.95  10
+    IF   $status == 'FAIL'
+        Get gui-vm user journalctl log
+        Log To Console    Could not find launcher icon, checking for power menu icon
+        Locate image on screen   ./power.png  0.55  5
+    END
 
 Move cursor
     Log To Console    Moving cursor to random location
@@ -395,3 +404,8 @@ Decrease brightness
     [Documentation]   The F5 key is physically implemented as KEY_BRIGHTNESSDOWN (code 224)
     Log To Console    Pressing F5
     Execute Command   ydotool key 224:1 224:0  sudo=True  sudo_password=${PASSWORD}
+
+Get gui-vm user journalctl log
+    [Setup]      Switch to gui-vm as user
+    Get user journalctl log   gui-vm-user.log
+    [Teardown]   Switch to gui-vm as ghaf


### PR DESCRIPTION
[Normal test run](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2280)
[No launcher icon, power icon found](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2276/)
[No launcher icon or power icon ](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2279/)
I manually blocked the icons to test. Artifacts are not saved for ghaf-hw-tests so the log file does not exist in Jenkins. Tested it locally.