### PR TITLE
Skip for test 'Measure UDP Bidir Throughput Small Packets' (RX, Dell Only)

### DIFF
--- a/Robot-Framework/test-suites/performance-tests/network.robot
+++ b/Robot-Framework/test-suites/performance-tests/network.robot
@@ -120,6 +120,8 @@ Measure UDP Bidir Throughput Small Packets
     ${statistics}           Save Speed Data   ${TEST NAME}  ${speed_data}
     Determine Test Status   ${statistics}
 
+    [Teardown]  Run Keyword If   "Dell" in "${DEVICE}"   Run Keyword If Test Failed   Skip   "Known issue: SSRCSP-6774"
+
 Measure UDP Throughput Big Packets
     [Documentation]  Start server on DUT. Send data from agent PC in reverse mode to get tx speed
     [Tags]  udp  nuc  orin-agx  orin-agx-64  riscv  lenovo-x1   dell-7330  SP-T233

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -3,7 +3,8 @@
 ## Active SKIPS
 
 | DATE SET   | TEST CASE                                         | TICKET / Additional Data.                                                                       |
-| ---------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+|------------|---------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| 27.06.2025 | Measure UDP Bidir Throughput Small Packets (Dell) | SSRCSP-6774                                                                                     |
 | 17.06.2025 | Start and close Google Chrome via GUI on LenovoX1 | SSRCSP-6716                                                                                     |
 | 13.06.2025 | Record Video With Camera (Dell)                   | SSRCSP-6694                                                                                     |
 | 06.06.2025 | Check user systemctl status (X1 and Dell)         | SSRCSP-6697                                                                                     |


### PR DESCRIPTION
I still haven't figured out if this is a test env/test related issue or a real bug. 
After boot throughput result is low, when executed again without device boot, result is as expected.

Test Result: [Prod#313](https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/313)
