### PR TITLE
Add Press Key(s) keyword

### DIFF
--- a/Robot-Framework/lib/GuiTesting.py
+++ b/Robot-Framework/lib/GuiTesting.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pyscreeze import locate, center
+from evdev import ecodes
 import logging
 import subprocess
 
@@ -45,3 +46,20 @@ class GuiTesting:
     
     def negate_app_icon(self, input_file, output_file):
         subprocess.run(['magick', input_file, '-negate', output_file])
+
+    def generate_ydotool_key_command(self, key_combination):
+        # Returns a `ydotool key ...` command string for the given key combination,
+        # e.g. generate_ydotool_key_command("LEFTMETA+LEFTSHIFT+ESC") -> 'ydotool key 125:1 42:1 1:1 1:0 42:0 125:0'
+        keys = key_combination.split("+")
+        key_codes = []
+        for key in keys:
+            key = key.strip().upper()
+            full_key = f"KEY_{key}"
+            if not hasattr(ecodes, full_key):
+                raise ValueError(f"Unknown key: {key} (tried {full_key})")
+            key_codes.append(getattr(ecodes, full_key))
+
+        press_events = [f"{code}:1" for code in key_codes]
+        release_events = [f"{code}:0" for code in reversed(key_codes)]
+
+        return "ydotool key " + " ".join(press_events + release_events)

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -41,7 +41,7 @@ Log in, unlock and verify
     IF   $status == 'FAIL'
         Log To Console    There was maybe a bug with the cosmic-greeter, let's try logging in again
         Log To Console    Pressing Tab to activate the password field
-        Execute Command    ydotool key 15:1 15:0  sudo=True  sudo_password=${PASSWORD}
+        Press Key(s)      TAB
         Log in via GUI
         Wait for Ghaf session activation
         Verify desktop availability
@@ -86,7 +86,7 @@ Log out via GUI
         RETURN
     END
     Log To Console    Logging out by pressing Super+Shift+Escape 
-    Execute Command   ydotool key 125:1 42:1 1:1 1:0 42:0 125:0  sudo=True  sudo_password=${PASSWORD}
+    Press Key(s)      LEFTMETA+LEFTSHIFT+ESC
     Tab and enter     tabs=2
 
 Type string and press enter
@@ -100,8 +100,7 @@ Type string and press enter
         Execute Command   ydotool type ${string}  sudo=True  sudo_password=${PASSWORD}
     END
     IF  ${enter}
-        Log To Console    Pressing Enter
-        Execute Command   ydotool key 28:1 28:0  sudo=True  sudo_password=${PASSWORD}
+        Press Key(s)      ENTER
     ELSE
         Log To Console    Skipping Enter
     END
@@ -109,12 +108,10 @@ Type string and press enter
 Tab and enter
     [Arguments]    ${tabs}=1
     Log To Console      Pressing Tab ${tabs} times and then Enter to select
-    ${command}=    Set Variable    ${EMPTY}
     FOR  ${i}  IN RANGE  ${tabs}
-        ${command}=    Set Variable  ${command} 15:1 15:0
+        Press Key(s)   TAB
     END
-    Execute Command    ydotool key ${command}  sudo=True  sudo_password=${PASSWORD}
-    Execute Command    ydotool key 28:1 28:0  sudo=True  sudo_password=${PASSWORD}
+    Press Key(s)       ENTER
 
 Locate image on screen
     [Documentation]    Take a screenshot. Locate given image on the screenshot.
@@ -298,16 +295,6 @@ Get screen brightness
     Log To Console    Brightness is ${brightness}
     RETURN            ${brightness}
 
-Increase brightness
-    [Documentation]   The F6 key is physically implemented as KEY_BRIGHTNESSUP (code 225)
-    Log To Console    Pressing F6
-    Execute Command   ydotool key 225:1 225:0  sudo=True  sudo_password=${PASSWORD}
-
-Decrease brightness
-    [Documentation]   The F5 key is physically implemented as KEY_BRIGHTNESSDOWN (code 224)
-    Log To Console    Pressing F5
-    Execute Command   ydotool key 224:1 224:0  sudo=True  sudo_password=${PASSWORD}
-
 Get gui-vm user journalctl log
     [Setup]      Switch to gui-vm as user
     Get user journalctl log   gui-vm-user.log
@@ -316,8 +303,18 @@ Get gui-vm user journalctl log
 Switch keyboard layout
     [Documentation]   Toggle layout between English, Arabic and Finnish
     Log To Console    Pressing Alt+Shift, shortcut for switching keyboard layout
-    Execute Command   ydotool key 56:1 42:1 42:0 56:0  sudo=True  sudo_password=${PASSWORD}
+    Press Key(s)      LEFTALT+LEFTSHIFT
 
 Timestamp screenshot
     ${current_time}  DateTime.Get Current Date  result_format=%Y%m%d_%H%M%S
     Run Process      sh  -c  cp ${GUI_TEMP_DIR}screenshot.png ${GUI_TEMP_DIR}screenshot_${current_time}.png  shell=true
+
+Press Key(s)
+    [Arguments]        ${key_combination}
+    [Documentation]    Simulates key press(es) using ydotool. If there are multiple keys they must be separated with '+'.
+    ...   Check the correct key name from https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
+    ${ydotool_command}    Generate Ydotool Key Command   ${key_combination}
+    Log               ${ydotool_command}
+    Log To Console    Pressing key(s): ${key_combination}
+    ${output}    ${rc}    Execute Command   ${ydotool_command}  sudo=True  sudo_password=${PASSWORD}    return_rc=True
+    Should Be Equal As Integers     ${rc}   0

--- a/Robot-Framework/test-suites/gui-tests/input_control.robot
+++ b/Robot-Framework/test-suites/gui-tests/input_control.robot
@@ -17,10 +17,10 @@ Change brightness with keyboard shortcuts
     [Documentation]     Change brightness with ydotool by clicking F5/F6 buttons
     [Tags]              lenovo-x1   SP-T140
     ${init_brightness}  Get screen brightness
-    Decrease brightness
+    Press Key(s)        BRIGHTNESSDOWN
     ${l_brightness}     Get screen brightness
     Should Be True      ${l_brightness} < ${init_brightness}
-    Increase brightness
+    Press Key(s)        BRIGHTNESSUP
     ${h_brightness}     Get screen brightness
     Should Be True      ${h_brightness} > ${l_brightness}
 
@@ -31,9 +31,9 @@ Change keyboard layout
     Launch Cosmic Term
     Switch to gui-vm as ghaf
     Type string and press enter                "echo "  enter=False
-    Type apostrophe
+    Press Key(s)    APOSTROPHE
     Press test key and switch keyboard layout  repeat=3
-    Type apostrophe
+    Press Key(s)    APOSTROPHE
     Type string and press enter                " > /tmp/key_check.txt"
     ${key_check}                               Execute Command  cat /tmp/key_check.txt
     Execute Command                            rm /tmp/key_check.txt  sudo=True  sudo_password=${PASSWORD}
@@ -50,13 +50,9 @@ Press test key and switch keyboard layout
     ...                       English ; / Arabic ك / Finnish ö
     [Arguments]               ${repeat}=1
     FOR   ${i}   IN RANGE  ${repeat}
-        Execute Command           ydotool key 39:1 39:0  sudo=True  sudo_password=${PASSWORD}
+        Press Key(s)   SEMICOLON	
         Switch keyboard layout
     END
-
-Type apostrophe
-    Log To Console            Typing apostrophe ' (English keyboard layout required)
-    Execute Command           ydotool key 40:1 40:0  sudo=True  sudo_password=${PASSWORD}
 
 Check cosmic config current layout value
     [Documentation]           Check the value of current layout in the xkb_config file.

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,7 @@
                 pyscreeze
                 opencv4
                 paramiko
+                evdev
               ])
               ++ (with self.packages.${system}; [
                 robotframework-jsonlibrary

--- a/pkgs/ghaf-robot/default.nix
+++ b/pkgs/ghaf-robot/default.nix
@@ -29,6 +29,7 @@ writeShellApplication {
       ps.pandas
       ps.pyscreeze
       ps.opencv4
+      ps.evdev
 
       # These are taken from this flake
       robotframework-advancedlogging


### PR DESCRIPTION
Add `Press Key(s)` keyword to call when using `ydotool key` command. It generates the command from the key names and runs it.
[
Lenovo-X1 testrun](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2354/) (the two tests that failed also failed in nightly pipeline)

Advantages:

- Makes the code easier to read -> `Press Key(s) LEFTMETA+LEFTSHIFT+ESC` instead of `Execute Command ydotool key 125:1 42:1 1:1 1:0 42:0 125:0 sudo=True sudo_password=${PASSWORD}`
- Removes the need to create new keywords for keys that are only used a few times. We can still have keywords for commonly used combinations. For example I removed `Increase brightness` &  `Decrease brightness` but left the `Switch keyboard layout` keyword.
- Easier error handling, already added a check for the return code. We can also catch errors if we want. Right now errors returned by ydotool are just ignored and can cause confusion when the test later fails.