### PR TITLE
Generalize keyword for switch to vm

### DIFF
--- a/Robot-Framework/lib/helper_functions.py
+++ b/Robot-Framework/lib/helper_functions.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+from robot.libraries.BuiltIn import BuiltIn
+
+def set_variable_by_name(name, value):
+    var_name = '${' + name + '}'
+    BuiltIn().set_global_variable(var_name, value)

--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -17,7 +17,7 @@ Prepare Test Environment
     Run journalctl recording
 
     IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Switch to gui-vm as ghaf
+        Switch to vm    gui-vm
         Save most common icons and paths to icons
         Create test user
         Start ydotoold
@@ -29,7 +29,7 @@ Clean Up Test Environment
     Connect to ghaf host
     Log journalctl
     IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Switch to gui-vm as ghaf
+        Switch to vm    gui-vm
         Start ydotoold
         Log out and verify   ${disable_dnd}
         Stop ydotoold
@@ -143,3 +143,12 @@ Get Falcon LLM Name
 Launch Cosmic Term
     Start XDG application   com.system76.CosmicTerm  gui_vm_app=true
     Check that the application was started    cosmic-term  exact_match=true
+
+Check variable availability
+    [Arguments]    ${variable_name}
+    ${value}=    Get Variable Value    ${${variable_name}}
+    IF  $value!='${EMPTY}' and $value!=None
+        RETURN  ${True}
+    ELSE
+        RETURN  ${False}
+    END

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -119,7 +119,7 @@ Locate image on screen
     [Arguments]        ${image_to_be_searched}  ${confidence}=0.999   ${iterations}=5   ${fail_expected}=False  ${debug_screenshot}=True
     ${coordinates}=        Set Variable  ${EMPTY}
     ${pass_status}=        Set Variable  FAIL
-    Switch to gui-vm as user
+    Switch to vm    gui-vm  user=${USER_LOGIN}
     Execute Command        mkdir test-images
     FOR   ${i}   IN RANGE  ${iterations}
         Log To Console     Taking cosmic screenshot
@@ -147,7 +147,7 @@ Locate image on screen
     ${mouse_x}  Get From Dictionary   ${coordinates}  x
     ${mouse_y}  Get From Dictionary   ${coordinates}  y
     RETURN  ${mouse_x}  ${mouse_y}
-    [Teardown]    Switch to gui-vm as ghaf
+    [Teardown]    Switch to vm    gui-vm
 
 Locate and click
     [Arguments]   ${image_to_be_searched}  ${confidence}=0.99  ${iterations}=5
@@ -200,7 +200,7 @@ Move cursor
 Check if logged out
     [Documentation]    Check if system is in logged out state
     [Arguments]        ${iterations}=10
-    Switch to gui-vm as user
+    Switch to vm    gui-vm  user=${USER_LOGIN}
     FOR   ${i}   IN RANGE  ${iterations}
         ${activity}=       Execute Command    systemctl --user is-active ghaf-session.target  return_stdout=True
         IF  $activity == "active"
@@ -212,11 +212,11 @@ Check if logged out
         Sleep  1
     END
     RETURN    ${False}
-    [Teardown]    Switch to gui-vm as ghaf
+    [Teardown]    Switch to vm    gui-vm
 
 Wait for Ghaf session activation
     [Documentation]    Wait until ghaf session is in active state
-    Switch to gui-vm as user
+    Switch to vm    gui-vm  user=${USER_LOGIN}
     Log To Console     Waiting for the Ghaf session to start...  no_newline=true 
     FOR   ${i}   IN RANGE  30
         ${activity}=       Execute Command    systemctl --user is-active ghaf-session.target  return_stdout=True
@@ -231,7 +231,7 @@ Wait for Ghaf session activation
     END
     Log To Console    Failed
     Log To Console    Ghaf session did not activate
-    [Teardown]    Switch to gui-vm as ghaf
+    [Teardown]    Switch to vm    gui-vm
 
 Get icon
     [Documentation]    Copy icon svg file to test agent machine. Crop and convert the svg file to png.
@@ -276,17 +276,17 @@ Save most common icons and paths to icons
 Stop swayidle
     [Documentation]    Stop swayidle to prevent automatic suspension
     Log To Console    Disabling automated lock and suspend
-    Switch to gui-vm as user
+    Switch to vm    gui-vm  user=${USER_LOGIN}
     Execute Command   systemctl --user stop swayidle
-    [Teardown]    Switch to gui-vm as ghaf
+    [Teardown]    Switch to vm    gui-vm
 
 Set do not disturb state
     [Documentation]   Set do not disturb to true or false
     [Arguments]       ${state}
     Log To Console    Setting Do Not Disturb to ${state}
-    Switch to gui-vm as user
+    Switch to vm    gui-vm  user=${USER_LOGIN}
     Execute Command   echo ${state} > ~/.config/cosmic/com.system76.CosmicNotifications/v1/do_not_disturb
-    [Teardown]    Switch to gui-vm as ghaf
+    [Teardown]    Switch to vm    gui-vm
 
 Get screen brightness
     [Documentation]   Get and return current brightness value
@@ -296,9 +296,9 @@ Get screen brightness
     RETURN            ${brightness}
 
 Get gui-vm user journalctl log
-    [Setup]      Switch to gui-vm as user
+    [Setup]      Switch to vm    gui-vm  user=${USER_LOGIN}
     Get user journalctl log   gui-vm-user.log
-    [Teardown]   Switch to gui-vm as ghaf
+    [Teardown]   Switch to vm    gui-vm
 
 Switch keyboard layout
     [Documentation]   Toggle layout between English, Arabic and Finnish

--- a/Robot-Framework/resources/power_meas_keywords.resource
+++ b/Robot-Framework/resources/power_meas_keywords.resource
@@ -4,6 +4,7 @@
 *** Settings ***
 Resource            ../config/variables.robot
 Library             ../lib/ParsePowerData.py    ${POWER_MEASUREMENT_DIR}    ${PLOT_DIR}
+Resource            ./common_keywords.resource
 Library             SSHLibrary
 Library             DateTime
 
@@ -15,19 +16,11 @@ ${RPI_IP_ADDRESS}         ${EMPTY}
 
 *** Keywords ***
 
-Check variable availability
-    ${value}=    Get Variable Value    ${RPI_IP_ADDRESS}
-    IF  $value!='${EMPTY}'
-        RETURN  ${True}
-    ELSE
-        RETURN  ${False}
-    END
-
 Start power measurement
     [Documentation]    Connect to the measurement agent and run script to start collecting measurement results
     [Arguments]        ${id}=power_data   ${timeout}=200
-    ${availability}            Check variable availability
-    Set Global Variable   ${SSH_MEASUREMENT}  ${EMPTY}
+    ${availability}            Check variable availability  RPI_IP_ADDRESS
+    Set Global Variable        ${SSH_MEASUREMENT}  ${EMPTY}
     IF  ${availability}==False
         Log To Console    Power measurement agent IP address not defined. Ignoring all power measurement related keywords.
         RETURN

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -9,11 +9,8 @@ Library             String
 Library             Process
 Library             String
 Library             ../lib/output_parser.py
+Library             ../lib/helper_functions.py
 
-*** Variables ***
-
-${GUI_VM_GHAF_SSH}     ${EMPTY}
-${GUI_VM_USER_SSH}     ${EMPTY}
 
 *** Keywords ***
 
@@ -122,7 +119,7 @@ Connect to netvm
 Connect to VM
     [Documentation]      Connect to any VM or ghaf-host over internal virtual network
     [Arguments]          ${vm_name}    ${user}=${LOGIN}   ${pw}=${PASSWORD}   ${timeout}=60
-    Log To Console       Connecting to ${vm_name} as ${user}...   no_newline=true
+    Log                  Connecting to ${vm_name} as ${user}...   console=True
     Check if ssh is ready on vm        ${vm_name}   ${timeout}
     ${failed_connection}  Set Variable  True
     ${start_time}  Get Time	epoch
@@ -148,7 +145,6 @@ Connect to VM
         BREAK
     END
     IF  ${failed_connection}    FAIL  Couldn't connect ${vm_name}
-
     # Logging in to vm
     ${logged_in}  Set Variable  False
     FOR    ${i}    IN RANGE     5
@@ -159,7 +155,6 @@ Connect to VM
     END
     IF  not ${logged_in}  FAIL  Could not login to ${vm_name} as ${user}.
     Log To Console  Connected and logged in.
-    
     # If connected and logged in successfully
     RETURN  ${connection}
 
@@ -678,34 +673,39 @@ Create test user
     Log To Console      Creating test user
     Execute Command     systemctl start setup-test-user.service  sudo=True  sudo_password=${password}
 
-Switch to gui-vm as ghaf
-    [Documentation]   Switches the ssh connection to the gui-vm using the user account
+Switch to vm
+    [Arguments]         ${hostname}   ${user}=ghaf
 
-    ${status}   Try to switch to active gui-vm connection   ${GUI_VM_GHAF_SSH}   ghaf
-
-    IF   ${status}
-        Log To Console    Switched to gui-vm as ghaf
+    IF  $user=='ghaf'
+        ${pw}   Set Variable    ${PASSWORD}
     ELSE
-        ${GUI_VM_GHAF_SSH}   Connect to VM       ${GUI_VM}
-        Set Global Variable    ${GUI_VM_GHAF_SSH}
+        ${pw}   Set Variable    ${USER_PASSWORD}
     END
 
-Switch to gui-vm as user
-    [Documentation]   Switches the ssh connection to the gui-vm using the ghaf user
+    ${c_hostname}       Convert To Uppercase    ${hostname}
+    ${c_user}           Convert To Uppercase    ${user}
+    ${ssh_connection}   Set Variable    ${c_hostname}_${c_user}_SSH
 
-    ${status}   Try to switch to active gui-vm connection   ${GUI_VM_USER_SSH}   ${USER_LOGIN}
+    ${variable_exists}    Check variable availability     ${ssh_connection}
 
-    IF   ${status}
-        Log To Console    Switched to gui-vm as user
-    ELSE
-        ${GUI_VM_USER_SSH}   Connect to VM       ${GUI_VM}  ${USER_LOGIN}  ${USER_PASSWORD}
-        Set Global Variable    ${GUI_VM_USER_SSH}
+    IF  ${variable_exists}
+
+        ${connection_index}     Set Variable    ${${ssh_connection}}
+        ${status}   Try to switch to active vm connection   ${connection_index}   ${hostname}   ${user}
+
+        IF   ${status}
+            Log    Switched to ${hostname} as ${user}   console=True
+            RETURN
+        END
     END
 
-Try to switch to active gui-vm connection
-    [Arguments]        ${ssh_connection}   ${user} 
+    ${connection_index}      Connect to VM          ${hostname}     ${user}     ${pw}
+    Set Variable By Name     ${ssh_connection}    ${connection_index}
 
-    ${connection_status}  ${new_connection}   Run Keyword And Ignore Error    Switch Connection   ${ssh_connection}
+Try to switch to active vm connection
+    [Arguments]        ${ssh_index}    ${hostname}   ${user}
+
+    ${connection_status}  ${previous_connection}   Run Keyword And Ignore Error    Switch Connection   ${ssh_index}
 
     ${status}   ${output_user}    Run Keyword And Ignore Error   Execute Command    whoami
     Log    ${output_user}
@@ -713,7 +713,7 @@ Try to switch to active gui-vm connection
 
     ${status}   ${output_host}    Run Keyword And Ignore Error   Execute Command    hostname
     Log    ${output_host}
-    ${host_status}    Run Keyword And Return Status    Should Be Equal    ${output_host}    gui-vm
+    ${host_status}    Run Keyword And Return Status    Should Be Equal    ${output_host}    ${hostname}
 
     IF   $connection_status=='FAIL' or not ${user_status} or not ${host_status}
         RETURN   False

--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -107,12 +107,12 @@ Start Display Settings on FMO
 *** Keywords ***
 
 Gui-vm Test Setup
-    Switch to gui-vm as user
+    Switch to vm    gui-vm  user=${USER_LOGIN}
 
 Gui-vm Test Teardown
-    Switch to gui-vm as ghaf
+    Switch to vm    gui-vm
     Kill process        @{APP_PIDS}
-    Switch to gui-vm as user
+    Switch to vm    gui-vm  user=${USER_LOGIN}
     ${app_log}          Execute command    cat output.log
     Log                 ${app_log}
 

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -96,7 +96,7 @@ Start app via GUI on LenovoX1
     Connect to VM       ${app-vm}
     Check that the application was started    ${app}  10  ${exact_match}
 
-    [Teardown]    Run Keywords    Switch to gui-vm as ghaf
+    [Teardown]    Run Keywords    Switch to vm    gui-vm
     ...           AND             Move cursor to corner
 
 Open app menu
@@ -122,7 +122,7 @@ Close app via GUI on LenovoX1
     Connect to netvm
     Connect to VM                             ${app-vm}
     Check that the application was started    ${app}  exact_match=${exact_match}
-    Switch to gui-vm as ghaf
+    Switch to vm    gui-vm
     Log To Console                            Going to click the close button of the application window
     Locate and click                          ${close_button}  0.8  iterations=${iterations}
     Connect to VM                             ${app-vm}
@@ -132,7 +132,7 @@ Close app via GUI on LenovoX1
         # If this window is closed the actual browser window still opens.
         # So need to prepare to close another window in chrome test case.
         IF  '${status}' != 'True'
-            Switch to gui-vm as ghaf
+            Switch to vm    gui-vm
             Locate and click    ${close_button}  0.8  5
             Connect to VM       ${app-vm}
             ${status}           Run Keyword And Return Status  Check that the application is not running  ${app}  5  ${exact_match}
@@ -143,7 +143,7 @@ Close app via GUI on LenovoX1
     END
     # In case closing the app via GUI failed
     [Teardown]     Run Keywords   Connect to VM   ${app-vm}   AND   Kill process   @{APP_PIDS}
-    ...            AND   Switch to gui-vm as ghaf   AND   Move cursor to corner
+    ...            AND   Switch to vm    gui-vm   AND   Move cursor to corner
 
 Start app via GUI on Orin AGX
     [Documentation]    Start Application via GUI test automation and verify related process started

--- a/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
@@ -26,7 +26,7 @@ GUI Suspend and wake up
     Set start timestamp
     # Connect back to gui-vm after power measurement has been started
     Connect to netvm
-    Switch to gui-vm as ghaf
+    Switch to vm    gui-vm
 
     Select power menu option   index=4
 
@@ -89,7 +89,7 @@ GUI Reboot
     END
     Sleep  30
     Connect   iterations=10
-    Switch to gui-vm as ghaf
+    Switch to vm    gui-vm
     Start ydotoold
     Log in, unlock and verify   enable_dnd=True
 
@@ -106,7 +106,7 @@ GUI Log out and log in
 
 GUI Power Test Setup
     Connect to netvm
-    Switch to gui-vm as ghaf
+    Switch to vm    gui-vm
     Log in, unlock and verify
 
 Select power menu option

--- a/Robot-Framework/test-suites/gui-tests/input_control.robot
+++ b/Robot-Framework/test-suites/gui-tests/input_control.robot
@@ -29,7 +29,7 @@ Change keyboard layout
     [Tags]              lenovo-x1   SP-T138
     Check cosmic config current layout value
     Launch Cosmic Term
-    Switch to gui-vm as ghaf
+    Switch to vm    gui-vm
     Type string and press enter                "echo "  enter=False
     Press Key(s)    APOSTROPHE
     Press test key and switch keyboard layout  repeat=3
@@ -58,7 +58,7 @@ Check cosmic config current layout value
     [Documentation]           Check the value of current layout in the xkb_config file.
     ...                       If the current value is not 'us' toggle until it is set to 'us'.
     Log To Console            Checking current keyboard layout
-    Switch to gui-vm as user
+    Switch to vm    gui-vm  user=${USER_LOGIN}
     ${output}  ${rc}=         Execute Command  cat .config/cosmic/com.system76.CosmicComp/v1/xkb_config | grep -w layout  return_rc=True
     # If the keyboard layout has never been toggled the file doesn't exist and command fails with rc 1
     # Then we assume default keyboard layout: 'us'
@@ -68,14 +68,14 @@ Check cosmic config current layout value
         ${current_layout}   Parse keyboard layout  ${output}
         Log                 ${current_layout}   console=True
         ${placement}        Get From List   ${current_layout}   1
-        Switch to gui-vm as ghaf
+        Switch to vm    gui-vm
         FOR   ${i}   IN RANGE  ${placement}
             Sleep   0.5
             Switch keyboard layout
         END
     END
-    [Teardown]    Switch to gui-vm as user
+    [Teardown]    Switch to vm    gui-vm  user=${USER_LOGIN}
 
 Kill gui-vm apps
-    Switch to gui-vm as ghaf
+    Switch to vm    gui-vm
     Kill process        @{APP_PIDS}


### PR DESCRIPTION
Create general keyword which can be used in switching to any vm like Switch to gui-vm as ghaf/user.

Replace Switch to gui-vm as ghaf/user keywords with

`Switch to vm    gui-vm`
and 
`Switch to vm    gui-vm  user=${USER_LOGIN}`


**NOTES:** 

After using `Close All Connections` keyword previously automatically created connection index variables still exist and have some value but the connections related to the indices are lost. So even though `Check variable availability` passes it doesn't ensure that the connection is still active. `Try to switch to active gui-vm connection` is still very important in handling the situations after `Close All Connections`.

I read from Robot Framework documentation that `Switch Connection` actually returns the index of the previous connection not index of the new connection switched to. Thus renamed the variable:
`${connection_status}  ${new_connection}   Run Keyword And Ignore Error    Switch Connection   ${ssh_connection}`
-->
`${connection_status}  ${previous_connection}   Run Keyword And Ignore Error    Switch Connection   ${ssh_index} `


**Regression test run on Dell**
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2403/

Testing vms after adding 
`Library             ../lib/output_parser.py` 
back to `ssh_keywords.resource`
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2409/
