### PR TITLE
Fix Open Image and Open text file

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -284,20 +284,6 @@ Start XDG application
     ${output}        Execute Command  cat output.log
     Log    ${output}
 
-Open Image
-    [Arguments]      ${pic_file}
-    ${output}        Execute Command    cat /run/current-system/sw/share/applications/ghaf-image-xdg.desktop
-    Log              ${output}
-    ${path}          Get App Path From Desktop  ${output}
-    ${xdgopen}       Get Substring      ${path}    0    -3
-    Log To Console   Trying to open ${pic_file}
-    Execute Command  nohup sh -c '${xdgopen} ${pic_file}' > /tmp/out.log 2>&1 &
-
-Open text file
-    [Arguments]      ${text_file}
-    Log To Console   Trying to open ${text_file}
-    ${output}        Execute Command  WAYLAND_DISPLAY=wayland-1 nohup sh -c 'cosmic-edit -f ${text_file}' > /tmp/out.log 2>&1 &
-
 Start Firefox
     [Documentation]  It's needed to set display variable manually because there is no real monitor connected to DUT
     Log To Console  ${\n}Starting Firefox

--- a/Robot-Framework/test-suites/functional-tests/apps.robot
+++ b/Robot-Framework/test-suites/functional-tests/apps.robot
@@ -164,6 +164,7 @@ Open PDF from app-vm
     Connect to VM      ${ZATHURA_VM}
     Check that the application was started    zathura    10
     [Teardown]  Run Keywords  Remove the file in VM    /tmp/test_pdf.pdf    ${vm}    AND
+    ...                       Remove the file in VM    /tmp/out.log         ${vm}    AND
     ...                       Connect to VM      ${ZATHURA_VM}    AND
     ...                       Kill Process And Log journalctl
 
@@ -174,3 +175,17 @@ Open PDF
     ${xdgopen}       Get Substring      ${path}    0    -3
     Log To Console   Trying to open ${pdf_file}
     Execute Command  echo ${PASSWORD} | sudo -S nohup sh -c '${xdgopen} ${pdf_file}' > /tmp/out.log 2>&1 &
+
+Open Image
+    [Arguments]      ${pic_file}
+    ${output}        Execute Command    cat /run/current-system/sw/share/applications/ghaf-image-xdg.desktop
+    Log              ${output}
+    ${path}          Get App Path From Desktop  ${output}
+    ${xdgopen}       Get Substring      ${path}    0    -3
+    Log To Console   Trying to open ${pic_file}
+    Execute Command  nohup sh -c '${xdgopen} ${pic_file}' > /tmp/out.log 2>&1 &
+
+Open text file
+    [Arguments]      ${text_file}
+    Log To Console   Trying to open ${text_file}
+    ${output}        Execute Command  WAYLAND_DISPLAY=wayland-1 nohup sh -c 'cosmic-edit -f ${text_file}' > /tmp/out.log 2>&1 &


### PR DESCRIPTION
After writing to `/tmp/out.log` file as ghaf user in `Open PDF from gui-vm` testuser cannot anymore write to that file because it was created by ghaf with related permissions.

So test cases `Open image with Oculante` and `Open text file with Cosmic Text Editor`
failed if `Open PDF from gui-vm` was run first.

Fixing this by removing `/tmp/out.log` file in the
Teardown of `Open PDF from gui-vm`.

This is something to be aware of in the future also since many tests leave out.log / output.log files hanging around in multiple vms of ghaf. However, the problem activated only in gui-vm since we don't use multiple users in other vms. Also test cases in gui-apps.robot could have failed but the thing that saved them is that they write stdout to different file (by `Start XDG application`): `output.log` in current path, not to `/tmp/out.log`.

Moved also keywords `Open Image` and `Open text file`
from ssh_keywords.resource to apps.robot.