### PR TITLE
Add support for FMO target

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -57,6 +57,7 @@ Set Variables
     Set Global Variable  ${BUSINESS_VM}        business-vm
     Set Global Variable  ${CHROME_VM}          chrome-vm
     Set Global Variable  ${COMMS_VM}           comms-vm
+    Set Global Variable  ${DOCKER_VM}          docker-vm
     Set Global Variable  ${GALA_VM}            gala-vm
     Set Global Variable  ${GUI_VM}             gui-vm
     Set Global Variable  ${ZATHURA_VM}         zathura-vm

--- a/Robot-Framework/test-suites/functional-tests/docker-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/docker-vm.robot
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Settings ***
+Documentation       Testing Docker VM (FMO target)
+Force Tags          bat  regression  docker-vm  fmo
+Resource            ../../config/variables.robot
+Resource            ../../resources/common_keywords.resource
+Resource            ../../resources/ssh_keywords.resource
+Test Setup          Docker Apps Test Setup
+Test Teardown       Docker Apps Test Teardown
+
+
+*** Test Cases ***
+
+Start FMO Onboarding Agent
+    [Documentation]   Start FMO Onboarding Agent in docker-vm and verify process started
+    [Tags]            onboarding
+    Start XDG application   "FMO Onboarding Agent"
+    Connect to VM       ${DOCKER_VM}
+    Check that the application was started    fmo-onboarding
+
+Start FMO Offboarding
+    [Documentation]   Start FMO Offboarding Agent in docker-vm and verify process started
+    [Tags]            offboarding
+    Start XDG application   "FMO Offboarding"
+    Connect to VM       ${DOCKER_VM}
+    Check that the application was started    fmo-offboarding
+
+
+*** Keywords ***
+
+Docker Apps Test Setup
+    Connect to netvm
+    Connect to VM       ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
+
+Docker Apps Test Teardown
+    Kill process       @{APP_PIDS}
+    Close All Connections

--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       Testing Gui-vm
-Force Tags          gui-vm   regression   lenovo-x1   dell-7330
+Force Tags          gui-vm   regression
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../config/variables.robot
 Resource            ../../resources/common_keywords.resource
@@ -19,54 +19,54 @@ Test Teardown       Gui-vm Test Teardown
 *** Test Cases ***
 Start Calculator on LenovoX1
     [Documentation]   Start Calculator and verify process started
-    [Tags]            bat   pre-merge  calculator  SP-T202
+    [Tags]            bat   pre-merge  calculator  SP-T202  lenovo-x1  dell-7330  fmo
     Start XDG application  Calculator  gui_vm_app=true
     Check that the application was started    calculator
 
 Start Sticky Notes on LenovoX1
     [Documentation]   Start Sticky Notes and verify process started
-    [Tags]            bat   pre-merge  sticky_notes  SP-T201-1
+    [Tags]            bat   pre-merge  sticky_notes  SP-T201-1  lenovo-x1  dell-7330  fmo
     Start XDG application  'Sticky Notes'  gui_vm_app=true
     Check that the application was started    sticky-wrapped
 
 Start Ghaf Control Panel on LenovoX1
     [Documentation]   Start Ghaf Control Panel and verify process started
-    [Tags]            bat   pre-merge  control_panel  SP-T205
+    [Tags]            bat   pre-merge  control_panel  SP-T205  lenovo-x1  dell-7330  fmo
     Start XDG application  'Ghaf Control Panel'  gui_vm_app=true
     Check that the application was started    ctrl-panel
 
 Start Bluetooth Settings on LenovoX1
     [Documentation]   Start Bluetooth Settings and verify process started
-    [Tags]            bat   pre-merge  bluetooth_settings  SP-T204
+    [Tags]            bat   pre-merge  bluetooth_settings  SP-T204  lenovo-x1  dell-7330  fmo
     Start XDG application  'Bluetooth Settings'  gui_vm_app=true
     Check that the application was started    blueman-manager-wrapped-wrapped
 
 Start COSMIC Files on LenovoX1
     [Documentation]   Start Cosmic Files and verify process started
-    [Tags]            bat   pre-merge  cosmic_files  SP-T206
+    [Tags]            bat   pre-merge  cosmic_files  SP-T206  lenovo-x1  dell-7330  fmo
     Start XDG application  com.system76.CosmicFiles  gui_vm_app=true
     Check that the application was started    cosmic-files %U  exact_match=true
 
 Start COSMIC Settings on LenovoX1
     [Documentation]   Start Cosmic Settings and verify process started
-    [Tags]            bat   pre-merge  cosmic_settings  SP-T254
+    [Tags]            bat   pre-merge  cosmic_settings  SP-T254  lenovo-x1  dell-7330  fmo
     Start XDG application  com.system76.CosmicSettings  gui_vm_app=true
     Check that the application was started    cosmic-settings  exact_match=true
 
 Start COSMIC Text Editor on LenovoX1
     [Documentation]   Start Cosmic Text Editor and verify process started
-    [Tags]            bat   pre-merge  cosmic_editor  SP-T243
+    [Tags]            bat   pre-merge  cosmic_editor  SP-T243  lenovo-x1  dell-7330  fmo
     Start XDG application   com.system76.CosmicEdit  gui_vm_app=true
     Check that the application was started    cosmic-edit %F  exact_match=true
 
 Start COSMIC Terminal on LenovoX1
     [Documentation]   Start Cosmic Terminal and verify process started
-    [Tags]            bat   cosmic_term  SP-T263
+    [Tags]            bat   cosmic_term  SP-T263  lenovo-x1   dell-7330  fmo
     Launch Cosmic Term
 
 Start Falcon AI on LenovoX1
     [Documentation]   Start Falcon AI and verify process started
-    [Tags]            falcon_ai  SP-T223-1
+    [Tags]            falcon_ai  SP-T223-1  lenovo-x1   dell-7330
     Get Falcon LLM Name
     Start XDG application  'Falcon AI'
     Wait Until Falcon Download Complete
@@ -78,13 +78,31 @@ Start Falcon AI on LenovoX1
 
 Check user systemctl status
     [Documentation]   Verify systemctl status --user is running
-    [Tags]            bat   SP-T260
+    [Tags]            bat   SP-T260  lenovo-x1   dell-7330  fmo
     ${known_issues}=    Create List
     ...    Dell|hidpi-auto-scaling.service|SSRCSP-6697
     ...    Lenovo|hidpi-auto-scaling.service|SSRCSP-6697
     Verify Systemctl status    range=3   user=True
 
     [Teardown]   Run Keyword If Test Failed   Check systemctl status for known issues  ${known_issues}  ${failed_units}
+
+Start Firefox GPU on FMO
+    [Documentation]   Start Firefox GPU and verify process started
+    [Tags]            bat   firefox_gpu  fmo
+    Start XDG application  'Firefox GPU'  gui_vm_app=true
+    Check that the application was started    firefox
+
+Start Google Chrome GPU on FMO
+    [Documentation]   Start Google Chrome GPU and verify process started
+    [Tags]            bat   chrome_gpu  fmo
+    Start XDG application  'Google Chrome GPU'  gui_vm_app=true
+    Check that the application was started    chrome
+
+Start Display Settings on FMO
+    [Documentation]   Start Display Settings and verify process started
+    [Tags]            bat   display_settings  fmo
+    Start XDG application  'Display Settings'  gui_vm_app=true
+    Check that the application was started    wdisplays
 
 *** Keywords ***
 

--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -16,13 +16,13 @@ Suite Teardown      Close All Connections
 Test ghaf version format
     [Documentation]    Test getting Ghaf version and verify its format:
     ...                Expected format: major.minor.yyyymmdd.commit_hash
-    [Tags]             SP-T54  nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1   dell-7330
+    [Tags]             SP-T54  nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1   dell-7330  fmo
     Verify Ghaf Version Format
 
 Test nixos version format
     [Documentation]    Test getting Nixos version and verify its format:
     ...                Expected format: major.minor.yyyymmdd.commit_hash (name)
-    [Tags]             SP-T55  nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1   dell-7330
+    [Tags]             SP-T55  nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1   dell-7330  fmo
     Verify Nixos Version Format
 
 Check QSPI version
@@ -32,7 +32,7 @@ Check QSPI version
 
 Check systemctl status
     [Documentation]    Verify systemctl status is running on host
-    [Tags]             SP-T98  nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1   dell-7330
+    [Tags]             SP-T98  nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1   dell-7330  fmo
     ${status}   ${output}   Run Keyword And Ignore Error    Verify Systemctl status
     Log   ${output}
 
@@ -51,7 +51,7 @@ Check systemctl status
 
 Check all VMs are running
     [Documentation]    Check that all VMs are running.
-    [Tags]             SP-T68  lenovo-x1   dell-7330
+    [Tags]             SP-T68  lenovo-x1   dell-7330  fmo
     ${output}   Execute Command    microvm -l
     @{vms}      Extract VM names   ${output}
     Should Not Be Empty   ${vms}  VM list is empty

--- a/Robot-Framework/test-suites/functional-tests/netvm.robot
+++ b/Robot-Framework/test-suites/functional-tests/netvm.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       Testing Network VM
-Force Tags          netvm
+Force Tags          netvm  bat regression  
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/virtualization_keywords.resource
 Resource            ../../resources/connection_keywords.resource
@@ -21,7 +21,7 @@ ${NETVM_SSH}       ${EMPTY}
 
 Verify NetVM is started
     [Documentation]         Verify that NetVM is active and running
-    [Tags]                  bat  regression  SP-T45  nuc  orin-agx  orin-agx-64  orin-nx  lenovo-x1   dell-7330
+    [Tags]                  SP-T45  nuc  orin-agx  orin-agx-64  orin-nx  lenovo-x1   dell-7330  fmo
     [Setup]                 Connect to ghaf host
     Verify service status   service=${netvm_service}
     Check Network Availability      ${NETVM_IP}    expected_result=True    range=5
@@ -29,7 +29,7 @@ Verify NetVM is started
 
 Wifi passthrough into NetVM (Orin-AGX)
     [Documentation]     Verify that wifi works inside netvm
-    [Tags]              bat  regression  SP-T111  orin-agx  orin-agx-64
+    [Tags]              SP-T111  orin-agx  orin-agx-64
     [Setup]             Connect to netvm
     Configure wifi      ${NETVM_SSH}  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Get wifi IP
@@ -45,7 +45,7 @@ Wifi passthrough into NetVM (Orin-AGX)
 
 Wifi passthrough into NetVM (Lenovo-X1)
     [Documentation]     Verify that wifi works inside netvm
-    [Tags]              bat  regression  SP-T101   lenovo-x1   dell-7330
+    [Tags]              SP-T101   lenovo-x1   dell-7330
     [Setup]             Connect to netvm
     Configure wifi      ${NETVM_SSH}  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Get wifi IP
@@ -61,7 +61,7 @@ Wifi passthrough into NetVM (Lenovo-X1)
 
 Wifi passthrough into NetVM (NUC)
     [Documentation]     Verify that wifi works inside netvm
-    [Tags]              bat  regression   SP-T111  nuc
+    [Tags]              SP-T111  nuc
     [Setup]             Connect to netvm
     Configure wifi via wpa_supplicant      ${netvm_ssh}  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Check Network Availability    8.8.8.8   expected_result=True
@@ -71,14 +71,14 @@ Wifi passthrough into NetVM (NUC)
 
 NetVM stops and starts successfully
     [Documentation]     Verify that NetVM stops properly and starts after that
-    [Tags]              bat  regression  SP-T47  SP-T90  nuc  orin-agx  orin-agx-64
+    [Tags]              SP-T47  SP-T90  nuc  orin-agx  orin-agx-64
     [Setup]             Connect to ghaf host
     Restart NetVM
     [Teardown]          Run Keywords  Start NetVM if dead   AND  Close All Connections
 
 NetVM is wiped after restarting
     [Documentation]     Verify that created file will be removed after restarting VM
-    [Tags]              bat  regression  SP-T48  nuc  orin-agx  orin-agx-64
+    [Tags]              SP-T48  nuc  orin-agx  orin-agx-64
     [Setup]             Connect to netvm
     Create file         /etc/test.txt
     Switch Connection   ${GHAF_HOST_SSH}
@@ -94,7 +94,7 @@ NetVM is wiped after restarting
 
 Verify NetVM PCI device passthrough
     [Documentation]     Verify that proper PCI devices have been passed through to the NetVM
-    [Tags]              bat  regression  SP-T96  nuc  orin-agx  orin-agx-64  orin-nx
+    [Tags]              SP-T96  nuc  orin-agx  orin-agx-64  orin-nx
     [Setup]             Connect to netvm
     Verify microvm PCI device passthrough    vmname=${NET_VM}
     [Teardown]          Run Keywords  Close All Connections   AND

--- a/Robot-Framework/test-suites/functional-tests/timesync.robot
+++ b/Robot-Framework/test-suites/functional-tests/timesync.robot
@@ -27,7 +27,7 @@ Time synchronization
     ...                      -Net-vm is not connected to net.
     ...                  - Ghaf-host is connected to net via Net-VM if adapter is used!.
     ...                  - In this test we expect adapter is not used -> Set Wi-Fi ON to enable net-vm to address net.
-    [Tags]            bat  regression   SP-T97   nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1   dell-7330
+    [Tags]            bat  regression   SP-T97   nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1   dell-7330  fmo
 
     IF  "AGX" in "${DEVICE}"  Set Wifi passthrough into NetVM
 


### PR DESCRIPTION
- Add support for running tests on FMO targets with the tag `fmo`
- Modify VM tests so that they first get the list of VMs that are running in the system and then run the tests for those VMs.

[Testrun on FMO Lenovo-X1](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2361/)
[Testrun on normal Lenovo-X1](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/2365/) with fmoANDlenovo-x1 tag