### PR TITLE
Update suspension test

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -125,11 +125,6 @@ Log versions
     ${nixos_version}    Execute Command   nixos-version
     Log To Console      Nixos version: ${nixos_version}
 
-Get mako path
-    ${output}            Execute Command     ls /nix/store | grep mako | grep -v .drv
-    ${result}            Extract mako path   ${output}
-    Set Global Variable  ${MAKO_PATH}    ${result}
-
 Get Falcon LLM Name
     ${output}            Execute Command     cat '/run/current-system/sw/share/applications/Falcon AI.desktop'
     ${line}              Get Lines Containing String  ${output}  Exec=

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -60,6 +60,8 @@ Log out and verify
     IF  ${disable_dnd}   Set do not disturb state   false
     ${logout_status}      Check if logged out    1
     IF  not ${logout_status}
+        ${lock}       Check if locked
+        IF  ${lock}   Unlock
         Log out via GUI
         ${logout_status}  Check if logged out
         IF  not ${logout_status}    FAIL  Failed to log out.
@@ -286,6 +288,13 @@ Stop swayidle
     Execute Command   systemctl --user stop swayidle
     [Teardown]    Switch to vm    gui-vm
 
+Start swayidle
+    [Documentation]    Start swayidle to allow automatic suspension
+    Log To Console    Enabling automated lock and suspend
+    Switch to vm    gui-vm  user=${USER_LOGIN}
+    Execute Command   systemctl --user start swayidle
+    [Teardown]    Switch to vm    gui-vm
+
 Set do not disturb state
     [Documentation]   Set do not disturb to true or false
     [Arguments]       ${state}
@@ -296,9 +305,10 @@ Set do not disturb state
 
 Get screen brightness
     [Documentation]   Get and return current brightness value
+    [Arguments]       ${log_brightness}=True
     ${output}         Execute Command    ls /nix/store | grep brightnessctl | grep -v .drv
     ${brightness}     Execute Command    /nix/store/${output}/bin/brightnessctl get
-    Log To Console    Brightness is ${brightness}
+    IF  ${log_brightness}    Log To Console    Brightness is ${brightness}
     RETURN            ${brightness}
 
 Get gui-vm user journalctl log

--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -116,54 +116,6 @@ Gui-vm Test Teardown
     ${app_log}          Execute command    cat output.log
     Log                 ${app_log}
 
-Check If Download Reached 100
-    ${notifications}  Execute Command  /nix/store/${MAKO_PATH}/bin/makoctl list
-    ${notifications}  Parse notifications    ${notifications}
-
-    ${count}=    Get Length    ${notifications}
-    Should Be True    ${count} > 0    No notifications received at all
-
-    FOR    ${key}     ${value}    IN    &{notifications}
-        ${status}     Run Keyword And Return Status    Should Contain    ${value}    Downloading Falcon 3
-        IF    ${status}
-            ${percentage}    Get Percentage    ${value}
-            Log To Console   Current percentage: ${percentage}%
-            Should Be Equal As Integers    ${percentage}    100
-            BREAK
-        END
-    END
-
-Get Percentage
-    [Arguments]       ${text}
-    ${match_status}   ${match_msg}    Run Keyword And Ignore Error    Should Match Regexp    ${text}    .*?(\\d+)%.*?
-    IF  '${match_status}' == 'PASS'
-        ${percent}    Set Variable    ${match_msg}[1]
-        Log           Current percentage: ${percent}%
-    END
-    Should Not Be Empty  ${percent}   Could not find percent in text: ${text}
-    RETURN            ${percent}
-
-Wait Until Download Is 100 Percent
-    Wait Until Keyword Succeeds    420s    5s    Check If Download Reached 100
-
-Check If Download Completed
-    ${notifications}  Execute Command  /nix/store/${MAKO_PATH}/bin/makoctl history
-    ${notifications}  Parse notifications    ${notifications}
-
-    ${completed}      Set Variable  ${False}
-    FOR    ${key}     ${value}    IN    &{notifications}
-        ${status}     Run Keyword And Return Status    Should Contain    ${value}    Download complete
-        IF    ${status}
-            Log To Console    Falcon download completed
-            ${completed}      Set Variable    ${True}
-            BREAK
-        END
-    END
-
-    IF  not ${completed}
-        Fail    No notifications contained 'Download complete'
-    END
-
 Wait Until Falcon Download Complete
     FOR  ${i}  IN RANGE   100
         ${output}          Execute Command  ollama list

--- a/Robot-Framework/test-suites/suspension-test/__init__.robot
+++ b/Robot-Framework/test-suites/suspension-test/__init__.robot
@@ -6,5 +6,5 @@ Documentation       Suspension test
 Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../config/variables.robot
-Suite Setup         Set Variables   ${DEVICE}
-Suite Teardown      Close All Connections
+Suite Setup         Prepare Test Environment
+Suite Teardown      Clean Up Test Environment


### PR DESCRIPTION
**Changes**
- Adapt suspension test case to https://github.com/tiiuae/ghaf/pull/1270 (The screen now turns off again after 7.5 minutes, brightness might not be at 100% after boot/login).
- Start to use `switch to vm` in suspension tests.
- Remove the reboot from the suspension test setup. With Cosmic there should be no need to reboot.
- Remove some dead code related to Mako.

**Testrun**
- [Lenovo-X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/35/) suspension & falcon