### PR TITLE
Use more general term "laptop" instead of "Lenovo-X1"

### DIFF
--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -28,7 +28,7 @@ Reboot Device Via Relay
     Log To Console    Turning device on...
     Turn Relay On     ${RELAY_NUMBER}
 
-Reboot LenovoX1
+Reboot Laptop
     [Arguments]       ${delay}=20
     [Documentation]   Turn off the laptop by pressing power button for 10 sec turn on by short pressing power button
     Log To Console    ${\n}Turning device off...

--- a/Robot-Framework/test-suites/boot-test/boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/boot_test.robot
@@ -40,10 +40,10 @@ Verify booting after restart by power
     END
     [Teardown]   Teardown
 
-Verify booting LenovoX1
-    [Documentation]    Restart LenovoX1 by power and verify init service is running
+Verify booting laptop
+    [Documentation]    Restart laptop by power and verify init service is running
     [Tags]             boot  plug  lenovo-x1   dell-7330
-    Reboot LenovoX1
+    Reboot Laptop
     Check If Device Is Up
     IF    ${IS_AVAILABLE} == False
         FAIL    The device did not start

--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -42,10 +42,10 @@ Verify booting after restart by power
     END
     [Teardown]   Test Teardown
 
-Verify booting LenovoX1
-    [Documentation]    Restart LenovoX1 by power and verify init service is running
+Verify booting laptop
+    [Documentation]    Restart the laptop by power and verify init service is running
     [Tags]             relayboot  plug  lenovo-x1   dell-7330
-    Reboot LenovoX1
+    Reboot Laptop
     Check If Device Is Up
     IF    ${IS_AVAILABLE} == False
         FAIL    The device did not start

--- a/Robot-Framework/test-suites/performance-tests/ballooning.robot
+++ b/Robot-Framework/test-suites/performance-tests/ballooning.robot
@@ -137,7 +137,7 @@ Ballooning Test Teardown
     [Documentation]    If test gets stucked, reboot device and connect to netvm (the next test can be executed).
     ...                After reboot, the artifacts should be not existing, so no need to clean.
     Run Keyword If Timeout Occurred  Run Keywords
-    ...        Reboot LenovoX1
+    ...        Reboot Laptop
     ...  AND   Connect to netvm
 
     Run Keyword If Test Passed  Clean Test Artifacts

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -269,16 +269,6 @@ Perf-Bench test
 
 *** Keywords ***
 
-LenovoX1 Setup
-    [Documentation]    Reboot LenovoX1
-    Reboot LenovoX1
-    ${port_22_is_available}     Check if ssh is ready on device   timeout=180
-    IF  ${port_22_is_available} == False
-        FAIL    Failed because port 22 of device was not available, tests can not be run.
-    END
-    Connect
-    ${output}          Execute Command    ssh-keygen -R ${NETVM_IP}
-
 Transfer FileIO Test Script To DUT
     Put File           performance-tests/fileio_test    /tmp
     Execute Command    chmod 777 /tmp/fileio_test


### PR DESCRIPTION
Replace word "Lenovo-X1" with "laptop" in those cases where it should apply both to lenovo-x1 and dell targets.

Remove one unused keyword.

Test runs on Dell
https://ci-dev.vedenemo.dev/job/ghaf-hw-test/131/
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/134/