### PR TITLE
Update systemctl skips

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -79,9 +79,10 @@ Start Falcon AI on LenovoX1
 Check user systemctl status
     [Documentation]   Verify systemctl status --user is running
     [Tags]            bat   SP-T260  lenovo-x1   dell-7330  fmo
+
     ${known_issues}=    Create List
-    ...    Dell|hidpi-auto-scaling.service|SSRCSP-6697
-    ...    Lenovo|hidpi-auto-scaling.service|SSRCSP-6697
+    # Add any known failing services here with the target device and bug ticket number.
+    # ...    device|service-name|ticket-number
     Verify Systemctl status    range=3   user=True
 
     [Teardown]   Run Keyword If Test Failed   Check systemctl status for known issues  ${known_issues}  ${failed_units}

--- a/Robot-Framework/test-suites/functional-tests/vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/vm.robot
@@ -34,9 +34,7 @@ Check systemctl status in every VM
     ${failed_new_services}=    Create List
     ${failed_old_services}=    Create List
     ${known_issues}=    Create List
-    ...    ANY|systemd-oomd.service|SSRCSP-6682
-    ...    ANY|persist-storage-dirs.service|SSRCSP-6682
-    ...    gui-vm|setup-ghaf-user.service|SSRCSP-6682
+    ...    gui-vm|setup-ghaf-user.service|SSRCSP-6858
 
     FOR  ${vm}  IN  @{VM_LIST}
         Connect to VM    ${vm}

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -7,9 +7,8 @@
 | 27.06.2025 | Measure UDP Bidir Throughput Small Packets (Dell) | SSRCSP-6774                                                                                     |
 | 17.06.2025 | Start and close Google Chrome via GUI on LenovoX1 | SSRCSP-6716                                                                                     |
 | 13.06.2025 | Record Video With Camera (Dell)                   | SSRCSP-6694                                                                                     |
-| 06.06.2025 | Check user systemctl status (X1 and Dell)         | SSRCSP-6697                                                                                     |
 | 05.06.2025 | Measure UDP Bidir Throughput Big Packets(AGX)     | SSRCSP-6623                                                                                     |
-| 02.06.2025 | Check systemctl status in every VM                | [Full list of skips in the test case](/Robot-Framework/test-suites/functional-tests/vm.robot)   |
+| 02.06.2025 | Check systemctl status in every VM                | SSRCSP-6858                                                                                     |
 | 27.05.2025 | TimeSynch (AGX)                                   | SSRCSP-6423. Unrecoverable error detected. #PR333                                               |
 |            | Measure Hard Boot Time                            | The searched journalctl line is sometimes (randomly) not there. Didn't find it this time        |
 |            | Measure Soft Boot Time -Dell                      | The searched journalctl line is sometimes (randomly) not there. Didn't find it this time.       |
@@ -28,4 +27,4 @@
 | 08.05.2025 | GUI Reboot                            | The X1 in the lab gets stuck when a reboot is attempted. Needs further investigation.     |
 | 08.05.2025 | GUI Suspend and wake up               | The X1 in the lab gets stuck when a suspension is attempted. Needs further investigation. |
 | 03/2025    | Performance Network.robot - ‘orin-nx’ | SSRCSP-6372 - Works locally but problems when Jenkins used, fails all..                   |
-| 22.1.2025  | Start Firefox - ‘nuc, orin-agx        | Firefox is temporarily disabled from SW                                                   |
+| 22.01.2025 | Start Firefox - ‘nuc, orin-agx        | Firefox is temporarily disabled from SW                                                   |


### PR DESCRIPTION
- `hidpi-auto-scaling.service` was only present on Labwc, no skip needed anymore
- `systemd-oomd.service` and `persist-storage-dirs.service` are no longer failing after https://github.com/tiiuae/ghaf/pull/1261
- `setup-ghaf-user.service` ticket number updated

**Testruns**
[Lenovo-X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/186/)
[Dell-7330](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/185/)