### PR TITLE
Change gui-vm log to be a txt file

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -314,7 +314,7 @@ Get screen brightness
 
 Get gui-vm user journalctl log
     [Setup]      Switch to vm    gui-vm  user=${USER_LOGIN}
-    Get user journalctl log   gui-vm-user.log
+    Get user journalctl log   gui-vm-user.txt
     [Teardown]   Switch to vm    gui-vm
 
 Switch keyboard layout


### PR DESCRIPTION
`.log` file was not getting copied correctly from the test agent.

Tested in dev by changing
`${APP_MENU_LAUNCHER}   ./launcher.png` -> `${APP_MENU_LAUNCHER}   ./search.png`
in gui_keywords.resource

https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/196/