### PR TITLE
Rearrange resources, clean settings

### DIFF
--- a/Robot-Framework/__framework__.resource
+++ b/Robot-Framework/__framework__.resource
@@ -1,7 +1,0 @@
-*** Settings ***
-Library  Collections
-Library  OperatingSystem
-Library  Process
-Library  String
-Library  XML
-Library  DateTime

--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -3,6 +3,8 @@
 
 *** Settings ***
 Library    OperatingSystem
+Library    Process
+Library    String
 
 
 *** Variables ***

--- a/Robot-Framework/lib/output_parser.py
+++ b/Robot-Framework/lib/output_parser.py
@@ -263,31 +263,6 @@ def extract_vm_names(output):
     vm_names = [line.split(':')[0] for line in lines if line]
     return vm_names
 
-def extract_mako_path(output):
-    pattern = "(?m)^[a-z0-9-]+-mako-[\d.]+$"
-    match = re.search(pattern, output)
-    if match:
-        return match.group(0)
-    else:
-        print(f"Couldn't find mako path with pattern {pattern}")
-        return None
-
-def get_last_mako_notification_id(output):
-    pattern = r"Notification\s+(\d+):"
-    matches = re.findall(pattern, output, re.MULTILINE)
-    if matches:
-        max_id = max(int(id_str) for id_str in matches)
-        return max_id
-    else:
-        print(f"Couldn't find last notification id with pattern {pattern}")
-        return None
-
-def parse_notifications(text):
-    pattern = r"Notification\s+(\d+):\s+([^\n]+)"
-    matches = re.findall(pattern, text)
-    notifications_dict = {int(num): msg for num, msg in matches}
-    return notifications_dict
-
 def parse_services_to_list(output):
     match = re.search(r"\[([^\]]+)\]", output)
     if not match:

--- a/Robot-Framework/resources/app_keywords.resource
+++ b/Robot-Framework/resources/app_keywords.resource
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Settings ***
+Library             ../lib/output_parser.py
+Resource            ../resources/file_keywords.resource
+Resource            ../resources/ssh_keywords.resource
+
+
+*** Keywords ***
+
+Start XDG application
+    [Arguments]      ${app_name}  ${gui_vm_app}=false
+    Log To Console   ${\n}Starting ${app_name}
+    ${app_name}      Check application name  ${app_name}
+    ${output}        Execute Command    cat /run/current-system/sw/share/applications/${app_name}.desktop
+    ${path}          Get App Path From Desktop  ${output}
+    IF  $gui_vm_app
+        Execute Command  nohup sh -c 'WAYLAND_DISPLAY=wayland-1 ${path}' > output.log 2>&1 &
+    ELSE
+        Execute Command  nohup sh -c '${path}' > output.log 2>&1 &
+    END
+
+Check that the application was started
+    [Arguments]          ${app_name}  ${range}=2  ${exact_match}=false
+    FOR   ${i}   IN RANGE  ${range}
+        @{found_pids}        Find pid by name    ${app_name}  ${exact_match}
+        Set Global Variable  @{APP_PIDS}  @{found_pids}
+        ${status}    Run Keyword And Return Status   Should Not Be Empty  ${APP_PIDS}
+        IF    ${status}    BREAK
+        Sleep   1
+    END
+    Should Not Be Empty  ${APP_PIDS}  ${app_name} is not started
+    Log To Console       ${app_name} is started
+
+Check that the application is not running
+    [Arguments]          ${app_name}  ${range}=2  ${exact_match}=false
+    ${pids}=  Set Variable  ${EMPTY}
+    FOR   ${i}   IN RANGE  ${range}
+        ${keyword_status}  ${pids}  Run Keyword And Ignore Error   Find pid by name    ${app_name}  ${exact_match}
+        Set Global Variable  @{APP_PIDS}  @{pids}
+        ${status}    Run Keyword And Return Status   Should Be Empty  ${pids}
+        IF    ${status}    BREAK
+        Sleep   1
+    END
+    Should Be Empty   ${pids}   ${app_name} is still running
+    Log To Console    ${app_name} not running
+
+Launch Cosmic Term
+    Start XDG application   com.system76.CosmicTerm  gui_vm_app=true
+    Check that the application was started    cosmic-term  exact_match=true
+
+Log and remove app output
+    [Documentation]    Specify the VM from which the app was started and the user (the owner of the file)
+    [Arguments]   ${file}    ${vm}    ${user}=ghaf
+    Switch to vm  ${vm}    ${user}
+    ${output}     Execute Command    cat ${file}
+    Log           ${output}
+    Remove file   ${file}    user=${user}
+
+Log app vm journalctl
+    [Documentation]    Specify the VM where the App is actually running
+    [Arguments]   ${vm}
+    Switch to vm  ${vm}
+    ${output}     Execute Command    journalctl
+    Log           ${output}
+
+Get Falcon LLM Name
+    ${output}            Execute Command     cat '/run/current-system/sw/share/applications/Falcon AI.desktop'
+    ${line}              Get Lines Containing String  ${output}  Exec=
+    ${path}              Set Variable  ${line[5:]}
+    ${llm_name_raw}      Execute Command  cat ${path} | grep LLM_NAME | head -n 1
+    # LLM_NAME="falcon3:10b" -> falcon3:10b
+    ${tmp}               Fetch From Right  ${llm_name_raw}  =
+    ${LLM_NAME}          Set Variable  ${tmp[1:-1]}
+    Set Global Variable  ${LLM_NAME}
+
+Check application name
+    [Documentation]  Check written format of application
+    [Arguments]  ${app_name}
+    ${app_name}  Strip String  ${app_name}  characters="'
+    ${output}    Execute Command    ls /run/current-system/sw/share/applications/
+    ${app}       Get Regexp Matches  ${output}  (?im)${app_name}
+    RETURN  '${app}[0]'

--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -2,142 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***
-Resource            ../config/variables.robot
-Resource            ../resources/gui_keywords.resource
-Resource            ../resources/connection_keywords.resource
 Library             ../lib/output_parser.py
+Library             Collections
 
 
 *** Keywords ***
-
-Prepare Test Environment
-    [Arguments]    ${stop_swayidle}=True   ${enable_dnd}=False
-    Initialize Variables And Connect
-    Log versions
-    Run journalctl recording
-
-    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Switch to vm    gui-vm
-        Save most common icons and paths to icons
-        Create test user
-        Start ydotoold
-        Log in, unlock and verify   ${stop_swayidle}   ${enable_dnd}
-    END
-
-Clean Up Test Environment
-    [Arguments]   ${disable_dnd}=False
-    Connect to ghaf host
-    Log journalctl
-    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Switch to vm    gui-vm
-        Start ydotoold
-        Log out and verify   ${disable_dnd}
-        Stop ydotoold
-    END
-    Close All Connections
-
-Check that the application was started
-    [Arguments]          ${app_name}  ${range}=2  ${exact_match}=false
-    FOR   ${i}   IN RANGE  ${range}
-        @{found_pids}        Find pid by name    ${app_name}  ${exact_match}
-        Set Global Variable  @{APP_PIDS}  @{found_pids}
-        ${status}    Run Keyword And Return Status   Should Not Be Empty  ${APP_PIDS}
-        IF    ${status}    BREAK
-        Sleep   1
-    END
-    Should Not Be Empty  ${APP_PIDS}  ${app_name} is not started
-    Log To Console       ${app_name} is started
-
-Check that the application is not running
-    [Arguments]          ${app_name}  ${range}=2  ${exact_match}=false
-    ${pids}=  Set Variable  ${EMPTY}
-    FOR   ${i}   IN RANGE  ${range}
-        ${keyword_status}  ${pids}  Run Keyword And Ignore Error   Find pid by name    ${app_name}  ${exact_match}
-        Set Global Variable  @{APP_PIDS}  @{pids}
-        ${status}    Run Keyword And Return Status   Should Be Empty  ${pids}
-        IF    ${status}    BREAK
-        Sleep   1
-    END
-    Should Be Empty   ${pids}   ${app_name} is still running
-    Log To Console    ${app_name} not running
-
-Check If Ping Fails
-    [Documentation]  Check that ping is not getting response from host
-    ${result}  Run Process  ping  ${DEVICE_IP_ADDRESS}  -c1  timeout=1s
-    Should Not Be Equal   ${result.rc}  ${0}
-
-Run journalctl recording
-    ${output}     Execute Command    nohup journalctl -f >> /tmp/jrnl.txt 2>&1 &
-
-Log journalctl
-    ${jrnl_size}  Execute Command    ls -lh /tmp/jrnl.txt
-    Log           ${jrnl_size}
-    # Copy journal log file to Robot outputs
-    SSHLibrary.Get file   /tmp/jrnl.txt   ${OUTPUT_DIR}/jrnl.txt
-    OperatingSystem.File Should Exist     ${OUTPUT_DIR}/jrnl.txt
-    @{pid}        Find pid by name   journalctl
-    Kill process  @{pid}
-
-Get user journalctl log
-    [Arguments]   ${filename}
-    Execute Command    journalctl --user > /tmp/${filename}
-    SSHLibrary.Get file   /tmp/${filename}   ${OUTPUT_DIR}/${filename}
-    OperatingSystem.File Should Exist     ${OUTPUT_DIR}/${filename}
-
-Check If Device Is Up
-    [Arguments]    ${range}=20
-    Set Global Variable    ${IS_AVAILABLE}       False
-    ${start_time}=    Get Time	epoch
-    FOR    ${i}    IN RANGE    ${range}
-        ${ping}=    Ping Host   ${DEVICE_IP_ADDRESS}
-        IF    ${ping}
-            Log To Console    Ping ${DEVICE_IP_ADDRESS} successful
-            BREAK
-        END
-        Sleep  1
-    END
-
-    IF    ${ping}
-        ${port_22_is_available}     Check if ssh is ready on device
-        IF  ${port_22_is_available}
-            Set Global Variable    ${IS_AVAILABLE}       True
-        ELSE
-            Set Global Variable    ${IS_AVAILABLE}       False
-        END
-    END
-
-    ${diff}=    Evaluate    int(time.time()) - int(${start_time})
-
-    IF  ${IS_AVAILABLE}    Log To Console    Device woke up after ${diff} sec.
-
-    IF  ${IS_AVAILABLE} == False
-        Log To Console    Device is not available after reboot via SSH, waited for ${diff} sec!
-        IF  "${SERIAL_PORT}" == "NONE"
-            Log To Console    There is no address for serial connection
-        ELSE
-            Check Serial Connection
-        END
-    END
-
-Log versions
-    ${ghaf_version}     Execute Command   ghaf-version
-    Log To Console      Ghaf version: ${ghaf_version}
-    ${nixos_version}    Execute Command   nixos-version
-    Log To Console      Nixos version: ${nixos_version}
-
-Get Falcon LLM Name
-    ${output}            Execute Command     cat '/run/current-system/sw/share/applications/Falcon AI.desktop'
-    ${line}              Get Lines Containing String  ${output}  Exec=
-    ${path}              Set Variable  ${line[5:]}
-    ${llm_name_raw}      Execute Command  cat ${path} | grep LLM_NAME | head -n 1
-    # LLM_NAME="falcon3:10b" -> falcon3:10b
-    ${tmp}               Fetch From Right  ${llm_name_raw}  =
-    ${LLM_NAME}          Set Variable  ${tmp[1:-1]}
-    Set Global Variable  ${LLM_NAME}
-
-Launch Cosmic Term
-    Start XDG application   com.system76.CosmicTerm  gui_vm_app=true
-    Check that the application was started    cosmic-term  exact_match=true
 
 Check variable availability
     [Arguments]    ${variable_name}
@@ -148,17 +17,69 @@ Check variable availability
         RETURN  ${False}
     END
 
-Log and remove app output
-    [Documentation]    Specify the VM from which the app was started and the user (the owner of the file)
-    [Arguments]   ${file}    ${vm}    ${user}=ghaf
-    Switch to vm  ${vm}    ${user}
-    ${output}     Execute Command    cat ${file}
-    Log           ${output}
-    Remove file   ${file}    user=${user}
+Verify Systemctl status
+    [Arguments]    ${range}=60    ${user}=False
+    [Documentation]    Check is systemctl running with given loop ${range}
 
-Log app vm journalctl
-    [Documentation]    Specify the VM where the App is actually running
-    [Arguments]   ${vm}
-    Switch to vm  ${vm}
-    ${output}     Execute Command    journalctl
-    Log           ${output}
+    IF    ${user}
+        ${cmd}               Set Variable   systemctl status --user
+        ${failed_units_cmd}  Set Variable   systemctl list-units --state=failed --user
+    ELSE
+        ${cmd}               Set Variable   systemctl status
+        ${failed_units_cmd}  Set Variable   systemctl list-units --state=failed
+    END
+
+    ${start_time}=    Get Time	epoch
+    FOR    ${i}    IN RANGE    ${range}
+        ${output}=    Execute Command    ${cmd}
+        ${status}=    Get Systemctl Status    ${output}
+        Log  ${output}
+
+        ${data_failed_units}   Execute Command    ${failed_units_cmd}
+        Log  ${data_failed_units}
+        ${failed_units}  Get failed units  ${data_failed_units}
+        Log   ${failed_units}
+        Set Test Variable   ${failed_units}
+
+        IF  '${status}' not in ['running', 'starting']
+            Log To Console   Systemctl status is ${status}
+            FAIL    Systemctl is not running! Status is ${status}. Failed processes are: ${failed_units}
+        ELSE IF    '${status}' == 'running'
+            ${diff}=    Evaluate    int(time.time()) - int(${start_time})
+            Log To Console   Systemctl status is ${status} after ${diff} sec
+            RETURN
+        END
+        Sleep    1
+    END
+    ${diff}=    Evaluate    int(time.time()) - int(${start_time})
+    FAIL    Systemctl is not running after ${diff} sec! Status is ${status}. Failed processes?: ${failed_units}
+
+Check systemctl status for known issues
+    [Arguments]    ${known_issues_list}   ${failing_services}
+    [Documentation]    Check if failing services contain issues that are not listed as known
+    ${old_issues}=    Create List
+    ${new_issues}=    Create List
+    FOR    ${failing_service}    IN    @{failing_services}
+        ${known}=    Set Variable    False
+        FOR    ${entry}    IN    @{known_issues_list}
+            ${list_device}  ${service}  ${issue}   Parse Known Issue   ${entry}
+
+            ${device_match}=     Run Keyword And Return Status    Should Contain    ${DEVICE}    ${list_device}
+            ${service_match}=    Run Keyword And Return Status    Should Contain    ${failing_service}    ${service}
+
+            IF   '${device_match}' == 'True' and ('${service}' == 'ANY' or '${service_match}') == 'True'
+                ${known}=     Set Variable    True
+            END
+        END
+        IF    ${known}   
+            Append To List    ${old_issues}    ${failing_service}
+        ELSE
+            Append To List    ${new_issues}    ${failing_service}
+        END
+    END
+    IF   ${new_issues} != []
+        Fail    Unexpected failed services: ${new_issues}, known failed services: ${old_issues}
+    ELSE
+        Skip    Known failed services: ${old_issues}
+    END
+

--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***
-Resource            ../config/variables.robot
-Library             BuiltIn
 Library             ../lib/PlugLibrary/PlugLibrary.py  ${PLUG_TYPE}
 Library             ../lib/SwitchbotLibrary.py  ${SWITCH_TOKEN}  ${SWITCH_SECRET}
+
 
 *** Keywords ***
 

--- a/Robot-Framework/resources/file_keywords.resource
+++ b/Robot-Framework/resources/file_keywords.resource
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Keywords ***
+
+Create file
+    [Documentation]    Create file with given path & name, requires existing ssh connection
+    [Arguments]        ${file_name}
+    Log To Console     Creating file ${file_name}
+    Execute Command    touch ${file_name}  sudo=True  sudo_password=${password}
+    Check file exists  ${file_name}
+
+Create text file
+    [Documentation]    Create text file with given text and name, requires existing ssh connection
+    [Arguments]        ${text}    ${file_name}
+    Log To Console     Creating file ${file_name}
+    ${out}    ${rc}    Execute Command    echo '${text}' > ${file_name}    return_rc=True
+    Should Be True     ${rc} == 0
+
+Remove file
+    [Documentation]    Remove file with given path & name, requires existing ssh connection
+    [Arguments]        ${file_name}  ${user}=ghaf
+    Log To Console     Removing file ${file_name}
+    IF  $user=='ghaf'
+        Execute Command    rm ${file_name}  sudo=True  sudo_password=${PASSWORD}
+        Check file doesn't exist  ${file_name}
+    ELSE
+        Execute Command    rm ${file_name}
+        Check file doesn't exist  ${file_name}  user=${USER_LOGIN}
+    END
+
+Copy file
+    [Documentation]    Copy file, requires existing ssh connection
+    [Arguments]        ${file_1}    ${file_2}
+    Log To Console     Copying file ${file_1} to ${file_2}
+    ${output}  ${rc}   Execute Command    cp ${file_1} ${file_2}   return_rc=True  sudo=True  sudo_password=${password}
+
+Check file exists
+    [Documentation]    Check file exists, requires existing ssh connection
+    [Arguments]        ${file_name}  ${user}=ghaf
+    Log To Console     Check if file ${file_name} exists
+    IF  $user=='ghaf'
+        ${output}  ${rc}   Execute Command    ls ${file_name}   return_rc=True  sudo=True  sudo_password=${password}
+    ELSE
+        ${output}  ${rc}   Execute Command    ls ${file_name}   return_rc=True
+    END
+    Should Be Equal As Integers   ${rc}   0
+
+Check file doesn't exist
+    [Documentation]    Check file doesn't exist, requires existing ssh connection
+    [Arguments]        ${file_name}  ${user}=ghaf
+    Log To Console     Check if file ${file_name} exists
+    IF  $user=='ghaf'
+        ${output}  ${rc}   Execute Command    ls ${file_name}   return_rc=True  sudo=True  sudo_password=${password}
+    ELSE
+        ${output}  ${rc}   Execute Command    ls ${file_name}   return_rc=True
+    END
+    Should Be Equal As Integers   ${rc}   2
+    Log To Console     File ${file_name} doesn't exist

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -1,4 +1,3 @@
-
 # SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
@@ -6,19 +5,19 @@
 Documentation       Keywords for gui tests. Note: These keywords assume the connection is to the gui-vm,
 ...                 as the ghaf user. If a keyword requires the user account, it will handle switching to
 ...                 the user and switch back to the ghaf user during teardown.
-Resource            ../config/variables.robot
+
 Library             ../lib/GuiTesting.py    ${OUTPUT_DIR}/outputs/gui-temp/
 Library             Collections
 Library             DateTime
-Library             OperatingSystem
+Resource            ../resources/ssh_keywords.resource
 
 
 *** Variables ***
-
 ${APP_MENU_LAUNCHER}   ./launcher.png
 ${LOCK_ICON}           ./lock.png
 ${DISABLE_LOGOUT}      ${EMPTY}
 ${GUI_TEMP_DIR}        ${OUTPUT_DIR}/outputs/gui-temp/
+
 
 *** Keywords ***
 
@@ -282,6 +281,10 @@ Save most common icons and paths to icons
     Get icon                ${ICONS}/hicolor/scalable/apps  com.system76.CosmicAppletPower-symbolic.svg  crop=0  background=black  output_filename=power.png
     Get icon                ${ICONS}/Cosmic/scalable/actions  system-lock-screen-symbolic.svg  background=black  output_filename=lock.png
 
+Create test user
+    Log To Console      Creating test user
+    Execute Command     systemctl start setup-test-user.service  sudo=True  sudo_password=${password}
+
 Stop swayidle
     [Documentation]    Stop swayidle to prevent automatic suspension
     Log To Console    Disabling automated lock and suspend
@@ -313,9 +316,12 @@ Get screen brightness
     RETURN            ${brightness}
 
 Get gui-vm user journalctl log
-    [Setup]      Switch to vm    gui-vm  user=${USER_LOGIN}
-    Get user journalctl log   gui-vm-user.txt
-    [Teardown]   Switch to vm    gui-vm
+    [Arguments]       ${filename}=gui-vm-user.txt
+    [Setup]           Switch to vm    gui-vm  user=${USER_LOGIN}
+    Execute Command   journalctl --user > /tmp/${filename}
+    SSHLibrary.Get file   /tmp/${filename}   ${OUTPUT_DIR}/${filename}
+    OperatingSystem.File Should Exist   ${OUTPUT_DIR}/${filename}
+    [Teardown]        Switch to vm    gui-vm
 
 Switch keyboard layout
     [Documentation]   Toggle layout between English, Arabic and Finnish

--- a/Robot-Framework/resources/performance_keywords.resource
+++ b/Robot-Framework/resources/performance_keywords.resource
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***
-Library             BuiltIn
 Library             Collections
 
 
@@ -55,3 +54,29 @@ Output Dictionary First Value
     ${keys}                 Get Dictionary Keys          ${statistics_dict}
     ${output}               Get From Dictionary          ${statistics_dict}    ${keys}[0]
     RETURN                  ${output}
+
+Install sysbench tool
+    ${command_output}=    Execute Command    nix-env --query --installed
+    ${not_installed} =	Run Keyword And Return Status	Should Not Contain    ${command_output}    sysbench
+    IF  ${not_installed}
+        Execute Command    nix-env -i sysbench
+        ${command_output}=    Execute Command    nix-env --query --installed
+        Log To Console    ${\n}Installed packages:${\n}${command_output}
+        Should Contain    ${command_output}    sysbench    sysbench tool was not installed
+        Log To Console    sysbench tool was successfully installed
+    ELSE
+        Log To Console    ${\n}sysbench tool was already installed
+    END
+
+Install iperf tool
+    ${command_output}=    Execute Command    nix-env --query --installed
+    ${not_installed} =	  Run Keyword And Return Status	Should Not Contain    ${command_output}    iperf
+    IF  ${not_installed}
+        Execute Command   nix-env -i iperf
+        ${command_output}=    Execute Command    nix-env --query --installed
+        Log To Console    ${\n}Installed packages:${\n}${command_output}
+        Should Contain    ${command_output}    iperf    iperf tool was not installed
+        Log To Console    iperf tool was successfully installed
+    ELSE
+        Log To Console    ${\n}iperf tool was already installed
+    END

--- a/Robot-Framework/resources/power_meas_keywords.resource
+++ b/Robot-Framework/resources/power_meas_keywords.resource
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***
-Resource            ../config/variables.robot
 Library             ../lib/ParsePowerData.py    ${POWER_MEASUREMENT_DIR}    ${PLOT_DIR}
-Resource            ./common_keywords.resource
-Library             SSHLibrary
 Library             DateTime
+Library             SSHLibrary
+Resource            ../resources/common_keywords.resource
+
 
 *** Variables ***
 ${SSH_MEASUREMENT}        ${EMPTY}

--- a/Robot-Framework/resources/serial_keywords.resource
+++ b/Robot-Framework/resources/serial_keywords.resource
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***
-Library             SerialLibrary    encoding=ascii
-Resource            ../config/variables.robot
-Library             BuiltIn
-Library             String
-Library             AdvancedLogging
-Library             ../lib/output_parser.py
 Library             ../lib/KMTronicLibrary.py   ${RELAY_SERIAL_PORT}
+Library             ../lib/output_parser.py
+Library             AdvancedLogging
+Library             SerialLibrary    encoding=ascii
+Library             String
+
 
 *** Keywords ***
+
 Open Serial Port
     [Arguments]    ${timeout}=1.0
     Add Port   ${SERIAL_PORT}

--- a/Robot-Framework/resources/setup_keywords.resource
+++ b/Robot-Framework/resources/setup_keywords.resource
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Settings ***
+Resource            ../config/variables.robot
+Resource            ../resources/gui_keywords.resource
+Resource            ../resources/ssh_keywords.resource
+
+
+*** Keywords ***
+
+Prepare Test Environment
+    [Arguments]   ${login}=True   ${stop_swayidle}=True   ${enable_dnd}=False
+    Initialize Variables And Connect
+    Log versions
+    Start journalctl recording
+
+    IF  ${login} and ("Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}")
+        Switch to vm    gui-vm
+        Save most common icons and paths to icons
+        Create test user
+        Start ydotoold
+        Log in, unlock and verify   ${stop_swayidle}   ${enable_dnd}
+    END
+
+Clean Up Test Environment
+    [Arguments]   ${disable_dnd}=False
+    Connect to ghaf host
+    Stop journalctl recording
+    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
+        Switch to vm    gui-vm
+        Start ydotoold
+        Log out and verify   ${disable_dnd}
+        Stop ydotoold
+    END
+    Close All Connections
+
+Initialize Variables And Connect
+    [Documentation]  Initialize variables. Connect to device and start logging
+    Close All Connections
+    Set Variables   ${DEVICE}
+    Run Keyword If  "${DEVICE_IP_ADDRESS}" == "NONE"    Get ethernet IP address
+    ${port_22_is_available}     Check if ssh is ready on device   timeout=60
+    IF  ${port_22_is_available} == False
+        FAIL    Failed because port 22 of device was not available, tests can not be run.
+    END
+    ${CONNECTION}        Connect to ghaf host
+    Set Global Variable  ${CONNECTION}
+
+Start journalctl recording
+    ${output}     Execute Command    nohup journalctl -f >> /tmp/jrnl.txt 2>&1 &
+
+Stop journalctl recording
+    ${jrnl_size}  Execute Command    ls -lh /tmp/jrnl.txt
+    Log           ${jrnl_size}
+    # Copy journal log file to Robot outputs
+    SSHLibrary.Get file   /tmp/jrnl.txt   ${OUTPUT_DIR}/jrnl.txt
+    OperatingSystem.File Should Exist     ${OUTPUT_DIR}/jrnl.txt
+    @{pid}        Find pid by name   journalctl
+    Kill process  @{pid}
+
+Log versions
+    ${ghaf_version}     Execute Command   ghaf-version
+    Log To Console      Ghaf version: ${ghaf_version}
+    ${nixos_version}    Execute Command   nixos-version
+    Log To Console      Nixos version: ${nixos_version}

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***
-Library             SSHLibrary
-Resource            ../config/variables.robot
-Library             BuiltIn
-Library             String
-Library             Process
-Library             String
-Library             ../lib/output_parser.py
 Library             ../lib/helper_functions.py
+Library             ../lib/output_parser.py
+Library             OperatingSystem
+Library             Process
+Library             SSHLibrary
+Library             String
+Resource            ../config/variables.robot
+Resource            ../resources/common_keywords.resource
 
 
 *** Keywords ***
@@ -20,6 +20,11 @@ Ping Host
     ${ping_output}=    Run Process   ping ${hostname} -c 1 -W ${timeout}   shell=True
     ${ping_success}    Run Keyword And Return Status    Should Contain    ${ping_output.stdout}    1 received
     Return From Keyword    ${ping_success}
+
+Check If Ping Fails
+    [Documentation]  Check that ping is not getting response from host
+    ${result}  Run Process  ping  ${DEVICE_IP_ADDRESS}  -c1  timeout=1s
+    Should Not Be Equal   ${result.rc}  ${0}
 
 Check Network Availability
     [Arguments]            ${host}  ${expected_result}=True  ${range}=5
@@ -45,6 +50,41 @@ Check Network Availability
     END
     IF    ${IS_AVAILABLE} != ${expected_result}
         FAIL    Expected availability of ${host}: ${expected_result}, in fact: ${IS_AVAILABLE}
+    END
+
+Check If Device Is Up
+    [Arguments]    ${range}=20
+    Set Global Variable    ${IS_AVAILABLE}       False
+    ${start_time}=    Get Time	epoch
+    FOR    ${i}    IN RANGE    ${range}
+        ${ping}=    Ping Host   ${DEVICE_IP_ADDRESS}
+        IF    ${ping}
+            Log To Console    Ping ${DEVICE_IP_ADDRESS} successful
+            BREAK
+        END
+        Sleep  1
+    END
+
+    IF    ${ping}
+        ${port_22_is_available}     Check if ssh is ready on device
+        IF  ${port_22_is_available}
+            Set Global Variable    ${IS_AVAILABLE}       True
+        ELSE
+            Set Global Variable    ${IS_AVAILABLE}       False
+        END
+    END
+
+    ${diff}=    Evaluate    int(time.time()) - int(${start_time})
+
+    IF  ${IS_AVAILABLE}    Log To Console    Device woke up after ${diff} sec.
+
+    IF  ${IS_AVAILABLE} == False
+        Log To Console    Device is not available after reboot via SSH, waited for ${diff} sec!
+        IF  "${SERIAL_PORT}" == "NONE"
+            Log To Console    There is no address for serial connection
+        ELSE
+            Check Serial Connection
+        END
     END
 
 Login with timeout
@@ -158,131 +198,6 @@ Connect to VM
     # If connected and logged in successfully
     RETURN  ${connection}
 
-Verify Systemctl status
-    [Arguments]    ${range}=60    ${user}=False
-    [Documentation]    Check is systemctl running with given loop ${range}
-
-    IF    ${user}
-        ${cmd}               Set Variable   systemctl status --user
-        ${failed_units_cmd}  Set Variable   systemctl list-units --state=failed --user
-    ELSE
-        ${cmd}               Set Variable   systemctl status
-        ${failed_units_cmd}  Set Variable   systemctl list-units --state=failed
-    END
-
-    ${start_time}=    Get Time	epoch
-    FOR    ${i}    IN RANGE    ${range}
-        ${output}=    Execute Command    ${cmd}
-        ${status}=    Get Systemctl Status    ${output}
-        Log  ${output}
-
-        ${data_failed_units}   Execute Command    ${failed_units_cmd}
-        Log  ${data_failed_units}
-        ${failed_units}  Get failed units  ${data_failed_units}
-        Log   ${failed_units}
-        Set Test Variable   ${failed_units}
-
-        IF  '${status}' not in ['running', 'starting']
-            Log To Console   Systemctl status is ${status}
-            FAIL    Systemctl is not running! Status is ${status}. Failed processes are: ${failed_units}
-        ELSE IF    '${status}' == 'running'
-            ${diff}=    Evaluate    int(time.time()) - int(${start_time})
-            Log To Console   Systemctl status is ${status} after ${diff} sec
-            RETURN
-        END
-        Sleep    1
-    END
-    ${diff}=    Evaluate    int(time.time()) - int(${start_time})
-    FAIL    Systemctl is not running after ${diff} sec! Status is ${status}. Failed processes?: ${failed_units}
-
-Check systemctl status for known issues
-    [Arguments]    ${known_issues_list}   ${failing_services}
-    [Documentation]    Check if failing services contain issues that are not listed as known
-    ${old_issues}=    Create List
-    ${new_issues}=    Create List
-    FOR    ${failing_service}    IN    @{failing_services}
-        ${known}=    Set Variable    False
-        FOR    ${entry}    IN    @{known_issues_list}
-            ${list_device}  ${service}  ${issue}   Parse Known Issue   ${entry}
-
-            ${device_match}=     Run Keyword And Return Status    Should Contain    ${DEVICE}    ${list_device}
-            ${service_match}=    Run Keyword And Return Status    Should Contain    ${failing_service}    ${service}
-
-            IF   '${device_match}' == 'True' and ('${service}' == 'ANY' or '${service_match}') == 'True'
-                ${known}=     Set Variable    True
-            END
-        END
-        IF    ${known}   
-            Append To List    ${old_issues}    ${failing_service}
-        ELSE
-            Append To List    ${new_issues}    ${failing_service}
-        END
-    END
-    IF   ${new_issues} != []
-        Fail    Unexpected failed services: ${new_issues}, known failed services: ${old_issues}
-    ELSE
-        Skip    Known failed services: ${old_issues}
-    END
-
-Check VM systemctl status for known issues
-    [Arguments]    ${vm}   ${known_issues_list}   ${failing_services}
-    [Documentation]    Check if failing services in VMs contain issues that are not listed as known
-    ${old_issues}=    Create List
-    ${new_issues}=    Create List
-    FOR    ${failing_service}    IN    @{failing_services}
-        ${known}=    Set Variable    False
-        FOR    ${entry}    IN    @{known_issues_list}
-            ${list_vm}  ${service}  ${issue}   Parse Known Issue   ${entry}
-
-            ${vm_match}=         Run Keyword And Return Status    Should Contain    ${vm}    ${list_vm}
-            ${service_match}=    Run Keyword And Return Status    Should Contain    ${failing_service}    ${service}
-
-            IF   ('${vm_match}' == 'True' or '${list_vm}' == 'ANY') and ('${service}' == 'ANY' or '${service_match}') == 'True'
-                ${known}=     Set Variable    True
-            END
-        END
-        IF    ${known}   
-            Append To List    ${old_issues}    ${failing_service}
-        ELSE
-            Append To List    ${new_issues}    ${failing_service}
-        END
-    END
-    RETURN    ${new_issues}   ${old_issues}
-
-Start application
-    [Arguments]      ${app_name}
-    Log To Console   ${\n}Starting ${app_name}
-    ${output}        Execute Command    cat /etc/xdg/weston/weston.ini
-    ${path}          Get App Path  ${output}  ${app_name}
-    Execute Command  nohup sh -c '${path}' > output.log 2>&1 &
-
-Check application name
-    [Documentation]  Check written format of application
-    [Arguments]  ${app_name}
-    ${app_name}  Strip String  ${app_name}  characters="'
-    ${output}    Execute Command    ls /run/current-system/sw/share/applications/
-    ${app}       Get Regexp Matches  ${output}  (?im)${app_name}
-    RETURN  '${app}[0]'
-
-Start XDG application
-    [Arguments]      ${app_name}  ${gui_vm_app}=false
-    Log To Console   ${\n}Starting ${app_name}
-    ${app_name}      Check application name  ${app_name}
-    ${output}        Execute Command    cat /run/current-system/sw/share/applications/${app_name}.desktop
-    ${path}          Get App Path From Desktop  ${output}
-    IF  $gui_vm_app
-        Execute Command  nohup sh -c 'WAYLAND_DISPLAY=wayland-1 ${path}' > output.log 2>&1 &
-    ELSE
-        Execute Command  nohup sh -c '${path}' > output.log 2>&1 &
-    END
-
-Start Firefox
-    [Documentation]  It's needed to set display variable manually because there is no real monitor connected to DUT
-    Log To Console  ${\n}Starting Firefox
-    ${command_output}   Execute Command    export WAYLAND_DISPLAY=wayland-1   #; nohup firefox > output.log 2>&1 &
-    ${firefox}          Execute Command    awk -F= '/^Exec/ {print $2; exit}' /run/current-system/sw/share/applications/Firefox.desktop
-    ${command_output}   Execute Command    nohup ${firefox} > output.log 2>&1 &
-
 Is process started
     [Arguments]    ${pid}
     ${rc}=      Execute Command    ps -p ${pid}   return_rc=True
@@ -394,95 +309,6 @@ Wait until NetVM service started
     END
     IF   ${status} == False    FAIL    NetVM is not ready after ${timeout}
 
-Create file
-    [Documentation]    Create file with given path & name, requires existing ssh connection
-    [Arguments]        ${file_name}
-    Log To Console     Creating file ${file_name}
-    Execute Command    touch ${file_name}  sudo=True  sudo_password=${password}
-    Check file exists  ${file_name}
-
-Create text file
-    [Documentation]    Create text file with given text and name, requires existing ssh connection
-    [Arguments]        ${text}    ${file_name}
-    Log To Console     Creating file ${file_name}
-    ${out}    ${rc}    Execute Command    echo '${text}' > ${file_name}    return_rc=True
-    Should Be True     ${rc} == 0
-
-Remove file
-    [Documentation]    Remove file with given path & name, requires existing ssh connection
-    [Arguments]        ${file_name}  ${user}=ghaf
-    Log To Console     Removing file ${file_name}
-    IF  $user=='ghaf'
-        Execute Command    rm ${file_name}  sudo=True  sudo_password=${PASSWORD}
-        Check file doesn't exist  ${file_name}
-    ELSE
-        Execute Command    rm ${file_name}
-        Check file doesn't exist  ${file_name}  user=${USER_LOGIN}
-    END
-
-Copy file
-    [Documentation]    Copy file, requires existing ssh connection
-    [Arguments]        ${file_1}    ${file_2}
-    Log To Console     Copying file ${file_1} to ${file_2}
-    ${output}  ${rc}   Execute Command    cp ${file_1} ${file_2}   return_rc=True  sudo=True  sudo_password=${password}
-
-Check file exists
-    [Documentation]    Check file exists, requires existing ssh connection
-    [Arguments]        ${file_name}  ${user}=ghaf
-    Log To Console     Check if file ${file_name} exists
-    IF  $user=='ghaf'
-        ${output}  ${rc}   Execute Command    ls ${file_name}   return_rc=True  sudo=True  sudo_password=${password}
-    ELSE
-        ${output}  ${rc}   Execute Command    ls ${file_name}   return_rc=True
-    END
-    Should Be Equal As Integers   ${rc}   0
-
-Check file doesn't exist
-    [Documentation]    Check file doesn't exist, requires existing ssh connection
-    [Arguments]        ${file_name}  ${user}=ghaf
-    Log To Console     Check if file ${file_name} exists
-    IF  $user=='ghaf'
-        ${output}  ${rc}   Execute Command    ls ${file_name}   return_rc=True  sudo=True  sudo_password=${password}
-    ELSE
-        ${output}  ${rc}   Execute Command    ls ${file_name}   return_rc=True
-    END
-    Should Be Equal As Integers   ${rc}   2
-    Log To Console     File ${file_name} doesn't exist
-
-Verify Ghaf Version Format
-    [Documentation]    Check that ghaf-version contains version number in the format:"dd.dd"
-    ${version}   Get Ghaf Version
-    Should Match Regexp	  ${version}  \\d{2}.\\d{2}.?\\d{0,2}\$
-
-Verify Nixos Version Format
-    [Documentation]    Check that nixos-version contains version number in the format:"dd.dd",
-    ...                date of commit in format yyyymmdd, 7 symbols of hash commit and version name in brackets
-    ${major}  ${minor}  ${date}  ${commit}  ${name}    Get Nixos Version
-    Should Match Regexp	  ${major}   ^\\d{2}$
-    Should Match Regexp	  ${minor}   ^\\d{2}$
-    Verify Date Format    ${date}
-    Should Match Regexp	  ${commit}   ^[0-9a-f]{7}$
-    IF  '${name}' == 'None'
-        FAIL    Expected NixOS version name, but there is None
-    END
-
-Get Ghaf Version
-    [Documentation]    Get version of Ghaf system, Example:
-    ...     "ghaf-version"    output: 23.05   parse result: 23.05
-    ${output}   ${rc}    Execute Command   ghaf-version   return_rc=True
-    Should Be Equal As Integers     ${rc}   0   Couldn't get ghaf version, command return code
-    Log To Console    ghaf-version: ${output}
-    RETURN    ${output}
-
-Get Nixos Version
-    [Documentation]    Get version of NixOS, Example:
-    ...     "nixos-version"   output: 23.05.20230625.35130d4 (Stoat)    parse result: 23.05, 20230625, 35130d4, Stoat
-    ${output}   ${rc}    Execute Command   nixos-version   return_rc=True
-    Should Be Equal As Integers     ${rc}   0   Couldn't get ghaf version, command return code
-    Log To Console    nixos-version: ${output}
-    ${major}  ${minor}  ${date}  ${commit}  ${name}     Parse Nixos Version   ${output}
-    RETURN    ${major}  ${minor}  ${date}  ${commit}  ${name}
-
 Save log
     Connect
     ${output}     Execute Command   journalctl > jrnl.txt${\n}
@@ -512,54 +338,6 @@ Check if ssh is ready on vm
         END
     END
     IF   ${status} == False    FAIL    Port 22 of ${vm} is not ready after ${timeout}
-
-Install sysbench tool
-    ${command_output}=    Execute Command    nix-env --query --installed
-    ${not_installed} =	Run Keyword And Return Status	Should Not Contain    ${command_output}    sysbench
-    IF  ${not_installed}
-        Execute Command    nix-env -i sysbench
-        ${command_output}=    Execute Command    nix-env --query --installed
-        Log To Console    ${\n}Installed packages:${\n}${command_output}
-        Should Contain    ${command_output}    sysbench    sysbench tool was not installed
-        Log To Console    sysbench tool was successfully installed
-    ELSE
-        Log To Console    ${\n}sysbench tool was already installed
-    END
-
-Install iperf tool
-    ${command_output}=    Execute Command    nix-env --query --installed
-    ${not_installed} =	  Run Keyword And Return Status	Should Not Contain    ${command_output}    iperf
-    IF  ${not_installed}
-        Execute Command   nix-env -i iperf
-        ${command_output}=    Execute Command    nix-env --query --installed
-        Log To Console    ${\n}Installed packages:${\n}${command_output}
-        Should Contain    ${command_output}    iperf    iperf tool was not installed
-        Log To Console    iperf tool was successfully installed
-    ELSE
-        Log To Console    ${\n}iperf tool was already installed
-    END
-
-Get Wifi Interface name
-    ${if_name}=    Execute Command    nmcli device status | grep wifi | head -n 1 | awk '{print $1}'
-    RETURN         ${if_name}
-
-Get wifi IP
-    [Documentation]     Parse ifconfig output and looks for wifi IP
-    ${if_name}=    Get Wifi Interface name
-    ${is_ready} =  Set Variable    False
-    FOR    ${i}    IN RANGE    20
-        ${output}     Execute Command      ifconfig
-        Log           ${output}
-        ${ip}         Get ip from ifconfig    ${output}   ${if_name}
-        ${status}     Run Keyword And Return Status    Should Not Be Equal As Strings    ${ip}    None
-        IF  ${status}
-            Log To Console     Ip is ${ip}
-            ${is_ready} =  Set Variable    True
-            BREAK
-        END
-        Sleep    1
-    END
-    IF   ${status} == False    FAIL    NetVM hasn't gotten an IP
 
 Get Virtual Network Interface IP
     [Documentation]     Parse ifconfig output and look for ethint0 IP
@@ -602,64 +380,6 @@ Check if ssh is ready on device
 
     RETURN  ${is_ready}
 
-Check QSPI Version is up to date
-    ${output}      Execute Command    ota-check-firmware
-    ${fw_version}  ${sw_version}      Get qspi versions   ${output}
-    Should Be True	'${fw_version}' == '${sw_version}'	  Update QSPI version! Test results can be wrong!
-
-Stop VM
-    [Documentation]     Stopt VM service and check the status.
-    ...                 Pre-condition: requires active ssh connection to ghaf host.
-    [Arguments]         ${vm_name}
-    Log To Console          Going to stop ${vm_name}
-    Execute Command         systemctl stop microvm@${vm_name}.service  sudo=True  sudo_password=${PASSWORD}
-    Sleep    3
-    ${status}  ${state}=    Verify service status  service=microvm@${vm_name}.service  expected_status=inactive  expected_state=dead
-    Verify service shutdown status   service=microvm@${vm_name}.service
-    Set Global Variable     ${VM_STATE}   ${state}
-    Log To Console          ${vm_name} is ${state}
-
-Start VM
-    [Documentation]     Try to start VM service service
-    ...                 Pre-condition: requires active ssh connection to ghaf host.
-    [Arguments]         ${vm_name}
-    Log To Console          Going to start ${vm_name}
-    Execute Command         systemctl start microvm@${vm_name}.service  sudo=True  sudo_password=${PASSWORD}
-    ${status}  ${state}=    Verify service status  service=microvm@${vm_name}.service  expected_status=active  expected_state=running
-    Set Global Variable     ${VM_STATE}   ${state}
-    Log To Console          ${vm_name} is ${state}
-    Wait until NetVM service started
-
-Restart VM
-    [Documentation]     Stop VM service via systemctl, wait ${delay} and start VM service
-    ...                 Pre-condition: requires active ssh connection to ghaf host.
-    [Arguments]         ${vm_name}  ${delay}=3
-    Stop VM  ${vm_name}
-    Sleep  ${delay}
-    Start VM  ${vm_name}
-    Check if ssh is ready on vm   ${vm_name}
-
-Check External SSD Size
-    [Documentation]  Check the size of ssd used in setup
-    Log To Console   Memory to be checked: SSD
-    ${lsblk}  Execute Command  lsblk
-    ${size}  Get Regexp Matches  ${lsblk}  (?im)(sda .*\\d*:\\d{1}.*\\d{1}\\s)(\\d{1,3})  2
-    RETURN  ${size}[0]
-
-Check Internal eMMC Size
-    [Documentation]  Check the size of eMMC used in setup
-    Log To Console   Memory to be checked: eMMC
-    ${lsblk}  Execute Command  lsblk
-    ${size}   Get Regexp Matches  ${lsblk}  (?im)(nvme0n1 .*\\d*:\\d{1}.*\\d{1}\\s)(\\d{1,3})  2
-    RETURN    ${size}[0]
-
-Check Persist Storage Size
-    [Documentation]  Check the size of persistent storage
-    ${storage}  Execute Command  df -h
-    Log  ${storage}
-    ${size}  Get Regexp Matches  ${storage}  (?im)(\\d{1,3}G)\(\\s*.*\\s)(\\d{1,3})(G)(\\s*.*\\s)/persist  3
-    RETURN  ${size}[0]
-
 Check ssh connection status
     [Documentation]    Check if there is already an active ssh connection to vm_name
     [Arguments]        ${vm_name}
@@ -678,10 +398,6 @@ Connect to VM if not already connected
         Connect to netvm
         Connect to VM   ${vm_name}
     END
-
-Create test user
-    Log To Console      Creating test user
-    Execute Command     systemctl start setup-test-user.service  sudo=True  sudo_password=${password}
 
 Switch to vm
     [Arguments]         ${hostname}   ${user}=ghaf

--- a/Robot-Framework/resources/virtualization_keywords.resource
+++ b/Robot-Framework/resources/virtualization_keywords.resource
@@ -3,8 +3,6 @@
 
 *** Settings ***
 Library             SSHLibrary
-Resource            ../config/variables.robot
-Library             BuiltIn
 Library             String
 
 

--- a/Robot-Framework/resources/wifi_keywords.resource
+++ b/Robot-Framework/resources/wifi_keywords.resource
@@ -1,11 +1,8 @@
 # SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
-*** Settings ***
-Resource            ../config/variables.robot
-
-
 *** Keywords ***
+
 Configure wifi
     [Arguments]         ${netvm_ssh}  ${SSID}  ${passw}
     Switch Connection   ${netvm_ssh}
@@ -34,14 +31,24 @@ Turn ON WiFi
     Log To Console      Turning on Wifi
     Execute Command     nmcli con up id ${SSID}    sudo=True    sudo_password=${PASSWORD}
 
-Initialize Variables And Connect
-    [Documentation]  Initialize variables. Connect to device and start logging
-    Close All Connections
-    Set Variables   ${DEVICE}
-    Run Keyword If  "${DEVICE_IP_ADDRESS}" == "NONE"    Get ethernet IP address
-    ${port_22_is_available}     Check if ssh is ready on device   timeout=60
-    IF  ${port_22_is_available} == False
-        FAIL    Failed because port 22 of device was not available, tests can not be run.
+Get Wifi Interface name
+    ${if_name}=    Execute Command    nmcli device status | grep wifi | head -n 1 | awk '{print $1}'
+    RETURN         ${if_name}
+
+Get wifi IP
+    [Documentation]     Parse ifconfig output and looks for wifi IP
+    ${if_name}=    Get Wifi Interface name
+    ${is_ready} =  Set Variable    False
+    FOR    ${i}    IN RANGE    20
+        ${output}     Execute Command      ifconfig
+        Log           ${output}
+        ${ip}         Get ip from ifconfig    ${output}   ${if_name}
+        ${status}     Run Keyword And Return Status    Should Not Be Equal As Strings    ${ip}    None
+        IF  ${status}
+            Log To Console     Ip is ${ip}
+            ${is_ready} =  Set Variable    True
+            BREAK
+        END
+        Sleep    1
     END
-    ${CONNECTION}        Connect to ghaf host
-    Set Global Variable  ${CONNECTION}
+    IF   ${status} == False    FAIL    NetVM hasn't gotten an IP

--- a/Robot-Framework/test-suites/boot-test/__init__.robot
+++ b/Robot-Framework/test-suites/boot-test/__init__.robot
@@ -3,9 +3,9 @@
 
 *** Settings ***
 Documentation       Boot test
-Resource            ../../resources/ssh_keywords.resource
+
 Resource            ../../config/variables.robot
+Resource            ../../resources/ssh_keywords.resource
+
 Suite Setup         Set Variables   ${DEVICE}
 Suite Teardown      Close All Connections
-
-

--- a/Robot-Framework/test-suites/boot-test/boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/boot_test.robot
@@ -4,11 +4,10 @@
 *** Settings ***
 Documentation       Testing target device booting up.
 Force Tags          ssh_boot_test
+
+Resource            ../../resources/device_control.resource
 Resource            ../../resources/serial_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/device_control.resource
-Resource            ../../config/variables.robot
-Resource            ../../resources/common_keywords.resource
 
 
 *** Variables ***

--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -4,12 +4,12 @@
 *** Settings ***
 Documentation       Testing target device booting up.
 Force Tags          ssh_boot_test
+
+Library             ../../lib/output_parser.py
+Resource            ../../resources/device_control.resource
 Resource            ../../resources/serial_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/device_control.resource
-Resource            ../../config/variables.robot
-Resource            ../../resources/common_keywords.resource
-Library             ../../lib/output_parser.py
+
 Suite Teardown      Teardown
 
 

--- a/Robot-Framework/test-suites/functional-tests/__init__.robot
+++ b/Robot-Framework/test-suites/functional-tests/__init__.robot
@@ -3,14 +3,12 @@
 
 *** Settings ***
 Documentation       Functional tests
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/common_keywords.resource
-Resource            ../../resources/connection_keywords.resource
-Resource            ../../resources/gui_keywords.resource
-Library             OperatingSystem
-Test Timeout        10 minutes
+
+Resource            ../../resources/setup_keywords.resource
+
 Suite Setup         Functional tests setup
 Suite Teardown      Functional tests teardown
+Test Timeout        10 minutes
 
 
 *** Variables ***

--- a/Robot-Framework/test-suites/functional-tests/apps.robot
+++ b/Robot-Framework/test-suites/functional-tests/apps.robot
@@ -4,11 +4,13 @@
 *** Settings ***
 Documentation       Testing launching applications
 Force Tags          apps   lenovo-x1   dell-7330
+
+Library             String
+Resource            ../../resources/app_keywords.resource
+Resource            ../../resources/file_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
-Resource            ../../config/variables.robot
-Resource            ../../resources/common_keywords.resource
+
 Suite Setup         Connect to netvm
-Library             ../../lib/output_parser.py
 
 
 *** Variables ***

--- a/Robot-Framework/test-suites/functional-tests/audio.robot
+++ b/Robot-Framework/test-suites/functional-tests/audio.robot
@@ -4,12 +4,11 @@
 *** Settings ***
 Documentation       Testing audio application
 Force Tags          audio   bat  regression  pre-merge
-Resource            ../../__framework__.resource
-Resource            ../../resources/serial_keywords.resource
-Resource            ../../resources/common_keywords.resource
-Resource            ../../resources/connection_keywords.resource
+
+Library             DateTime
+Library             OperatingSystem
 Resource            ../../resources/ssh_keywords.resource
-Resource            ../../config/variables.robot
+
 Test Setup          Connect to netvm
 Test Teardown       Close All Connections
 Test Timeout        3 minutes

--- a/Robot-Framework/test-suites/functional-tests/business-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/business-vm.robot
@@ -3,11 +3,11 @@
 
 *** Settings ***
 Documentation       Testing Business VM
-Force Tags          bat  regression  businessvm  lenovo-x1   dell-7330
+Force Tags          bat  regression  business-vm  lenovo-x1   dell-7330
+
+Resource            ../../resources/app_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/virtualization_keywords.resource
-Resource            ../../config/variables.robot
-Resource            ../../resources/common_keywords.resource
+
 Suite Setup         Connect to netvm
 Test Setup          Business Apps Test Setup
 Test Teardown       Business Apps Test Teardown

--- a/Robot-Framework/test-suites/functional-tests/docker-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/docker-vm.robot
@@ -4,9 +4,10 @@
 *** Settings ***
 Documentation       Testing Docker VM (FMO target)
 Force Tags          bat  regression  docker-vm  fmo
-Resource            ../../config/variables.robot
-Resource            ../../resources/common_keywords.resource
+
+Resource            ../../resources/app_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
+
 Test Setup          Docker Apps Test Setup
 Test Teardown       Docker Apps Test Teardown
 

--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -4,9 +4,11 @@
 *** Settings ***
 Documentation       Testing Gui-vm
 Force Tags          gui-vm   regression
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../config/variables.robot
+
+Resource            ../../resources/app_keywords.resource
 Resource            ../../resources/common_keywords.resource
+Resource            ../../resources/ssh_keywords.resource
+
 Suite Setup         Connect to netvm
 Test Setup          Gui-vm Test Setup
 Test Teardown       Gui-vm Test Teardown
@@ -17,6 +19,7 @@ Test Teardown       Gui-vm Test Teardown
 
 
 *** Test Cases ***
+
 Start Calculator on LenovoX1
     [Documentation]   Start Calculator and verify process started
     [Tags]            bat   pre-merge  calculator  SP-T202  lenovo-x1  dell-7330  fmo

--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -4,12 +4,15 @@
 *** Settings ***
 Documentation       Common system tests on host
 Force Tags          host  bat  regression  pre-merge
-Resource            ../../__framework__.resource
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/serial_keywords.resource
+
 Library             ../../lib/output_parser.py
+Resource            ../../resources/common_keywords.resource
+Resource            ../../resources/serial_keywords.resource
+Resource            ../../resources/ssh_keywords.resource
+
 Suite Setup         Connect to ghaf host
 Suite Teardown      Close All Connections
+
 
 *** Test Cases ***
 
@@ -95,3 +98,66 @@ Check veritysetup status
     ${output}        Execute Command    veritysetup status root  sudo=True  sudo_password=${PASSWORD}
     ${status}        Get Verity Status  ${output}
     Should Be True   '${status}' == 'verified'
+
+
+*** Keywords ***
+
+Verify Ghaf Version Format
+    [Documentation]    Check that ghaf-version contains version number in the format:"dd.dd"
+    ${version}   Get Ghaf Version
+    Should Match Regexp	  ${version}  \\d{2}.\\d{2}.?\\d{0,2}\$
+
+Verify Nixos Version Format
+    [Documentation]    Check that nixos-version contains version number in the format:"dd.dd",
+    ...                date of commit in format yyyymmdd, 7 symbols of hash commit and version name in brackets
+    ${major}  ${minor}  ${date}  ${commit}  ${name}    Get Nixos Version
+    Should Match Regexp	  ${major}   ^\\d{2}$
+    Should Match Regexp	  ${minor}   ^\\d{2}$
+    Verify Date Format    ${date}
+    Should Match Regexp	  ${commit}   ^[0-9a-f]{7}$
+    IF  '${name}' == 'None'
+        FAIL    Expected NixOS version name, but there is None
+    END
+
+Get Ghaf Version
+    [Documentation]    Get version of Ghaf system, Example:
+    ...     "ghaf-version"    output: 23.05   parse result: 23.05
+    ${output}   ${rc}    Execute Command   ghaf-version   return_rc=True
+    Should Be Equal As Integers     ${rc}   0   Couldn't get ghaf version, command return code
+    Log To Console    ghaf-version: ${output}
+    RETURN    ${output}
+
+Get Nixos Version
+    [Documentation]    Get version of NixOS, Example:
+    ...     "nixos-version"   output: 23.05.20230625.35130d4 (Stoat)    parse result: 23.05, 20230625, 35130d4, Stoat
+    ${output}   ${rc}    Execute Command   nixos-version   return_rc=True
+    Should Be Equal As Integers     ${rc}   0   Couldn't get ghaf version, command return code
+    Log To Console    nixos-version: ${output}
+    ${major}  ${minor}  ${date}  ${commit}  ${name}     Parse Nixos Version   ${output}
+    RETURN    ${major}  ${minor}  ${date}  ${commit}  ${name}
+
+Check QSPI Version is up to date
+    ${output}      Execute Command    ota-check-firmware
+    ${fw_version}  ${sw_version}      Get qspi versions   ${output}
+    Should Be True	'${fw_version}' == '${sw_version}'	  Update QSPI version! Test results can be wrong!
+
+Check External SSD Size
+    [Documentation]  Check the size of ssd used in setup
+    Log To Console   Memory to be checked: SSD
+    ${lsblk}  Execute Command  lsblk
+    ${size}  Get Regexp Matches  ${lsblk}  (?im)(sda .*\\d*:\\d{1}.*\\d{1}\\s)(\\d{1,3})  2
+    RETURN  ${size}[0]
+
+Check Internal eMMC Size
+    [Documentation]  Check the size of eMMC used in setup
+    Log To Console   Memory to be checked: eMMC
+    ${lsblk}  Execute Command  lsblk
+    ${size}   Get Regexp Matches  ${lsblk}  (?im)(nvme0n1 .*\\d*:\\d{1}.*\\d{1}\\s)(\\d{1,3})  2
+    RETURN    ${size}[0]
+
+Check Persist Storage Size
+    [Documentation]  Check the size of persistent storage
+    ${storage}  Execute Command  df -h
+    Log  ${storage}
+    ${size}  Get Regexp Matches  ${storage}  (?im)(\\d{1,3}G)\(\\s*.*\\s)(\\d{1,3})(G)(\\s*.*\\s)/persist  3
+    RETURN  ${size}[0]

--- a/Robot-Framework/test-suites/functional-tests/logging.robot
+++ b/Robot-Framework/test-suites/functional-tests/logging.robot
@@ -4,10 +4,11 @@
 *** Settings ***
 Documentation       Testing logging
 Force Tags          bat  regression   logging  lenovo-x1   dell-7330
-Resource            ../../config/variables.robot
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/connection_keywords.resource
+
 Library             DateTime
+Library             OperatingSystem
+Resource            ../../resources/ssh_keywords.resource
+
 Suite Setup         Connect to netvm
 Suite Teardown      Close All Connections
 
@@ -18,6 +19,7 @@ ${GRAFANA_LOGS}       https://loki.ghaflogs.vedenemo.dev
 
 
 *** Test Cases ***
+
 Check Grafana logs
     [Documentation]  Check that all virtual machines are sending logs to Grafana
     [Tags]           SP-T172

--- a/Robot-Framework/test-suites/functional-tests/net-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/net-vm.robot
@@ -3,11 +3,13 @@
 
 *** Settings ***
 Documentation       Testing Network VM
-Force Tags          netvm  bat  regression
+Force Tags          net-vm  bat  regression
+
+Resource            ../../resources/file_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/virtualization_keywords.resource
-Resource            ../../resources/connection_keywords.resource
-Resource            ../../config/variables.robot
+Resource            ../../resources/wifi_keywords.resource
+
 Suite Teardown      Close All Connections
 
 

--- a/Robot-Framework/test-suites/functional-tests/optee.robot
+++ b/Robot-Framework/test-suites/functional-tests/optee.robot
@@ -3,14 +3,14 @@
 
 *** Settings ***
 Documentation       Test OP-TEE PKCS#11 through pkcs11-tool wrappers
+
 Resource            ../../resources/ssh_keywords.resource
-Resource            ../../config/variables.robot
+
 Suite Setup         Connect to ghaf host
 Suite Teardown      Close All Connections
 
 
 *** Test Cases ***
-
 
 OP-TEE xtest
        [Documentation]  Runs OP-TEE's xtest

--- a/Robot-Framework/test-suites/functional-tests/shares.robot
+++ b/Robot-Framework/test-suites/functional-tests/shares.robot
@@ -4,10 +4,14 @@
 *** Settings ***
 Documentation       Testing files sharing among VMs
 Force Tags          shares  SP-T198  lenovo-x1  dell-7330
+
+Resource            ../../resources/file_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
+
 Test Template       File sharing test
 Suite Setup         Shares setup
 Suite Teardown      Close All Connections
+
 
 *** Test Cases ***
 

--- a/Robot-Framework/test-suites/functional-tests/timesync.robot
+++ b/Robot-Framework/test-suites/functional-tests/timesync.robot
@@ -3,10 +3,12 @@
 
 *** Settings ***
 Documentation       Testing time synchronization
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../config/variables.robot
-Resource            ../../resources/connection_keywords.resource
+Force tags          timesync  bat  regression
+
 Library             ../../lib/TimeLibrary.py
+Resource            ../../resources/ssh_keywords.resource
+Resource            ../../resources/wifi_keywords.resource
+
 Suite Teardown      Close All Connections
 
 
@@ -27,7 +29,7 @@ Time synchronization
     ...                      -Net-vm is not connected to net.
     ...                  - Ghaf-host is connected to net via Net-VM if adapter is used!.
     ...                  - In this test we expect adapter is not used -> Set Wi-Fi ON to enable net-vm to address net.
-    [Tags]            bat  regression   SP-T97   nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1   dell-7330  fmo
+    [Tags]            SP-T97   nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1   dell-7330  fmo
 
     IF  "AGX" in "${DEVICE}"  Set Wifi passthrough into NetVM
 

--- a/Robot-Framework/test-suites/functional-tests/video.robot
+++ b/Robot-Framework/test-suites/functional-tests/video.robot
@@ -4,23 +4,22 @@
 *** Settings ***
 Documentation       Testing camera application
 Force Tags          bat  regression   video  lenovo-x1   dell-7330
-Resource            ../../__framework__.resource
-Resource            ../../resources/serial_keywords.resource
-Resource            ../../resources/common_keywords.resource
-Resource            ../../resources/connection_keywords.resource
+
+Library             Collections
+Library             OperatingSystem
 Resource            ../../resources/ssh_keywords.resource
-Resource            ../../config/variables.robot
+
 Test Setup          Connect to netvm
 Test Teardown       Close All Connections
 Test Timeout        2 minutes
 
 
 *** Variables ***
-
 ${VIDEO_DIR}    ${OUTPUT_DIR}/outputs/video-temp
 
 
 *** Test Cases ***
+
 Check Camera Application
     [Documentation]  Check that camera application is available in business-vm and not in other vm
     [Tags]  SP-T235

--- a/Robot-Framework/test-suites/gui-tests/__init__.robot
+++ b/Robot-Framework/test-suites/gui-tests/__init__.robot
@@ -3,14 +3,14 @@
 
 *** Settings ***
 Documentation       GUI tests
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/gui_keywords.resource
-Resource            ../../resources/common_keywords.resource
-Resource            ../../resources/connection_keywords.resource
+
 Library             ../../lib/GuiTesting.py   ${OUTPUT_DIR}/outputs/gui-temp/
-Test Timeout        5 minutes
+Resource            ../../resources/setup_keywords.resource
+Resource            ../../resources/gui_keywords.resource
+
 Suite Setup         GUI Tests Setup
 Suite Teardown      GUI Tests Teardown
+Test Timeout        5 minutes
 
 
 *** Keywords ***

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -4,15 +4,14 @@
 *** Settings ***
 Documentation       Testing launching applications via GUI
 Force Tags          gui   gui-apps
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../config/variables.robot
-Resource            ../../resources/common_keywords.resource
-Resource            ../../resources/gui_keywords.resource
+
 Library             ../../lib/GuiTesting.py   ${OUTPUT_DIR}/outputs/gui-temp/
+Resource            ../../resources/app_keywords.resource
+Resource            ../../resources/gui_keywords.resource
+Resource            ../../resources/ssh_keywords.resource
 
 
 *** Variables ***
-
 @{APP_PIDS}             ${EMPTY}
 
 

--- a/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
@@ -4,13 +4,14 @@
 *** Settings ***
 Documentation       Testing taskbar power widget options
 Force Tags          gui   gui-power-menu
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../config/variables.robot
-Resource            ../../resources/gui_keywords.resource
-Resource            ../../resources/common_keywords.resource
-Resource            ../../resources/power_meas_keywords.resource
+
 Library             ../../lib/SwitchbotLibrary.py  ${SWITCH_TOKEN}  ${SWITCH_SECRET}
+Resource            ../../resources/gui_keywords.resource
+Resource            ../../resources/power_meas_keywords.resource
+Resource            ../../resources/ssh_keywords.resource
+
 Test Setup          GUI Power Test Setup
+
 
 *** Test Cases ***
 

--- a/Robot-Framework/test-suites/gui-tests/input_control.robot
+++ b/Robot-Framework/test-suites/gui-tests/input_control.robot
@@ -4,11 +4,11 @@
 *** Settings ***
 Documentation       Tests for input-related GUI functionality
 Force Tags          gui  gui-input
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/gui_keywords.resource
-Resource            ../../resources/common_keywords.resource
-Library             Collections
+
 Library             ../../lib/output_parser.py
+Library             Collections
+Resource            ../../resources/app_keywords.resource
+Resource            ../../resources/gui_keywords.resource
 
 
 *** Test Cases ***

--- a/Robot-Framework/test-suites/performance-tests/__init__.robot
+++ b/Robot-Framework/test-suites/performance-tests/__init__.robot
@@ -3,8 +3,9 @@
 
 *** Settings ***
 Documentation       Performance tests
-Resource            ../../resources/ssh_keywords.resource
+
+Library             SSHLibrary
 Resource            ../../config/variables.robot
+
 Suite Setup         Set Variables   ${DEVICE}
 Suite Teardown      Close All Connections
-

--- a/Robot-Framework/test-suites/performance-tests/ballooning.robot
+++ b/Robot-Framework/test-suites/performance-tests/ballooning.robot
@@ -4,14 +4,18 @@
 *** Settings ***
 Documentation       Testing performance of memory ballooning
 Force Tags          performance     ballooning
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/device_control.resource
+
+Resource            ../../config/variables.robot
 Library             ../../lib/PerformanceDataProcessing.py  ${DEVICE}  ${BUILD_ID}  ${COMMIT_HASH}  ${JOB}
 ...                 ${PERF_DATA_DIR}  ${CONFIG_PATH}  ${PLOT_DIR}  ${PERF_LOW_LIMIT}
+Resource            ../../resources/device_control.resource
+Resource            ../../resources/ssh_keywords.resource
+
 Suite Setup         Connect to netvm
-Test Teardown       Ballooning Test Teardown
 Suite Teardown      Close All Connections
+Test Teardown       Ballooning Test Teardown
 Test Timeout        5 minutes
+
 
 *** Variables ***
 ${test_status_file}      /tmp/ballooning_test_status

--- a/Robot-Framework/test-suites/performance-tests/boot_time_test.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time_test.robot
@@ -4,18 +4,20 @@
 *** Settings ***
 Documentation       Testing target device bootup time.
 Force Tags          boot_time_test   performance
-Resource            ../../resources/serial_keywords.resource
-Resource            ../../resources/common_keywords.resource
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/device_control.resource
-Resource            ../../resources/performance_keywords.resource
+
 Resource            ../../config/variables.robot
-Variables           ../../lib/performance_thresholds.py
 Library             ../../lib/PerformanceDataProcessing.py  ${DEVICE}  ${BUILD_ID}  ${COMMIT_HASH}  ${JOB}
 ...                 ${PERF_DATA_DIR}  ${CONFIG_PATH}  ${PLOT_DIR}  ${PERF_LOW_LIMIT}
 Library             DateTime
 Library             Collections
-Suite Setup         Boot Time Test Setup
+Resource            ../../resources/device_control.resource
+Resource            ../../resources/performance_keywords.resource
+Resource            ../../resources/serial_keywords.resource
+Resource            ../../resources/setup_keywords.resource
+Resource            ../../resources/ssh_keywords.resource
+Variables           ../../lib/performance_thresholds.py
+
+Suite Setup         Prepare Test Environment  login=False
 Suite Teardown      Close All Connections
 
 
@@ -142,15 +144,6 @@ Check Time To Notification
     ${time}  Subtract Time From Time  ${notification_time}  ${start_time}   exclude_millis=True
     Should Be True  0 < ${time} < 120
     RETURN  ${time}
-
-Boot Time Test Setup
-    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Connect to ghaf host
-        Verify service status   range=15  service=microvm@gui-vm.service  expected_status=active  expected_state=running
-        Connect to netvm
-        Connect to VM           ${GUI_VM}
-        Create test user
-    END
 
 Check Result Validity
     [Arguments]      ${captured_results}

--- a/Robot-Framework/test-suites/performance-tests/network.robot
+++ b/Robot-Framework/test-suites/performance-tests/network.robot
@@ -5,17 +5,19 @@
 Documentation       Network performance tests
 ...                 Requires iperf installed on test running PC (sudo apt install iperf)
 Force Tags          performance  network
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/serial_keywords.resource
+
 Resource            ../../config/variables.robot
-Resource            ../../resources/performance_keywords.resource
-Resource            ../../resources/connection_keywords.resource
 Library             ../../lib/output_parser.py
 Library             Process
 Library             ../../lib/PerformanceDataProcessing.py  ${DEVICE}  ${BUILD_ID}  ${COMMIT_HASH}  ${JOB}
 ...                 ${PERF_DATA_DIR}  ${CONFIG_PATH}  ${PLOT_DIR}  ${PERF_LOW_LIMIT}
 Library             Collections
 Library             JSONLibrary
+Resource            ../../resources/performance_keywords.resource
+Resource            ../../resources/serial_keywords.resource
+Resource            ../../resources/setup_keywords.resource
+Resource            ../../resources/ssh_keywords.resource
+
 Suite Setup         Run Keywords  Initialize Variables And Connect
 ...                 AND  Select network connection to use
 ...                 AND  Run iperf server on DUT

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -4,17 +4,19 @@
 *** Settings ***
 Documentation       Gathering performance data
 Force Tags          performance
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/serial_keywords.resource
+
 Resource            ../../config/variables.robot
-Resource            ../../resources/performance_keywords.resource
-Resource            ../../resources/connection_keywords.resource
 Library             ../../lib/output_parser.py
 Library             ../../lib/parse_perfbench.py
 Library             ../../lib/PerformanceDataProcessing.py  ${DEVICE}  ${BUILD_ID}  ${COMMIT_HASH}  ${JOB}
 ...                 ${PERF_DATA_DIR}  ${CONFIG_PATH}  ${PLOT_DIR}  ${PERF_LOW_LIMIT}
 Library             Collections
 Library             DateTime
+Resource            ../../resources/performance_keywords.resource
+Resource            ../../resources/serial_keywords.resource
+Resource            ../../resources/setup_keywords.resource
+Resource            ../../resources/ssh_keywords.resource
+
 Suite Setup         Initialize Variables And Connect
 Suite Teardown      Close All Connections
 

--- a/Robot-Framework/test-suites/security-tests/__init__.robot
+++ b/Robot-Framework/test-suites/security-tests/__init__.robot
@@ -3,7 +3,8 @@
 
 *** Settings ***
 Documentation       Security tests
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/connection_keywords.resource
+
+Resource            ../../resources/setup_keywords.resource
+
 Suite Setup         Initialize Variables And Connect
 Suite Teardown      Close All Connections

--- a/Robot-Framework/test-suites/security-tests/ip_spoofing_test.robot
+++ b/Robot-Framework/test-suites/security-tests/ip_spoofing_test.robot
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***
-Resource            ../../config/variables.robot
 Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/common_keywords.resource
+
 
 *** Variables ***
 ${connection}
 ${ip_server}
+
 
 *** Test Cases ***
 

--- a/Robot-Framework/test-suites/suspension-test/__init__.robot
+++ b/Robot-Framework/test-suites/suspension-test/__init__.robot
@@ -3,8 +3,8 @@
 
 *** Settings ***
 Documentation       Suspension test
-Resource            ../../resources/common_keywords.resource
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../config/variables.robot
+
+Resource            ../../resources/setup_keywords.resource
+
 Suite Setup         Prepare Test Environment
 Suite Teardown      Clean Up Test Environment

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -4,15 +4,14 @@
 *** Settings ***
 Documentation       Testing automatic suspension of Lenovo-X1
 Force Tags          regression   suspension
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../config/variables.robot
-Resource            ../../resources/common_keywords.resource
-Resource            ../../resources/gui_keywords.resource
+
 Resource            ../../resources/device_control.resource
-Resource            ../../resources/connection_keywords.resource
+Resource            ../../resources/gui_keywords.resource
 Resource            ../../resources/power_meas_keywords.resource
+Resource            ../../resources/ssh_keywords.resource
 Library             ../../lib/output_parser.py
 Library             JSONLibrary
+
 
 *** Test Cases ***
 


### PR DESCRIPTION
**Motivation**
- Reorganize keywords in resource files into more logical groups.
- Remove unnecessary resources and libraries from robot files to simplify the `Settings` sections.

**Changes**
- New resource files to categorize keywords better
    - `app_keywords.resource` - app related keywords
    - `file_keywords.resource` - file management
    - `setup_keywords.resource` - keywords for preparing and cleaning up the test environment
    - `wifi_keywords.resource` (previously `connection_keywords.resource`) - everything related to wifi connections
- Unified robot file settings and removed unnecessary libraries and resources. This style guide was used as a reference https://docs.robotframework.org/docs/style_guide
- Moved some keywords only used by one robot to that robot file (eg. version check keywords were moved to `host.robot`)

**Testruns**
- lenovo-x1 [regression and gui](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/202/)
- lenovo-x1 [performance](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/207/)
- dell-7330 [regression](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/210/)
- dell-7330 [performance](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/212/)
- orin-agx [regression and performance](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/209/)
- cross orin-agx [regression and performance](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/211/)
- orin-agx64 [regression](https://ci-dev.vedenemo.dev/job/ghaf-hw-test/134/)
- orin-nx [regression and performance](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/208/)
