### PR TITLE
Add Dell-7330 to ballooning test

### DIFF
--- a/Robot-Framework/test-suites/performance-tests/ballooning.robot
+++ b/Robot-Framework/test-suites/performance-tests/ballooning.robot
@@ -14,56 +14,84 @@ Resource            ../../resources/ssh_keywords.resource
 Suite Setup         Connect to netvm
 Suite Teardown      Close All Connections
 Test Teardown       Ballooning Test Teardown
-Test Timeout        5 minutes
+Test Timeout        10 minutes
 
 
 *** Variables ***
-${test_status_file}      /tmp/ballooning_test_status
+${robot_status_file}      /tmp/ballooning_robot_status
+${script_status_file}     /tmp/ballooning_script_status
+${test_dir}               /tmp
+${rebooted}               False
 
 
 *** Test Cases ***
 
 Test ballooning in chrome-vm
-    [Tags]                  ballooning_chrome_vm    lenovo-x1   SP-T255
-    Test ballooning in VM   vm=chrome-vm   expected_mem_at_inflate=11000    max_mem_wr=9000
+    [Tags]                  ballooning_chrome_vm    lenovo-x1   dell-7330   SP-T255
+    Test ballooning in VM   vm=chrome-vm   max_init_memory=6500
 
 Test ballooning in business-vm
-    [Tags]                  ballooning_business_vm   lenovo-x1  SP-T256
-    Test ballooning in VM   vm=business-vm   expected_mem_at_inflate=11000    max_mem_wr=9000
+    [Tags]                  ballooning_business_vm   lenovo-x1   dell-7330   SP-T256
+    Test ballooning in VM   vm=business-vm   max_init_memory=6500
 
 
 *** Keywords ***
 
 Test ballooning in VM
     [Documentation]    Check if dynamic allocation of memory works when consuming a lot of memory.
-    [Arguments]        ${vm}    ${expected_mem_at_inflate}  ${max_mem_wr}
+    [Arguments]        ${vm}   ${max_init_memory}
 
-    ${test_dir}=                      Set Variable  /tmp
+    # Dell is slow. Apply slowness factor for timeouts if running on Dell.
+    ${slowness_factor}=           Set Variable  1
+    IF  "Dell" in "${DEVICE}"
+        ${slowness_factor}=       Set Variable  2
+    END
+
     ${inflate_passed}=                Set Variable  False
     ${deflate_passed}=                Set Variable  False
-    ${timeout1}=                      Set Variable  140
-    ${timeout2}=                      Set Variable  20
+    ${init_mem_check_ok}=             Set Variable  False
+    ${mem_check_iterations}=          Set Variable  7
+    ${timeout1}=                      Evaluate      int(${slowness_factor} * 140)
+    ${timeout2}=                      Evaluate      int(${slowness_factor} * 60)
     ${timeout3}=                      Evaluate      int(${timeout1} + ${timeout2} + 20)
-    ${expected_mem_at_inflate}        Evaluate      int(${expected_mem_at_inflate})
-    ${consume_iterations}             Evaluate      int(${max_mem_wr} / 2)
+    ${expected_inflate_ratio}=        Set Variable  1.7
 
-    Connect to VM                     ${vm}
+    Connect to VM                     ${vm}     timeout=120
+
+    FOR    ${i}    IN RANGE    ${mem_check_iterations}
+        ${init_total_mem}=                Execute Command  free --mega | awk -F: 'NR==2 {print $2}' | awk '{print $1}'
+        Log                               Total memory at start ${init_total_mem}  console=True
+        IF  ${init_total_mem} > ${max_init_memory}
+            Log To Console                Initial total memory too high. Waiting for the mem-manager to adjust it.
+            Sleep  10
+        ELSE
+            ${init_mem_check_ok}=             Set Variable  True
+            BREAK
+        END
+    END
+    IF  $init_mem_check_ok != 'True'
+        FAIL    Unexpectedly high initial total memory.\nghaf-mem-manager service of ${vm} has probably failed.
+    END
+
+    ${expected_mem_at_inflate}        Evaluate      int(${init_total_mem} * ${expected_inflate_ratio})
+    Log                               Expected total memory at inflate ${expected_mem_at_inflate}  console=True
+    ${consume_iterations}             Evaluate      int(${expected_mem_at_inflate} / 2)
+    ${expected_deflate_mem}           Evaluate      int(${init_total_mem} + 500)
+    Log                               Expected total memory at deflate ${expected_deflate_mem}  console=True
+
     Put File                          performance-tests/consume_memory           ${test_dir}
     Put File                          performance-tests/log_memory               ${test_dir}
     Execute Command                   chmod 777 ${test_dir}/consume_memory      sudo=True  sudo_password=${PASSWORD}
     Execute Command                   chmod 777 ${test_dir}/log_memory          sudo=True  sudo_password=${PASSWORD}
 
-    Execute Command                   echo "stage0" > ${test_status_file}
-    Execute Command                   chmod 666 ${test_status_file}   sudo=True  sudo_password=${PASSWORD}
-    ${init_total_mem}=                Execute Command  free --mega | awk -F: 'NR==2 {print $2}' | awk '{print $1}'
-    Log                               Total memory at start ${init_total_mem}   console=True
-    ${expected_deflate_mem}           Evaluate      int(${init_total_mem} + 500)
+    Execute Command                   echo "stage0" > ${robot_status_file}
+    Execute Command                   chmod 666 ${robot_status_file}   sudo=True  sudo_password=${PASSWORD}
 
     Log To Console                    Starting memory logging script
     Run Keyword And Ignore Error      Execute Command  -b timeout ${timeout3} ${test_dir}/log_memory ${test_dir} ${vm}_${BUILD_ID}  sudo=True  sudo_password=${PASSWORD}  timeout=1
 
     Log To Console                    Starting memory consuming script
-    Run Keyword And Ignore Error      Execute Command  -b timeout ${timeout1} ${test_dir}/consume_memory ${consume_iterations} ${test_status_file}  sudo=True  sudo_password=${PASSWORD}  timeout=1
+    Run Keyword And Ignore Error      Execute Command  -b timeout ${timeout1} ${test_dir}/consume_memory ${consume_iterations} ${robot_status_file} ${script_status_file}  sudo=True  sudo_password=${PASSWORD}  timeout=1
 
     ${start_time}=                    Get Time	epoch
     FOR    ${i}    IN RANGE    ${timeout1}
@@ -72,17 +100,19 @@ Test ballooning in VM
             Log To Console            Expected total memory increase detected
             ${inflate_passed}=        Set Variable   True
             Sleep   2
-            Execute Command           echo "stage1" > ${test_status_file}
+            Execute Command           echo "stage1" > ${robot_status_file}
             BREAK
         END
-        ${inflate_process_status}=    Execute Command   cat ${test_status_file}
+        ${inflate_process_status}=    Execute Command   cat ${script_status_file}
         IF  $inflate_process_status == 'stage1'
+            Log To Console            Inflate script finished but expected total memory increase not detected
             BREAK
         END
         ${diff}=                      Evaluate    int(time.time()) - int(${start_time})
         IF   ${diff} < ${timeout1}
             Sleep    1
         ELSE
+            Log To Console            Timeout for inflate exceeded. Expected total memory increase not detected.
             BREAK
         END
     END
@@ -108,7 +138,7 @@ Test ballooning in VM
         END
     END
 
-    Execute Command                   echo "stage2" > ${test_status_file}
+    Execute Command                   echo "stage2" > ${robot_status_file}
     Sleep                             2
     Get memory logs                   ${test_dir}/ballooning_${vm}_${BUILD_ID}.csv
     Plot ballooning                   ${vm}_${BUILD_ID}
@@ -138,14 +168,18 @@ Plot ballooning
     Log   <img src="${REL_PLOT_DIR}mem_ballooning_${id}.png" alt="Power plot" width="1200">    HTML
 
 Ballooning Test Teardown
-    [Documentation]    If test gets stucked, reboot device and connect to netvm (the next test can be executed).
+    [Documentation]    If test gets stuck, reboot device and connect to netvm (the next test can be executed).
     ...                After reboot, the artifacts should be not existing, so no need to clean.
-    Run Keyword If Timeout Occurred  Run Keywords
-    ...        Reboot Laptop
-    ...  AND   Connect to netvm
+    Run Keyword If Timeout Occurred     Procedure After Timeout
+    IF  $rebooted != 'True'
+        Clean Test Artifacts
+    END
 
-    Run Keyword If Test Passed  Clean Test Artifacts
+Procedure After Timeout
+    Reboot Laptop
+    Connect to netvm
+    ${rebooted}=        Set Variable  True
 
 Clean Test Artifacts
     Execute Command     rm -r /dev/shm/test         sudo=True  sudo_password=${PASSWORD}
-    Execute Command     rm ${test_status_file}      sudo=True  sudo_password=${PASSWORD}
+    Execute Command     rm ${test_dir}/ballooning*   sudo=True   sudo_password=${PASSWORD}

--- a/Robot-Framework/test-suites/performance-tests/consume_memory
+++ b/Robot-Framework/test-suites/performance-tests/consume_memory
@@ -8,22 +8,25 @@
 # consumption causing the script to be killed before finishing.
 
 write_iterations=$1
-status_file="$2"
+robot_status_file="$2"
+script_status_file="$3"
+
+echo "stage0" > ${script_status_file}
 
 # Create a 2MB source file
 mkdir /dev/shm/test
-for i in $(seq 80000); do
+for i in $(seq 76923); do
     echo "fillthememorywiththisdata" >> /dev/shm/test/source
 done
 
 # Fill the memory by copying the source file
 for index in $(seq ${write_iterations}); do
-    cp /dev/shm/test/source /dev/shm/test/file${index}
-    if [[ $(cat ${status_file}) == "stage1" ]]
+    if [[ $(cat ${robot_status_file}) != "stage0" ]]
     then
         break
     fi
+    cp /dev/shm/test/source /dev/shm/test/file${index}
 done
 
 sleep 1
-echo stage1 > ${status_file}
+echo "stage1" > ${script_status_file}

--- a/Robot-Framework/test-suites/performance-tests/log_memory
+++ b/Robot-Framework/test-suites/performance-tests/log_memory
@@ -7,7 +7,7 @@ status_file="$3"
 
 echo "time,total_mem,used_mem,available_mem" > ${test_dir}/ballooning_${id}.csv
 start_time=$(date +%s.%3N)
-for i in $(seq 240); do
+for i in $(seq 1000); do
     current_time=$(date +%s.%3N)
     elapsed_time=$(awk "BEGIN {print $current_time - $start_time}")
     total=$(free --mega | awk -F: 'NR==2 {print $2}' | awk '{print $1}')


### PR DESCRIPTION
This PR makes ballooning test tooling more general and suitable also for Dell target.

Use expected_inflate_ratio instead of hard coded size for expected inflated memory. This way the keyword should work for any vm regardless of the configured initial memory. In ghaf configuration default ballooning ratio is 2, so let's set expected_inflate_ratio a bit lower.

Noticed that shortly after ssh login total memory of the vm can be very high (17Gi) and mem-manager service slowly decreases it. So need to give it enough time to reduce the memory. Ballooning test should start from deflated state, not when the memory of the vm is still inflated. This is especially for the slow dell target but also lenovo-x1 has sometimes vms still in inflated state after connecting to them. Added a loop for initial memory check. This is the place we still need a hard coded memory limit (as an argument) for determining if the vm is in deflated state.

Noticed that the consume_memory script is not actually able to write to the status file created by Robot. So decided to use separate status files for Robot and the shell script. They read each others status files correctly.

Sometimes ballooning might not work properly on Dell target if mem-manager services are failing but at least in the latest test runs this didn't happen.

Ballooning test on Lenovo-X1 takes around 5.5 min but on Dell it takes more than 14 min! On Dell mem-manager is much slower in adjusting memory.

Lenovo-X1
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/237/

Dell
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/263/