### PR TITLE
Fix keyword timeouts

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/__init__.robot
+++ b/Robot-Framework/test-suites/functional-tests/__init__.robot
@@ -18,10 +18,10 @@ ${DISABLE_LOGOUT}     ${EMPTY}
 *** Keywords ***
 
 Functional tests setup
-    [timeout]    5 minutes
+    [Timeout]    5 minutes
     Prepare Test Environment
     Switch Connection    ${CONNECTION}
 
 Functional tests teardown
-    [timeout]    5 minutes
+    [Timeout]    5 minutes
     Clean Up Test Environment

--- a/Robot-Framework/test-suites/gui-tests/__init__.robot
+++ b/Robot-Framework/test-suites/gui-tests/__init__.robot
@@ -16,6 +16,7 @@ Test Timeout        5 minutes
 *** Keywords ***
 
 GUI Tests Setup
+    [Timeout]    5 minutes
     Prepare Test Environment   enable_dnd=True
 
     # There's a bug that occasionally causes the app menu to freeze on Cosmic, especially on the first login. 
@@ -24,4 +25,5 @@ GUI Tests Setup
     Log in, unlock and verify   enable_dnd=True
 
 GUI Tests Teardown
+    [Timeout]    5 minutes
     Clean Up Test Environment   disable_dnd=True

--- a/Robot-Framework/test-suites/suspension-test/__init__.robot
+++ b/Robot-Framework/test-suites/suspension-test/__init__.robot
@@ -6,5 +6,16 @@ Documentation       Suspension test
 
 Resource            ../../resources/setup_keywords.resource
 
-Suite Setup         Prepare Test Environment
-Suite Teardown      Clean Up Test Environment
+Suite Setup         Suspension test setup
+Suite Teardown      Suspension test teardown
+
+
+*** Keywords ***
+
+Suspension test setup
+    [Timeout]    5 minutes
+    Prepare Test Environment
+
+Suspension test teardown
+    [Timeout]    5 minutes
+    Clean Up Test Environment

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -43,7 +43,7 @@ Automatic suspension
     Wait    50
     ${locked}         Check if locked
     Should Be True    ${locked}
-    
+
     Wait     150
     Check the screen state   off
 


### PR DESCRIPTION
suspension test failed after 5 minutes timeout exceeded in its teardown: https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/267/artifact/Robot-Framework/test-suites/suspensionANDlenovo-x1/log.html