### PR TITLE
Small fixes

### DIFF
--- a/Robot-Framework/lib/PerformanceDataProcessing.py
+++ b/Robot-Framework/lib/PerformanceDataProcessing.py
@@ -180,8 +180,8 @@ class PerformanceDataProcessing:
             stats[0] = last_measurement
             stats[4] = last_measurement
             stats[5] = last_measurement
-            stats[6] = 2 * last_measurement
-            stats[7] = 0
+            stats[6] = self.low_limit
+            stats[7] = self.low_limit
 
         if last_measurement < self.low_limit:
             flag = self.zero_result_flag

--- a/Robot-Framework/resources/serial_keywords.resource
+++ b/Robot-Framework/resources/serial_keywords.resource
@@ -119,7 +119,7 @@ Save log
     Connect via serial    timeout=60.0
     Write Data    sh -c 'journalctl | tee jrnl.txt | cat'${\n}
     ${output} =   SerialLibrary.Read Until    ghaf@ghaf-host:
-    Write Advanced Testlog    journalctl.log     ${output}
+    Write Advanced Testlog    journalctl.txt     ${output}
     Log  ${output}
     [Teardown]    Delete All Ports
 


### PR DESCRIPTION
Save journalctl.txt instead of journalctl.log in `serial_keyword.Save log` (for jenkins controller to be able to save it).
**Testrun with modified branch forcing relayboot to fail ssh connection test and `Verify init.scope status via serial`**
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/268/

If a performance test has not yet valid measurement results in its measurement history (all results are below self.low_limit) let's just plot a single marginal self.low_limit, not some marginal calculated from the invalid measured values. (upper_marginal should actually be N/A before baseline but as we are plotting the marginals without legend we can just plot the same marginal twice.)
**Demonstrated with an iperf test case producing constantly invalid results:**
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/270/
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/270/artifact/Robot-Framework/test-suites/orin-agxANDSP-T234/OrinAGX1_Measure%20UDP%20Bidir%20Throughput%20Big%20Packets.png