### PR TITLE
Refactor setup for performance boot tests (Lenovo & Dell)

### DIFF
--- a/Robot-Framework/resources/setup_keywords.resource
+++ b/Robot-Framework/resources/setup_keywords.resource
@@ -15,12 +15,14 @@ Prepare Test Environment
     Log versions
     Start journalctl recording
 
-    IF  ${login} and ("Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}")
+    IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
         Switch to vm    gui-vm
-        Save most common icons and paths to icons
         Create test user
-        Start ydotoold
-        Log in, unlock and verify   ${stop_swayidle}   ${enable_dnd}
+        IF  ${login}
+            Save most common icons and paths to icons
+            Start ydotoold
+            Log in, unlock and verify   ${stop_swayidle}   ${enable_dnd}
+        END
     END
 
 Clean Up Test Environment


### PR DESCRIPTION
Boot tests in performance -pipeline have been failing for a few days in row.
It turned out that that this was due to test code refactoring, a special case that was not noticed during testing.('testuser ' was not created).


Test results:
Dell: https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/306/
Lenovo X1: https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/307/