### PR TITLE
Open ports on AGX instead of flush

### DIFF
--- a/Robot-Framework/test-suites/performance-tests/network.robot
+++ b/Robot-Framework/test-suites/performance-tests/network.robot
@@ -169,36 +169,21 @@ Select network connection to use
 
 Run iperf server on DUT
     [Documentation]   Run iperf on DUT in server mode
-    IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}" or "Dell" in "${DEVICE}"
-         Open port 5201 from iptables
-    ELSE
-         Clear iptables rules
-    END
-
-    ${command}        Set Variable    iperf -s
-    Execute Command   nohup ${command} > /tmp/output.log 2>&1 &
+    Open port 5201 from iptables
+    ${command}                      Set Variable    iperf -s
+    Execute Command                 nohup ${command} > /tmp/output.log 2>&1 &
     Check iperf was started
-
-Clear iptables rules
-    [Documentation]  Clear IP tables rules to open ports
-    Execute Command  iptables -F  sudo=True  sudo_password=${PASSWORD}
 
 Open port 5201 from iptables
     [Documentation]  Firewall rule to open needed port for perf test.
-    Execute Command  iptables -I INPUT -m tcp -p tcp --dport 5201 -j ACCEPT  sudo=True  sudo_password=${PASSWORD}
-    Execute Command  iptables -I INPUT -m udp -p udp --dport 5201 -j ACCEPT  sudo=True  sudo_password=${PASSWORD}
-
-    # Accept incoming packages that do belong to some already opened connection
-    Execute Command  iptables -I INPUT -m state RELATED, ESTABLISHED -j ACCEPT  sudo=True  sudo_password=${PASSWORD}
+    Execute Command  iptables -A ghaf-fw-in-filter -p tcp --dport 5201 -j ACCEPT  sudo=True  sudo_password=${PASSWORD}
+    Execute Command  iptables -A ghaf-fw-in-filter -p udp --dport 5201 -j ACCEPT  sudo=True  sudo_password=${PASSWORD}
     Sleep        1
 
 Close port 5201 from iptables
     [Documentation]  Firewall rule to close the port that was used in per testing
-    Execute Command  iptables -I INPUT -m tcp -p tcp --dport 5201 -j DROP  sudo=True  sudo_password=${PASSWORD}
-    Execute Command  iptables -I INPUT -m udp -p udp --dport 5201 -j DROP  sudo=True  sudo_password=${PASSWORD}
-
-    # Reject also incoming packages that do belong to some already opened connection
-    Execute Command  iptables -I INPUT -m state RELATED, ESTABLISHED -j DROP  sudo=True  sudo_password=${PASSWORD}
+    Execute Command  iptables -A ghaf-fw-in-filter -p tcp --dport 5201 -j DROP  sudo=True  sudo_password=${PASSWORD}
+    Execute Command  iptables -A ghaf-fw-in-filter -p udp --dport 5201 -j DROP  sudo=True  sudo_password=${PASSWORD}
 
 Stop iperf server
     @{pid}=  Find pid by name  iperf


### PR DESCRIPTION
After PR1285 'iptables -F' will cause Orin AGX to drop all ssh connections. To avoid this open needed ports one by one. 

There is also an other issue in the current way of opening ports. We should not bypass the ghaf firewall rules by
```
iptables -I INPUT -m tcp -p tcp --dport 5201 -j ACCEPT
iptables -I INPUT -m udp -p udp --dport 5201 -j ACCEPT
```
instead open the ports in ghaf-fw-in-filter by
```
iptables -A ghaf-fw-in-filter -p tcp --dport 5201 -j ACCEPT
iptables -A ghaf-fw-in-filter -p udp --dport 5201 -j ACCEPT
```
then we can measure the actual effect of the rules to the speed.


Delete 'Clear iptables rules' keyword.

Delete iptables commands which don't not work:
`iptables -I INPUT -m state RELATED, ESTABLISHED -j ACCEPT`


**network tests of this PR fail on current mainline Orin AGX image:**
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/376/artifact/Robot-Framework/test-suites/orin-agxANDnetwork/report.html#totals

**With the agx image from PR1285 pre-merge tests they pass:**
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/380/

**With lenovo-x1 image from PR1285 pre-merge tests:**
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/388/