### PR TITLE
Refactor setups and teardowns

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -42,11 +42,11 @@ Verify Systemctl status
         Set Test Variable   ${failed_units}
 
         IF  '${status}' not in ['running', 'starting']
-            Log To Console   Systemctl status is ${status}
+            Log     Systemctl status is ${status}  console=True
             FAIL    Systemctl is not running! Status is ${status}. Failed processes are: ${failed_units}
         ELSE IF    '${status}' == 'running'
             ${diff}=    Evaluate    int(time.time()) - int(${start_time})
-            Log To Console   Systemctl status is ${status} after ${diff} sec
+            Log     Systemctl status is ${status} after ${diff} sec  console=True
             RETURN
         END
         Sleep    1

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -149,7 +149,7 @@ Locate on screen
         Timestamp screenshot
         FAIL  Image recognition failure: ${searched_item}
     END
-    Log To Console    Coordinates: ${coordinates}
+    Log         Coordinates: ${coordinates}  console=True
     ${mouse_x}  Get From Dictionary   ${coordinates}  x
     ${mouse_y}  Get From Dictionary   ${coordinates}  y
     RETURN  ${mouse_x}  ${mouse_y}
@@ -220,9 +220,9 @@ Check if logged out
     FOR   ${i}   IN RANGE  ${iterations}
         ${activity}=       Execute Command    systemctl --user is-active xdg-desktop-portal.service  return_stdout=True
         IF  $activity == "active"
-            Log To Console      User session is ${activity}, user is logged in
+            Log      User session is ${activity}, user is logged in  console=True
         ELSE
-            Log To Console      User session is ${activity}, user is logged out
+            Log      User session is ${activity}, user is logged out  console=True
             RETURN    ${True}
         END
         Sleep  1
@@ -238,8 +238,8 @@ Wait for user session to be active
     FOR   ${i}   IN RANGE   ${iterations}
         ${activity}=       Execute Command    systemctl --user is-active xdg-desktop-portal.service  return_stdout=True
         IF  $activity == "active"
-            Log To Console    Success
-            Log To Console    User session is ${activity}, user is logged in
+            Log    Success  console=True
+            Log    User session is ${activity}, user is logged in  console=True
             BREAK
         END
         Log To Console   ${i}.  no_newline=true

--- a/Robot-Framework/resources/performance_keywords.resource
+++ b/Robot-Framework/resources/performance_keywords.resource
@@ -61,7 +61,7 @@ Install sysbench tool
     IF  ${not_installed}
         Execute Command    nix-env -i sysbench
         ${command_output}=    Execute Command    nix-env --query --installed
-        Log To Console    ${\n}Installed packages:${\n}${command_output}
+        Log               ${\n}Installed packages:${\n}${command_output}  console=True
         Should Contain    ${command_output}    sysbench    sysbench tool was not installed
         Log To Console    sysbench tool was successfully installed
     ELSE

--- a/Robot-Framework/resources/serial_keywords.resource
+++ b/Robot-Framework/resources/serial_keywords.resource
@@ -97,11 +97,11 @@ Verify init.scope status via serial
         Write Data    \x03${\n}        # write ctrl+c to stop reading status
         ${status}  ${state}   Get Service Status    ${output}
         IF  '${state}' not in ['running', 'starting']
-            Log To Console   init.scope status is ${status}
+            Log     init.scope status is ${status}  console=True
             FAIL    init.scope is not running! Status is ${state}
         ELSE IF    '${state}' == 'running'
             ${diff}=    Evaluate    int(time.time()) - int(${start_time})
-            Log To Console   init.scope status is ${status}
+            Log     init.scope status is ${status}  console=True
             RETURN
         END
         Sleep    1

--- a/Robot-Framework/resources/setup_keywords.resource
+++ b/Robot-Framework/resources/setup_keywords.resource
@@ -11,7 +11,7 @@ Resource            ../resources/ssh_keywords.resource
 
 Prepare Test Environment
     [Arguments]   ${login}=True   ${stop_swayidle}=True   ${enable_dnd}=False
-    Initialize Variables And Connect
+    Connect to device
     Log versions
     Start journalctl recording
 
@@ -26,6 +26,7 @@ Prepare Test Environment
     END
 
 Clean Up Test Environment
+    [Timeout]     5 minutes
     [Arguments]   ${disable_dnd}=False
     Connect to ghaf host
     Stop journalctl recording
@@ -37,10 +38,9 @@ Clean Up Test Environment
     END
     Close All Connections
 
-Initialize Variables And Connect
-    [Documentation]  Initialize variables. Connect to device and start logging
+Connect to device
+    [Documentation]  Connect to device
     Close All Connections
-    Set Variables   ${DEVICE}
     Run Keyword If  "${DEVICE_IP_ADDRESS}" == "NONE"    Get ethernet IP address
     ${port_22_is_available}     Check if ssh is ready on device   timeout=60
     IF  ${port_22_is_available} == False

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -28,20 +28,20 @@ Check If Ping Fails
 
 Check Network Availability
     [Arguments]            ${host}  ${expected_result}=True  ${range}=5
-    Log To Console         Checking network ${host} availability, expected: ${expected_result}
+    Log                    Checking network ${host} availability, expected: ${expected_result}  console=True
     Set Global Variable    ${IS_AVAILABLE}   False
     FOR   ${i}   IN RANGE  ${range}
         Write    ping ${host} -c 1
         TRY
             Read Until           1 received
             Set Global Variable  ${IS_AVAILABLE}  True
-            Log To Console  ${host} is available
+            Log   ${host} is available  console=True
             IF    ${expected_result} == True
                 BREAK
             END
         EXCEPT
             IF    ${expected_result} == False
-                Log To Console  ${host} is unavailable
+                Log    ${host} is unavailable  console=True
                 BREAK
             ELSE
                 CONTINUE

--- a/Robot-Framework/test-suites/__init__.robot
+++ b/Robot-Framework/test-suites/__init__.robot
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Settings ***
+Resource            ../config/variables.robot
+Suite Setup         Global Setup
+
+*** Keywords ***
+Global Setup
+    Log To Console  Global setup: Initialize Variables
+    Set Variables   ${DEVICE}

--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -130,8 +130,8 @@ Wait Until Falcon Download Complete
 
 Ask the question
     [Arguments]      ${question}
-    Log To Console   Asking AI: ${question}
+    Log              Asking AI: ${question}  console=True
     Execute Command  script -q -c 'ollama run falcon3:10b "${question}" > result.txt'     return_stderr=True    timeout=60
     ${answer}        Execute Command  cat result.txt
-    Log To Console   The answer is: ${answer}
+    Log              The answer is: ${answer}  console=True
     RETURN           ${answer}

--- a/Robot-Framework/test-suites/performance-tests/network.robot
+++ b/Robot-Framework/test-suites/performance-tests/network.robot
@@ -18,7 +18,7 @@ Resource            ../../resources/serial_keywords.resource
 Resource            ../../resources/setup_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
-Suite Setup         Run Keywords  Initialize Variables And Connect
+Suite Setup         Run Keywords  Connect to device
 ...                 AND  Select network connection to use
 ...                 AND  Run iperf server on DUT
 Suite Teardown      Run Keywords  Stop iperf server
@@ -158,7 +158,7 @@ Measure UDP Bidir Throughput Big Packets
 
 *** Keywords ***
 Select network connection to use
-    [Documentation]  Select the connection to be used. This cannot be done in Keyword 'Initialize Variables And Connect'
+    [Documentation]  Select the connection to be used. This cannot be done in Keyword 'Connect to device'
      ...             since it then breaks the  other test suites.
      IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}" or "Dell" in "${DEVICE}"
          ${CONNECTION}       Connect to netvm
@@ -188,7 +188,7 @@ Close port 5201 from iptables
 Stop iperf server
     @{pid}=  Find pid by name  iperf
     IF  @{pid} != @{EMPTY}
-        Log To Console  Close iperf server: @{pid}
+        Log             Close iperf server: @{pid}  console=True
         Kill process    @{pid}
     END
 

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -17,7 +17,7 @@ Resource            ../../resources/serial_keywords.resource
 Resource            ../../resources/setup_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
-Suite Setup         Initialize Variables And Connect
+Suite Setup         Connect to device
 Suite Teardown      Close All Connections
 
 *** Variables ***
@@ -214,7 +214,7 @@ Sysbench test in VMs
         ${threads_n}	Get From Dictionary	  ${threads}	 ${vm}
         ${vm_fail}      Transfer Sysbench Test Script To VM   ${vm}
         IF  '${vm_fail}' == 'FAIL'
-            Log To Console  Skipping tests for ${vm} because couldn't connect to it
+            Log         Skipping tests for ${vm} because couldn't connect to it  console=True
         ELSE
             ${output}       Execute Command      /tmp/sysbench_test ${threads_n}  sudo=True  sudo_password=${PASSWORD}
             Run Keyword If    ${threads_n} > 1   Save sysbench results   ${vm}
@@ -286,7 +286,7 @@ Transfer Sysbench Test Script To VM
         ${vm_fail}    ${result} =    Run Keyword And Ignore Error    Connect to VM    ${vm}
         Run Keyword If    '${vm_fail}' == 'FAIL'   Append To List	 ${FAILED_VMS}	  ${vm}
         Run Keyword If    '${vm_fail}' == 'FAIL'   Return From Keyword  ${vm_fail}
-        Log To Console    Successfully connected to ${vm}
+        Log               Successfully connected to ${vm}  console=True
     END
     Put File           performance-tests/sysbench_test    /tmp
     Execute Command    chmod 777 /tmp/sysbench_test
@@ -300,11 +300,11 @@ Save cpu results
     ${statistics}       Output Dictionary First Value   ${statistics_dict}
     IF  "${statistics}[flag]" == "-1"
         Append To List     ${FAILED_VM_TESTS}        ${host}_${test}
-        Log To Console     Deviation detected in test: ${host}_${test}
+        Log                Deviation detected in test: ${host}_${test}  console=True
     END
     IF  "${statistics}[flag]" == "1"
         Append To List     ${IMPROVED_VM_TESTS}      ${host}_${test}
-        Log To Console     Improvement detected in test: ${host}_${test}
+        Log                Improvement detected in test: ${host}_${test}  console=True
     END
 
 Save memory results
@@ -317,11 +317,11 @@ Save memory results
     ${statistics}       Output Dictionary First Value   ${statistics_dict}
     IF  "${statistics}[flag]" == "-1"
         Append To List     ${FAILED_VM_TESTS}        ${host}_${test}
-        Log To Console     Deviation detected in test: ${host}_${test}
+        Log                Deviation detected in test: ${host}_${test}  console=True
     END
     IF  "${statistics}[flag]" == "1"
         Append To List     ${IMPROVED_VM_TESTS}      ${host}_${test}
-        Log To Console     Improvement detected in test: ${host}_${test}
+        Log                Improvement detected in test: ${host}_${test}  console=True
     END
 
 Save sysbench results

--- a/Robot-Framework/test-suites/security-tests/__init__.robot
+++ b/Robot-Framework/test-suites/security-tests/__init__.robot
@@ -6,5 +6,5 @@ Documentation       Security tests
 
 Resource            ../../resources/setup_keywords.resource
 
-Suite Setup         Initialize Variables And Connect
+Suite Setup         Connect to device
 Suite Teardown      Close All Connections

--- a/Robot-Framework/test-suites/suspension-test/__init__.robot
+++ b/Robot-Framework/test-suites/suspension-test/__init__.robot
@@ -4,6 +4,7 @@
 *** Settings ***
 Documentation       Suspension test
 
+Resource            ../../resources/device_control.resource
 Resource            ../../resources/setup_keywords.resource
 
 Suite Setup         Suspension test setup


### PR DESCRIPTION
Changes:
1. Now there is common __init__ file for ALL test suites, where "global" setup is defined. Here we initialize variables. This will require to use these variable in all other test suiltes' init files, especially use device control library.
2. Suspension test: after waking up od the device - check that lock screen appeared. In case is test fails, reboot laptop.
3. Replace "Log To Console" with "Log" + console=True for comments with variables, to be able to see them in reports, not only in logs.

Example of the failed suspension test with reboot in the test teardown: https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/408/artifact/Robot-Framework/test-suites/SP-T162/log.html
Here are 3 levels of setups/teardowns:
<img width="793" height="1119" alt="image" src="https://github.com/user-attachments/assets/f901a9e8-d6f5-48af-aeec-1c14726d6cc1" />
