### PR TITLE
Improvements to app tests

### DIFF
--- a/Robot-Framework/resources/app_keywords.resource
+++ b/Robot-Framework/resources/app_keywords.resource
@@ -10,16 +10,12 @@ Resource            ../resources/ssh_keywords.resource
 *** Keywords ***
 
 Start XDG application
-    [Arguments]      ${app_name}  ${gui_vm_app}=false
+    [Arguments]      ${app_name}
     Log To Console   ${\n}Starting ${app_name}
     ${app_name}      Check application name  ${app_name}
     ${output}        Execute Command    cat /run/current-system/sw/share/applications/${app_name}.desktop
     ${path}          Get App Path From Desktop  ${output}
-    IF  $gui_vm_app
-        Execute Command  nohup sh -c 'WAYLAND_DISPLAY=wayland-1 ${path}' > output.log 2>&1 &
-    ELSE
-        Execute Command  nohup sh -c '${path}' > output.log 2>&1 &
-    END
+    Execute Command  nohup sh -c 'WAYLAND_DISPLAY=wayland-1 ${path}' > output.log 2>&1 &
 
 Check that the application was started
     [Arguments]          ${app_name}  ${range}=2  ${exact_match}=false
@@ -47,7 +43,7 @@ Check that the application is not running
     Log To Console    ${app_name} not running
 
 Launch Cosmic Term
-    Start XDG application   com.system76.CosmicTerm  gui_vm_app=true
+    Start XDG application   com.system76.CosmicTerm
     Check that the application was started    cosmic-term  exact_match=true
 
 Log and remove app output
@@ -56,7 +52,7 @@ Log and remove app output
     Switch to vm  ${vm}    ${user}
     ${output}     Execute Command    cat ${file}
     Log           ${output}
-    Remove file   ${file}    user=${user}
+    Remove file   ${file}
 
 Log app vm journalctl
     [Documentation]    Specify the VM where the App is actually running

--- a/Robot-Framework/resources/file_keywords.resource
+++ b/Robot-Framework/resources/file_keywords.resource
@@ -5,10 +5,14 @@
 
 Create file
     [Documentation]    Create file with given path & name, requires existing ssh connection
-    [Arguments]        ${file_name}
+    [Arguments]        ${file_name}   ${sudo}=False
     Log To Console     Creating file ${file_name}
-    Execute Command    touch ${file_name}  sudo=True  sudo_password=${password}
-    Check file exists  ${file_name}
+    IF  ${sudo}
+        Execute Command    touch ${file_name}  sudo=True  sudo_password=${password}
+    ELSE
+        Execute Command    touch ${file_name}
+    END
+    Check file exists  ${file_name}   ${sudo}
 
 Create text file
     [Documentation]    Create text file with given text and name, requires existing ssh connection
@@ -19,27 +23,26 @@ Create text file
 
 Remove file
     [Documentation]    Remove file with given path & name, requires existing ssh connection
-    [Arguments]        ${file_name}  ${user}=ghaf
+    [Arguments]        ${file_name}   ${sudo}=False
     Log To Console     Removing file ${file_name}
-    IF  $user=='ghaf'
-        Execute Command    rm ${file_name}  sudo=True  sudo_password=${PASSWORD}
-        Check file doesn't exist  ${file_name}
+        IF  ${sudo}
+        Execute Command    rm ${file_name}  sudo=True  sudo_password=${password}
     ELSE
         Execute Command    rm ${file_name}
-        Check file doesn't exist  ${file_name}  user=${USER_LOGIN}
     END
+    Check file doesn't exist  ${file_name}   ${sudo}
 
 Copy file
     [Documentation]    Copy file, requires existing ssh connection
     [Arguments]        ${file_1}    ${file_2}
     Log To Console     Copying file ${file_1} to ${file_2}
-    ${output}  ${rc}   Execute Command    cp ${file_1} ${file_2}   return_rc=True  sudo=True  sudo_password=${password}
+    ${output}  ${rc}   Execute Command    cp ${file_1} ${file_2}   return_rc=True
 
 Check file exists
     [Documentation]    Check file exists, requires existing ssh connection
-    [Arguments]        ${file_name}  ${user}=ghaf
+    [Arguments]        ${file_name}   ${sudo}=False
     Log To Console     Check if file ${file_name} exists
-    IF  $user=='ghaf'
+    IF  ${sudo}
         ${output}  ${rc}   Execute Command    ls ${file_name}   return_rc=True  sudo=True  sudo_password=${password}
     ELSE
         ${output}  ${rc}   Execute Command    ls ${file_name}   return_rc=True
@@ -48,10 +51,10 @@ Check file exists
 
 Check file doesn't exist
     [Documentation]    Check file doesn't exist, requires existing ssh connection
-    [Arguments]        ${file_name}  ${user}=ghaf
+    [Arguments]        ${file_name}  ${sudo}=False
     Log To Console     Check if file ${file_name} exists
-    IF  $user=='ghaf'
-        ${output}  ${rc}   Execute Command    ls ${file_name}   return_rc=True  sudo=True  sudo_password=${password}
+    IF  ${sudo}
+        ${output}  ${rc}   Execute Command    ls ${file_name}   return_rc=True   sudo=True  sudo_password=${password}
     ELSE
         ${output}  ${rc}   Execute Command    ls ${file_name}   return_rc=True
     END

--- a/Robot-Framework/test-suites/functional-tests/apps.robot
+++ b/Robot-Framework/test-suites/functional-tests/apps.robot
@@ -119,11 +119,11 @@ Open image with Oculante
 Open text file with Cosmic Text Editor
     [Documentation]    Open text file and check that Cosmic Text Editor app is started
     [Tags]             bat  regression  SP-T262
-    Connect to VM      ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
+    Switch to vm       gui-vm  user=${USER_LOGIN}
     Create text file   test    /tmp/test_text.txt
     Open text file     /tmp/test_text.txt
     Check that the application was started    cosmic-edit    10
-    [Teardown]  Run Keywords  Remove the file in VM    /tmp/test_text.txt    ${GUI_VM}    AND
+    [Teardown]  Run Keywords  Remove the file in VM    /tmp/test_text.txt    ${GUI_VM}    ${USER_LOGIN}    AND
     ...                       Kill Process And Save Logs    ${GUI_VM}    ${USER_LOGIN}    /tmp/out.log
 
 
@@ -142,10 +142,9 @@ Kill Process And Save Logs
     Run Keyword If Test Failed  Log app vm journalctl  ${app_running_vm}
 
 Remove the file in VM
-    [Arguments]        ${file_name}    ${vm}
-    Switch to vm       ${vm}
+    [Arguments]        ${file_name}    ${vm}   ${user}=ghaf
+    Switch to vm       ${vm}   user=${user}
     Remove file        ${file_name}
-    Check file doesn't exist    ${file_name}
 
 Open PDF from app-vm
     [Arguments]        ${vm}

--- a/Robot-Framework/test-suites/functional-tests/business-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/business-vm.robot
@@ -58,5 +58,5 @@ Business Apps Test Setup
 
 Business Apps Test Teardown
     Kill process  @{APP_PIDS}
-    Log and remove app output     output.log             ${BUSINESS_VM}
+    Log and remove app output     output.log             ${GUI_VM}    ${USER_LOGIN}
     Run Keyword If Test Failed    Log app vm journalctl  ${BUSINESS_VM}

--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -20,54 +20,54 @@ Test Teardown       Gui-vm Test Teardown
 
 *** Test Cases ***
 
-Start Calculator on LenovoX1
+Start Calculator
     [Documentation]   Start Calculator and verify process started
     [Tags]            bat   pre-merge  calculator  SP-T202  lenovo-x1  dell-7330  fmo
-    Start XDG application  Calculator  gui_vm_app=true
+    Start XDG application  Calculator
     Check that the application was started    calculator
 
-Start Sticky Notes on LenovoX1
+Start Sticky Notes
     [Documentation]   Start Sticky Notes and verify process started
     [Tags]            bat   pre-merge  sticky_notes  SP-T201-1  lenovo-x1  dell-7330  fmo
-    Start XDG application  'Sticky Notes'  gui_vm_app=true
+    Start XDG application  'Sticky Notes'
     Check that the application was started    sticky-wrapped
 
-Start Ghaf Control Panel on LenovoX1
+Start Ghaf Control Panel
     [Documentation]   Start Ghaf Control Panel and verify process started
     [Tags]            bat   pre-merge  control_panel  SP-T205  lenovo-x1  dell-7330  fmo
-    Start XDG application  'Ghaf Control Panel'  gui_vm_app=true
+    Start XDG application  'Ghaf Control Panel'
     Check that the application was started    ctrl-panel
 
-Start Bluetooth Settings on LenovoX1
+Start Bluetooth Settings
     [Documentation]   Start Bluetooth Settings and verify process started
     [Tags]            bat   pre-merge  bluetooth_settings  SP-T204  lenovo-x1  dell-7330  fmo
-    Start XDG application  'Bluetooth Settings'  gui_vm_app=true
+    Start XDG application  'Bluetooth Settings'
     Check that the application was started    blueman-manager-wrapped-wrapped
 
-Start COSMIC Files on LenovoX1
+Start COSMIC Files
     [Documentation]   Start Cosmic Files and verify process started
     [Tags]            bat   pre-merge  cosmic_files  SP-T206  lenovo-x1  dell-7330  fmo
-    Start XDG application  com.system76.CosmicFiles  gui_vm_app=true
+    Start XDG application  com.system76.CosmicFiles
     Check that the application was started    cosmic-files %U  exact_match=true
 
-Start COSMIC Settings on LenovoX1
+Start COSMIC Settings
     [Documentation]   Start Cosmic Settings and verify process started
     [Tags]            bat   pre-merge  cosmic_settings  SP-T254  lenovo-x1  dell-7330  fmo
-    Start XDG application  com.system76.CosmicSettings  gui_vm_app=true
+    Start XDG application  com.system76.CosmicSettings
     Check that the application was started    cosmic-settings  exact_match=true
 
-Start COSMIC Text Editor on LenovoX1
+Start COSMIC Text Editor
     [Documentation]   Start Cosmic Text Editor and verify process started
     [Tags]            bat   pre-merge  cosmic_editor  SP-T243  lenovo-x1  dell-7330  fmo
-    Start XDG application   com.system76.CosmicEdit  gui_vm_app=true
+    Start XDG application   com.system76.CosmicEdit
     Check that the application was started    cosmic-edit %F  exact_match=true
 
-Start COSMIC Terminal on LenovoX1
+Start COSMIC Terminal
     [Documentation]   Start Cosmic Terminal and verify process started
     [Tags]            bat   cosmic_term  SP-T263  lenovo-x1   dell-7330  fmo
     Launch Cosmic Term
 
-Start Falcon AI on LenovoX1
+Start Falcon AI
     [Documentation]   Start Falcon AI and verify process started
     [Tags]            falcon_ai  SP-T223-1  lenovo-x1   dell-7330
     Get Falcon LLM Name
@@ -93,19 +93,19 @@ Check user systemctl status
 Start Firefox GPU on FMO
     [Documentation]   Start Firefox GPU and verify process started
     [Tags]            bat   firefox_gpu  fmo
-    Start XDG application  'Firefox GPU'  gui_vm_app=true
+    Start XDG application  'Firefox GPU'
     Check that the application was started    firefox
 
 Start Google Chrome GPU on FMO
     [Documentation]   Start Google Chrome GPU and verify process started
     [Tags]            bat   chrome_gpu  fmo
-    Start XDG application  'Google Chrome GPU'  gui_vm_app=true
+    Start XDG application  'Google Chrome GPU'
     Check that the application was started    chrome
 
 Start Display Settings on FMO
     [Documentation]   Start Display Settings and verify process started
     [Tags]            bat   display_settings  fmo
-    Start XDG application  'Display Settings'  gui_vm_app=true
+    Start XDG application  'Display Settings'
     Check that the application was started    wdisplays
 
 *** Keywords ***
@@ -116,9 +116,8 @@ Gui-vm Test Setup
 Gui-vm Test Teardown
     Switch to vm    gui-vm
     Kill process        @{APP_PIDS}
-    Switch to vm    gui-vm  user=${USER_LOGIN}
-    ${app_log}          Execute command    cat output.log
-    Log                 ${app_log}
+    Log and remove app output     output.log             gui-vm    ${USER_LOGIN}
+    Run Keyword If Test Failed    Log app vm journalctl  gui-vm
 
 Wait Until Falcon Download Complete
     FOR  ${i}  IN RANGE   100

--- a/Robot-Framework/test-suites/functional-tests/shares.robot
+++ b/Robot-Framework/test-suites/functional-tests/shares.robot
@@ -48,11 +48,11 @@ File sharing test
     Set Test Variable  ${vm1_in_guivm}    /Shares/'Unsafe ${vm1} share'
     Set Test Variable  ${vm2_in_guivm}    /Shares/'Unsafe ${vm2} share'
     Connect to VM      ${vm1}
-    Create file        ${path_in_vm}/${file_name}
-    Connect to VM      ${GUI_VM}
+    Create file        ${path_in_vm}/${file_name}   sudo=True
+    Connect to VM      ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
     Copy file          ${vm1_in_guivm}/${file_name}    ${vm2_in_guivm}/${file_name}
     Connect to VM      ${vm2}
-    Check file exists  ${path_in_vm}/${file_name}
+    Check file exists  ${path_in_vm}/${file_name}   sudo=True
     [Teardown]         Run Keywords
     ...                Remove the file in VM    ${path_in_vm}/${file_name}    ${vm1}    AND
     ...                Remove the file in VM    ${path_in_vm}/${file_name}    ${vm2}
@@ -65,5 +65,4 @@ Shares setup
 Remove the file in VM
     [Arguments]        ${file_name}    ${vm}
     Connect to VM      ${vm}
-    Remove file        ${file_name}
-    Check file doesn't exist    ${file_name}
+    Remove file        ${file_name}    sudo=True


### PR DESCRIPTION
Fixed a few issues related to app tests
- `Remove the file in VM` was calling `Check file doesn't exist` twice. First inside `Remove file` and then again directly from the keyword.
- In `Start XDG application` the condition `IF $gui_vm_app` was always evaluated as true. I found out that we don't need a separate command for gui apps and other apps anymore.
- Gui-vm app tests still had `on LenovoX1` in their names.
- Saving the log in `Business Apps Test Teardown` was not working.
- For gui-vm app tests the app logs were not removed and journal logs were not saved in case the test failed.

In addition to those I removed `sudo` from all file related commands in app tests that don’t require it. Using `sudo` adds about 4 seconds extra every time. That does not sound like a lot but adds up very quickly in the app teardowns.

This PR makes the lenovo-x1 bat suite ~2 minutes faster.

[Testrun](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/461/)