### PR TITLE
Optimize audio test

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/audio.robot
+++ b/Robot-Framework/test-suites/functional-tests/audio.robot
@@ -3,14 +3,14 @@
 
 *** Settings ***
 Documentation       Testing audio application
-Force Tags          audio   bat  regression  pre-merge
+Force Tags          audio   bat  regression  pre-merge   lenovo-x1   dell-7330
 
 Library             DateTime
-Library             OperatingSystem
+Resource            ../../resources/file_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
-Test Setup          Connect to netvm
-Test Teardown       Close All Connections
+Suite Setup         Connect to netvm
+Suite Teardown      Close All Connections
 Test Timeout        3 minutes
 
 
@@ -20,38 +20,45 @@ ${AUDIO_DIR}    ${OUTPUT_DIR}/outputs/audio-temp
 
 
 *** Test Cases ***
-Record Audio And Verify
-    [Documentation]  Record short audio with pulseaudio tool. Verify audio clip is bigger than default empty file (40Kb)
-    [Teardown]  Execute Command  rm /tmp/test*.wav  sudo=True  sudo_password=${PASSWORD}
-    [Tags]      SP-T247   lenovo-x1   dell-7330
-    FOR  ${vm}  IN  ${CHROME_VM}  ${BUSINESS_VM}
-        Connect to VM  ${vm}
-        # Execute Command timeouts in business-vm, but it is executing the command
-        Log To Console  Recording audio file
-        Run Keyword And Ignore Error  Execute Command  parecord -r /tmp/test_${vm}.wav  sudo=True  sudo_password=${PASSWORD}  timeout=10
-        Sleep  5
-        Execute Command  pkill parecord  timeout=10  sudo=True  sudo_password=${PASSWORD}
-        Sleep  1
-        SSHLibrary.Get File  /tmp/test_${vm}.wav  ${AUDIO_DIR}/test_${vm}.wav
-        Check Audio File  ${AUDIO_DIR}/test_${vm}.wav
-    END
+
+Record audio in Chrome-VM
+    [Tags]  SP-T247-1
+    Record Audio And Verify   ${CHROME_VM}
+
+Record audio in Business-VM
+    [Tags]   SP-T247-2
+    Record Audio And Verify   ${BUSINESS_VM}
+
+Record audio in Comms-VM
+    [Tags]   SP-T247-3
+    Record Audio And Verify   ${COMMS_VM}
 
 Check Audio devices
     [Documentation]  List audio sinks and sources in business-vm and chrome-vm and check status is running
-    [Tags]      SP-T246   lenovo-x1   dell-7330
-    FOR  ${vm}  IN  ${CHROME_VM}  ${BUSINESS_VM}
-        Connect to VM  ${vm}
-        ${sources}  Execute Command  pactl list sources   sudo=True  sudo_password=${PASSWORD}
-        ${sinks}  Execute Command  pactl list sinks   sudo=True  sudo_password=${PASSWORD}
+    [Tags]      SP-T246
+    FOR  ${vm}  IN  ${CHROME_VM}  ${BUSINESS_VM}  ${COMMS_VM}
+        Switch to vm   ${vm}
+        ${sources}   Execute Command  pactl list sources
+        ${sinks}     Execute Command  pactl list sinks
         Should Not Be Empty  ${sources}
         Should Not Be Empty  ${sinks}
     END
 
 
 *** Keywords ***
+Record Audio And Verify
+    [Documentation]  Record short audio with pulseaudio tool. Verify audio clip is bigger than default empty file (40Kb)
+    [Arguments]      ${vm}   ${audiofile}=test_${vm}.wav
+    Switch to vm           ${vm}
+    Log To Console         Recording audio file
+    Execute Command        sh -c 'parecord -r /tmp/${audiofile} & sleep 5 && pkill parecord && chown ghaf:ghaf /tmp/${audiofile}'    sudo=True  sudo_password=${PASSWORD}    timeout=15
+    SSHLibrary.Get File    /tmp/${audiofile}  ${AUDIO_DIR}/${audiofile}
+    Check Audio File       ${AUDIO_DIR}/${audiofile}
+    [Teardown]   Remove file   /tmp/${audiofile}
+
 Check Audio File
     [Documentation]  Check some basic audio data
-    [Arguments]  ${audiofile}  ${expected_duration}=5 sec
+    [Arguments]  ${audiofile}  ${expected_duration}=2 sec
     ${out}  Run  ffmpeg -i ${audiofile}
     ${duration}  Get Regexp Matches  ${out}  (?im)(Duration: )(\\d{1,2}:\\d{1,2}:\\d{1,2}.\\d{1,3})  2
     ${bitrate}  Get Regexp Matches  ${out}  (?im)(bitrate: )(\\d{1,4})  2


### PR DESCRIPTION
- This PR does not significantly change how the test works, only makes them faster. Audio tests take about half the time they used to after this PR.
- Separated `Record Audio And Verify` into separate test cases so that only some of them can be included into pre-merge if necessary.
- Added comms-vm to audio tests. It should probably have been added right after it was created but better late than never.

[Lenovo-X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/469/)
[Dell-7330](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/472/)