### PR TITLE
Open specific port instead of iptables flush

### DIFF
--- a/Robot-Framework/test-suites/security-tests/nc_server
+++ b/Robot-Framework/test-suites/security-tests/nc_server
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
-sudo iptables -F
+sudo iptables -A ghaf-fw-in-filter -p tcp --dport 5201 -j ACCEPT
 
 echo "" > /tmp/server_received.txt
 

--- a/Robot-Framework/test-suites/security-tests/nc_stealer
+++ b/Robot-Framework/test-suites/security-tests/nc_stealer
@@ -5,7 +5,7 @@
 # ip_server=
 # ip_stealer=
 
-sudo iptables -F
+sudo iptables -A ghaf-fw-in-filter -p tcp --dport 5201 -j ACCEPT
 
 echo "" > /tmp/stolen.txt
 


### PR DESCRIPTION
Motivated by list of new security requirements I decided to test ipspoofing. It didn't work. Here is the fix (same issue as in the iperf tests). The test result is still FAIL because ghaf allows internal ipspoofing.