### PR TITLE
Add timeout to Locate on screen

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -116,24 +116,26 @@ Locate on screen
     [Documentation]    Take a screenshot. Locate given image or text on the screenshot.
     ...                Return center coordinates of the item in mouse coordinate system.
     [Arguments]        ${type}  ${searched_item}  ${confidence}=0.999   ${iterations}=5   ${fail_expected}=False  ${debug_screenshot}=True
+    [Timeout]          2 minutes
     ${coordinates}=        Set Variable  ${EMPTY}
     ${pass_status}=        Set Variable  FAIL
-    Switch to vm    gui-vm  user=${USER_LOGIN}
+    Switch to vm           gui-vm  user=${USER_LOGIN}
     Execute Command        mkdir test-images
+    ${screenshot_cmd}=     Set Variable  cosmic-screenshot --interactive=false --save-dir ./test-images
     FOR   ${i}   IN RANGE  ${iterations}
         Log To Console     Taking cosmic screenshot
-        ${result}=         Run Keyword And Ignore Error  Execute Command  cosmic-screenshot --interactive=false --save-dir ./test-images  return_stdout=True   return_rc=True   timeout=5
+        ${result}=         Run Keyword And Ignore Error  Execute Command  ${screenshot_cmd}  return_stdout=True  return_rc=True  timeout=5
         Log                ${result}
         IF  "${result}[1][1]" == "0"
             SSHLibrary.Get File  ${result[1][0]}  ${GUI_TEMP_DIR}screenshot.png
             IF  $type=="image"
                 Log To Console    Locating image ${searched_item} on ${result[1][0]}
-                ${pass_status}  ${coordinates}  Run Keyword And Ignore Error  Locate image  ${GUI_TEMP_DIR}${searched_item}   ${confidence}
+                ${pass_status}    ${coordinates}  Run Keyword And Ignore Error  Locate image  ${GUI_TEMP_DIR}${searched_item}   ${confidence}
             ELSE IF  $type=="text"
                 Log To Console    Locating text ${searched_item} on ${result[1][0]}
-                ${pass_status}  ${coordinates}  Run Keyword And Ignore Error  Locate text  ${searched_item}
+                ${pass_status}    ${coordinates}  Run Keyword And Ignore Error  Locate text  ${searched_item}
             ELSE
-                FAIL    Wrong type given for image recognition
+                FAIL              Wrong type given for image recognition
             END
         END
         IF    $pass_status=='PASS'


### PR DESCRIPTION
Robot [timeout] in `GUI Tests Setup` keyword (gui-tests/__init__.robot) might not always be passed down in the hierarchy of nested keywords. Again we saw test automation getting stuck at screenshotting:

https://ci-prod.vedenemo.dev/job/ghaf-hw-test/1993/console
```
00:26:28  Logging in
00:26:39  Typing password
00:26:43  Pressing key(s): ENTER
00:26:47  Switched to gui-vm as testuser
00:26:53  Waiting for the user session to be active...0.1.2.3.4.5.6.7.Success
00:26:53  User session is active, user is logged in
00:26:53  Switched to gui-vm as ghaf
00:26:53  Verifying login by trying to detect the launcher icon
00:26:53  Switched to gui-vm as testuser
00:26:53  Taking cosmic screenshot
00:27:00  Taking cosmic screenshot
07:09:34  Aborted by [milva-unikie](https://ci-prod.vedenemo.dev/user/cgxtawx2ys11bmlrawusbmdpdgh1yg)
07:09:34  Sending interrupt signal to process
07:09:44  Second signal will force exit.
```

Let's try to define timeout in  `Locate on screen` which got stuck.


https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/558/