### PR TITLE
Add skip for X1 'Automatic suspension' -test

### DIFF
--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -67,6 +67,7 @@ Test setup
 
 Test teardown
     Run Keyword If Test Failed    Reboot Laptop
+    IF  "Lenovo" in "${DEVICE}"   Run Keyword If Test Failed  Skip  "Known issue: SSRCSP-6986"
 
 Wait
     [Arguments]     ${sec}

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -3,7 +3,8 @@
 ## Active SKIPS
 
 | DATE SET   | TEST CASE                                         | TICKET / Additional Data.                                                                       |
-| ---------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+|------------|---------------------------------------------------| ----------------------------------------------------------------------------------------------- |
+| 15.08.2025 | Automatic suspension (Lenovo X1)                  | SSRCSP-6986                                                                                     |
 | 27.06.2025 | Measure UDP Bidir Throughput Small Packets (Dell) | SSRCSP-6774                                                                                     |
 | 17.06.2025 | Start and close Google Chrome via GUI on LenovoX1 | SSRCSP-6716                                                                                     |
 | 13.06.2025 | Record Video With Camera (Dell)                   | SSRCSP-6694                                                                                     |


### PR DESCRIPTION
In case of suspension test failure, set test as 'skipped' with related bug id.

[Test Run: ](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/637/)