### PR TITLE
Refactor suspension test

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -268,8 +268,6 @@ Get icon
 Check if locked
     [Documentation]    Check if the screen lock is active
     ${logout_status}   Check if logged out   1
-    # Press tab once to deselect the password field in case it was active. This helps with image recognition.
-    Press Key(s)   TAB
     IF  not ${logout_status}
         ${status}   ${output}      Run Keyword And Ignore Error   Locate on screen  image  ${LOCK_ICON}  0.95  1  debug_screenshot=False
         IF  '${status}' == 'PASS'

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -53,6 +53,9 @@ Automatic suspension
     Connect
     Generate power plot           ${BUILD_ID}   ${TEST NAME}
     Stop recording power
+    Check the screen state   off
+    # Screen wakeup requires a mouse move
+    Move Cursor
     Check the screen state   on
     ${locked}         Check if locked
     Should Be True    ${locked}    Lock screen didn't appear
@@ -67,7 +70,6 @@ Test setup
 
 Test teardown
     Run Keyword If Test Failed    Reboot Laptop
-    IF  "Lenovo" in "${DEVICE}"   Run Keyword If Test Failed  Skip  "Known issue: SSRCSP-6986"
 
 Wait
     [Arguments]     ${sec}

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -4,7 +4,6 @@
 
 | DATE SET   | TEST CASE                                         | TICKET / Additional Data.                                                                       |
 |------------|---------------------------------------------------| ----------------------------------------------------------------------------------------------- |
-| 15.08.2025 | Automatic suspension (Lenovo X1)                  | SSRCSP-6986                                                                                     |
 | 27.06.2025 | Measure UDP Bidir Throughput Small Packets (Dell) | SSRCSP-6774                                                                                     |
 | 17.06.2025 | Start and close Google Chrome via GUI on LenovoX1 | SSRCSP-6716                                                                                     |
 | 13.06.2025 | Record Video With Camera (Dell)                   | SSRCSP-6694                                                                                     |


### PR DESCRIPTION
Small changes to fix automatic suspension test
-Removed one TAB-hit that re-started 'time counting for suspension' and that's why test seemed to behave in strange way
-Waking up the screen after suspension requires some keyboard activity, added cursor move there

Test result: [787]( https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/787/)