### PR TITLE
Adapt to changed ota-check-firmware output

### DIFF
--- a/Robot-Framework/lib/output_parser.py
+++ b/Robot-Framework/lib/output_parser.py
@@ -214,7 +214,7 @@ def get_ip_from_ifconfig(output, if_name):
 
 def get_qspi_versions(output):
     fw_pattern = r"Current firmware version is: (\d*.\d*.\d*)"
-    sw_pattern = r"Current software version is: (\d*.\d*.\d*)"
+    sw_pattern = r"Expected firmware version is: (\d*.\d*.\d*)"
 
     match = re.search(fw_pattern, output)
     if match:


### PR DESCRIPTION
Should be merged after ghaf PR 1332

https://github.com/tiiuae/ghaf/pull/1332 introduces small change to the output of ota-check-firmware command:

[ghaf@ghaf-host:~]$ ota-check-firmware 
Current firmware version is: 36.4.4-32c18b019057
Expected firmware version is: 36.4.4-8e724924f23c

Need to change the output_parser.py accordingly.

Note that after this jetpack update ota-check-firmware output includes also hash. Emrah said we can ignore the hash for now.