### PR TITLE
Allow testuser to use ydotool

### DIFF
--- a/Robot-Framework/lib/GuiTesting.py
+++ b/Robot-Framework/lib/GuiTesting.py
@@ -69,8 +69,8 @@ class GuiTesting:
         subprocess.run(['magick', input_file, '-negate', output_file])
 
     def generate_ydotool_key_command(self, key_combination):
-        # Returns a `ydotool key ...` command string for the given key combination,
-        # e.g. generate_ydotool_key_command("LEFTMETA+LEFTSHIFT+ESC") -> 'ydotool key 125:1 42:1 1:1 1:0 42:0 125:0'
+        # Returns a `key ...` command string for the given key combination,
+        # e.g. generate_ydotool_key_command("LEFTMETA+LEFTSHIFT+ESC") -> 'key 125:1 42:1 1:1 1:0 42:0 125:0'
         keys = key_combination.split("+")
         key_codes = []
         for key in keys:
@@ -83,4 +83,4 @@ class GuiTesting:
         press_events = [f"{code}:1" for code in key_codes]
         release_events = [f"{code}:0" for code in reversed(key_codes)]
 
-        return "ydotool key " + " ".join(press_events + release_events)
+        return "key " + " ".join(press_events + release_events)

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***
-Documentation       Keywords for gui tests. Note: These keywords assume the connection is to the gui-vm,
-...                 as the ghaf user. If a keyword requires the user account, it will handle switching to
-...                 the user and switch back to the ghaf user during teardown.
+Documentation       Keywords for gui tests. Note: These keywords assume the connection is to the gui-vm
+...                 as the non-privileged user.
 
 Library             ../lib/GuiTesting.py    ${OUTPUT_DIR}/outputs/gui-temp/
 Library             Collections
@@ -18,6 +17,7 @@ ${APP_MENU_LAUNCHER}   ./launcher.png
 ${LOCK_ICON}           ./lock.png
 ${DISABLE_LOGOUT}      ${EMPTY}
 ${GUI_TEMP_DIR}        ${OUTPUT_DIR}/outputs/gui-temp/
+${YDOTOOL_SOCKET}      /tmp/.ydotool_socket
 
 
 *** Keywords ***
@@ -71,11 +71,11 @@ Log in via GUI
     [Documentation]   Log in by typing password
     Log To Console    Logging in
     # Make sure that password field is active by clicking on screen
-    Execute Command   ydotool mousemove --absolute -x 50 -y 50  sudo=True  sudo_password=${PASSWORD}
-    Execute Command   ydotool click 0xC0  sudo=True  sudo_password=${PASSWORD}
+    Run ydotool command   mousemove --absolute -x 50 -y 50   sudo=True
+    Run ydotool command   click 0xC0  sudo=True
 
     IF  "Dell" in "${DEVICE}"    Sleep  5
-    Type string and press enter  ${USER_PASSWORD}  confidential=True
+    Type string and press enter  ${USER_PASSWORD}  confidential=True   sudo=True
 
 Log out via GUI
     [Documentation]   Log out by using keyboard shortcut
@@ -87,20 +87,21 @@ Log out via GUI
     END
     Log To Console    Logging out by pressing Super+Shift+Escape 
     Press Key(s)      LEFTMETA+LEFTSHIFT+ESC
+    IF  "Dell" in "${DEVICE}"    Sleep  3
     Tab and enter     tabs=2
 
 Type string and press enter
-    [Arguments]    ${string}=${EMPTY}  ${confidential}=False  ${enter}=True
+    [Arguments]    ${string}=${EMPTY}  ${confidential}=False  ${enter}=True   ${sudo}=False
     IF  ${confidential} 
         Log To Console    Typing password
     ELSE
         Log To Console    Typing "${string}"
     END
     IF  $string != '${EMPTY}'
-        Execute Command   ydotool type ${string}  sudo=True  sudo_password=${PASSWORD}
+        Run ydotool command   type ${string}  ${sudo}
     END
     IF  ${enter}
-        Press Key(s)      ENTER
+        Press Key(s)      ENTER   ${sudo}
     ELSE
         Log To Console    Skipping Enter
     END
@@ -120,7 +121,6 @@ Locate on screen
     [Timeout]          2 minutes
     ${coordinates}=        Set Variable  ${EMPTY}
     ${pass_status}=        Set Variable  FAIL
-    Switch to vm           gui-vm  user=${USER_LOGIN}
     Execute Command        mkdir test-images
     ${screenshot_cmd}=     Set Variable  cosmic-screenshot --interactive=false --save-dir ./test-images
     FOR   ${i}   IN RANGE  ${iterations}
@@ -160,35 +160,17 @@ Locate on screen
     ${mouse_x}  Get From Dictionary   ${coordinates}  x
     ${mouse_y}  Get From Dictionary   ${coordinates}  y
     RETURN  ${mouse_x}  ${mouse_y}
-    [Teardown]    Switch to vm    gui-vm
 
 Locate and click
     [Arguments]   ${type}  ${searched_item}  ${confidence}=0.99  ${iterations}=5
     ${mouse_x}  ${mouse_y}  Locate on screen  ${type}  ${searched_item}  ${confidence}  ${iterations}
-    Execute Command   ydotool mousemove --absolute -x ${mouse_x} -y ${mouse_y}  sudo=True  sudo_password=${PASSWORD}
-    Execute Command   ydotool click 0xC0  sudo=True  sudo_password=${PASSWORD}
-
-Start ydotoold
-    [Documentation]    Start ydotool daemon if it is not already running.
-    ${ydotoold_state}=    Execute Command    sh -c 'ps aux | grep ydotoold | grep -v grep'
-    IF  $ydotoold_state == '${EMPTY}'
-        Log To Console    Starting ydotool daemon
-        Run Keyword And Ignore Error  Execute Command   -b /run/current-system/sw/bin/ydotoold --socket-path /tmp/.ydotool_socket  sudo=True  sudo_password=${PASSWORD}  timeout=3
-        ${ydotoold_state}=    Execute Command    sh -c 'ps aux | grep ydotoold | grep -v grep'
-        Should Not Be Empty  ${ydotoold_state}  failed to start ydotool daemon
-    ELSE
-        Log To Console    Check: ydotool daemon running
-    END
-
-Stop ydotoold
-    [Documentation]    Kill ydotool daemon
-    Log To Console    Stopping ydotool daemon
-    Execute Command   pkill ydotoold  sudo=True  sudo_password=${PASSWORD}
+    Run ydotool command   mousemove --absolute -x ${mouse_x} -y ${mouse_y}
+    Run ydotool command   click 0xC0
 
 Move cursor to corner
     [Documentation]    Move the cursor to the upper left corner so that it will not block searching further gui screenshots
     Log To Console    Moving cursor to corner from blocking further image detection
-    Execute Command   ydotool mousemove --absolute -x 50 -y 50  sudo=True  sudo_password=${PASSWORD}
+    Run ydotool command   mousemove --absolute -x 50 -y 50
 
 Verify desktop availability
     [Documentation]    Wait for the login and check that launcher icon is available on desktop
@@ -222,12 +204,11 @@ Move cursor
     Log To Console    Moving cursor to random location
     ${x}    Evaluate  random.randint(50, 500)  modules=random
     ${y}    Evaluate  random.randint(50, 500)  modules=random
-    Execute Command   ydotool mousemove --absolute -x ${x} -y ${y}  sudo=True  sudo_password=${PASSWORD}
+    Run ydotool command   mousemove --absolute -x ${x} -y ${y}
 
 Check if logged out
     [Documentation]    Check if system is in logged out state
     [Arguments]        ${iterations}=10
-    Switch to vm    gui-vm  user=${USER_LOGIN}
     FOR   ${i}   IN RANGE  ${iterations}
         ${activity}=       Execute Command    systemctl --user is-active xdg-desktop-portal.service  return_stdout=True
         IF  $activity == "active"
@@ -239,12 +220,10 @@ Check if logged out
         Sleep  1
     END
     RETURN    ${False}
-    [Teardown]    Switch to vm    gui-vm
 
 Wait for user session to be active
     [Documentation]    Wait until the user session is in active state
     [Arguments]        ${iterations}=30
-    Switch to vm    gui-vm  user=${USER_LOGIN}
     Log To Console     Waiting for the user session to be active...  no_newline=true 
     FOR   ${i}   IN RANGE   ${iterations}
         ${activity}=       Execute Command    systemctl --user is-active xdg-desktop-portal.service  return_stdout=True
@@ -257,7 +236,6 @@ Wait for user session to be active
         Sleep   0.5
     END
     RETURN   ${activity}
-    [Teardown]    Switch to vm    gui-vm
 
 Get icon
     [Documentation]    Copy icon svg file to test agent machine. Crop and convert the svg file to png.
@@ -284,46 +262,23 @@ Unlock
     Locate and click   image  ${LOCK_ICON}   0.95  5
     Log To Console     Typing password to unlock
     Type string and press enter  ${USER_PASSWORD}  confidential=True
-
-Save gui icons and icon path
-    [Documentation]         Save the icons that are used in multiple test cases
-    ...                     Save path to icons
-    Log To Console          Saving commonly used test icons
-    ${ICONS}                Execute Command   find $(echo $XDG_DATA_DIRS | tr ':' ' ') -type d -name "icons" 2>/dev/null
-    Set Global Variable     ${ICONS}
-    Get icon                ${ICONS}/hicolor/scalable/apps  com.system76.CosmicAppLibrary.svg  crop=0  background=black  output_filename=launcher.png
-    Get icon                ${ICONS}/Papirus/24x24/symbolic/actions  window-close-symbolic.svg  crop=0  background=white  output_filename=window-close.png
-    Negate app icon         ${GUI_TEMP_DIR}window-close.png  ${GUI_TEMP_DIR}window-close-neg.png
-    Get icon                ${ICONS}/Cosmic/scalable/actions  system-search-symbolic.svg  crop=0  background=white  output_filename=search.png
-    Negate app icon         ${GUI_TEMP_DIR}search.png  ${GUI_TEMP_DIR}search-neg.png
-    Get icon                ${ICONS}/Papirus/24x24/actions  system-shutdown.svg  crop=0  background=black  output_filename=power.png
-    Get icon                ${ICONS}/Cosmic/scalable/actions  system-lock-screen-symbolic.svg  background=black  output_filename=lock.png
-
-Create test user
-    Log To Console      Creating test user
-    Execute Command     systemctl start setup-test-user.service  sudo=True  sudo_password=${password}
+    Sleep   1
 
 Stop swayidle
     [Documentation]    Stop swayidle to prevent automatic suspension
     Log To Console    Disabling automated lock and suspend
-    Switch to vm    gui-vm  user=${USER_LOGIN}
     Execute Command   systemctl --user stop swayidle
-    [Teardown]    Switch to vm    gui-vm
 
 Start swayidle
     [Documentation]    Start swayidle to allow automatic suspension
     Log To Console    Enabling automated lock and suspend
-    Switch to vm    gui-vm  user=${USER_LOGIN}
     Execute Command   systemctl --user start swayidle
-    [Teardown]    Switch to vm    gui-vm
 
 Set do not disturb state
     [Documentation]   Set do not disturb to true or false
     [Arguments]       ${state}
     Log To Console    Setting Do Not Disturb to ${state}
-    Switch to vm    gui-vm  user=${USER_LOGIN}
     Execute Command   echo ${state} > ~/.config/cosmic/com.system76.CosmicNotifications/v1/do_not_disturb
-    [Teardown]    Switch to vm    gui-vm
 
 Get screen brightness
     [Documentation]   Get and return current brightness value
@@ -333,25 +288,11 @@ Get screen brightness
     IF  ${log_brightness}    Log To Console    Brightness is ${brightness}
     RETURN            ${brightness}
 
-Get volume level
-    [Documentation]   Get and return current volume value
-    ${pamixer}        Execute Command    ls /nix/store/ | grep pamixer | grep -v .drv
-    ${volume}         Execute Command    /nix/store/${pamixer}/bin/pamixer --get-volume  sudo=True  sudo_password=${PASSWORD}
-    RETURN            ${volume}
-
-Get mute status
-    [Documentation]   Get and return current mute status
-    ${pamixer}        Execute Command    ls /nix/store/ | grep pamixer | grep -v .drv
-    ${mute}           Execute Command    /nix/store/${pamixer}/bin/pamixer --get-mute  sudo=True  sudo_password=${PASSWORD}
-    RETURN            ${mute}
-
 Get gui-vm user journalctl log
     [Arguments]       ${filename}=gui-vm-user.txt
-    [Setup]           Switch to vm    gui-vm  user=${USER_LOGIN}
     Execute Command   journalctl --user > /tmp/${filename}
     SSHLibrary.Get file   /tmp/${filename}   ${OUTPUT_DIR}/${filename}
     OperatingSystem.File Should Exist   ${OUTPUT_DIR}/${filename}
-    [Teardown]        Switch to vm    gui-vm
 
 Switch keyboard layout
     [Documentation]   Toggle layout between English, Arabic and Finnish
@@ -363,24 +304,32 @@ Timestamp screenshot
     Run Process      sh  -c  cp ${GUI_TEMP_DIR}screenshot.png ${GUI_TEMP_DIR}screenshot_${current_time}.png  shell=true
 
 Press Key(s)
-    [Arguments]        ${key_combination}
+    [Arguments]        ${key_combination}   ${sudo}=False
     [Documentation]    Simulates key press(es) using ydotool. If there are multiple keys they must be separated with '+'.
     ...   Check the correct key name from https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
     ${ydotool_command}    Generate Ydotool Key Command   ${key_combination}
-    Log               ${ydotool_command}
-    Log To Console    Pressing key(s): ${key_combination}
-    ${output}    ${rc}    Execute Command   ${ydotool_command}  sudo=True  sudo_password=${PASSWORD}    return_rc=True
+    Log                   ${ydotool_command}
+    Log To Console        Pressing key(s): ${key_combination}
+    Run ydotool command   ${ydotool_command}   ${sudo}
+
+Run ydotool command
+    [Arguments]    ${command}   ${sudo}=False
+    IF   $sudo == "True"
+        Switch to vm    gui-vm
+        Log To Console   Running ydotool command with ghaf user
+        ${output}    ${rc}    Execute Command   ydotool ${command}  sudo=True  sudo_password=${PASSWORD}    return_rc=True
+        Switch to vm    gui-vm  user=${USER_LOGIN}
+    ELSE
+        ${output}    ${rc}    Execute Command    YDOTOOL_SOCKET=${YDOTOOL_SOCKET} ydotool ${command}    return_rc=True
+    END
     Should Be Equal As Integers     ${rc}   0
+    Sleep   0.2
 
 Change to gray wallpaper
-    [Setup]           Switch to vm    gui-vm  user=${USER_LOGIN}
     Log To Console    Changing to gray wallpaper
     Put File          ../test-files/background.config   .
     Execute Command   mv background.config .config/cosmic/com.system76.CosmicBackground/v1/all
-    [Teardown]        Switch to vm    gui-vm
 
 Restore default wallpaper
-    [Setup]           Switch to vm    gui-vm  user=${USER_LOGIN}
     Log To Console    Changing back to default wallpaper
     Remove file       ~/.config/cosmic/com.system76.CosmicBackground/v1/all
-    [Teardown]        Switch to vm    gui-vm

--- a/Robot-Framework/resources/setup_keywords.resource
+++ b/Robot-Framework/resources/setup_keywords.resource
@@ -21,6 +21,7 @@ Prepare Test Environment
         IF  ${login}
             Save gui icons and icon path
             Start ydotoold
+            Switch to vm   gui-vm  user=${USER_LOGIN}
             Log in, unlock and verify   ${enable_dnd}
         END
     END
@@ -31,8 +32,8 @@ Clean Up Test Environment
     Connect to ghaf host
     Stop journalctl recording
     IF  "Lenovo" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        Switch to vm    gui-vm
         Start ydotoold
+        Switch to vm    gui-vm  user=${USER_LOGIN}
         Log out and verify   ${disable_dnd}
         Stop ydotoold
     END
@@ -68,3 +69,44 @@ Log versions
     Log To Console      Nixos version: ${nixos_version}
     ${device_id}        Execute Command   cat /persist/common/device-id
     Log To Console      Device ID: ${device_id}
+
+Create test user
+    Log To Console      Creating test user
+    Execute Command     systemctl start setup-test-user.service  sudo=True  sudo_password=${password}
+
+Start ydotoold
+    [Documentation]    Start ydotool daemon if it is not already running.
+    [Setup]            Switch to vm    gui-vm
+    ${ydotoold_state}=    Execute Command    sh -c 'ps aux | grep ydotoold | grep -v grep'
+    IF  $ydotoold_state == '${EMPTY}'
+        Log To Console    Starting ydotool daemon
+        Run Keyword And Ignore Error  Execute Command   -b /run/current-system/sw/bin/ydotoold --socket-path /tmp/.ydotool_socket  sudo=True  sudo_password=${PASSWORD}  timeout=3
+        ${ydotoold_state}=    Execute Command    sh -c 'ps aux | grep ydotoold | grep -v grep'
+        Should Not Be Empty  ${ydotoold_state}  failed to start ydotool daemon
+        # Allow all users to use Ydotool
+        ${output}   Execute Command       chmod 666 /tmp/.ydotool_socket  return_stdout=True  return_rc=True   sudo=True  sudo_password=${PASSWORD}
+        Log   ${output}
+    ELSE
+        Log To Console    Check: ydotool daemon running
+    END
+
+Stop ydotoold
+    [Documentation]   Kill ydotool daemon
+    [Setup]           Switch to vm    gui-vm
+    Log To Console    Stopping ydotool daemon
+    Execute Command   pkill ydotoold  sudo=True  sudo_password=${PASSWORD}
+
+Save gui icons and icon path
+    [Documentation]         Save the icons that are used in multiple test cases
+    ...                     Save path to icons
+    Log To Console          Saving commonly used test icons
+    ${ICONS}                Execute Command   find $(echo $XDG_DATA_DIRS | tr ':' ' ') -type d -name "icons" 2>/dev/null
+    Set Global Variable     ${ICONS}
+    Get icon                ${ICONS}/hicolor/scalable/apps  com.system76.CosmicAppLibrary.svg  crop=0  background=black  output_filename=launcher.png
+    Get icon                ${ICONS}/Papirus/24x24/symbolic/actions  window-close-symbolic.svg  crop=0  background=white  output_filename=window-close.png
+    Negate app icon         ${GUI_TEMP_DIR}window-close.png  ${GUI_TEMP_DIR}window-close-neg.png
+    Get icon                ${ICONS}/Cosmic/scalable/actions  system-search-symbolic.svg  crop=0  background=white  output_filename=search.png
+    Negate app icon         ${GUI_TEMP_DIR}search.png  ${GUI_TEMP_DIR}search-neg.png
+    Get icon                ${ICONS}/Papirus/24x24/actions  system-shutdown.svg  crop=0  background=black  output_filename=power.png
+    Get icon                ${ICONS}/Cosmic/scalable/actions  system-lock-screen-symbolic.svg  background=black  output_filename=lock.png
+

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -67,16 +67,6 @@ Start and close COSMIC Files via GUI on LenovoX1
     Start app via GUI on LenovoX1   ${GUI_VM}  cosmic-files  display_name=Files  exact_match=true
     Close app via GUI on LenovoX1   ${GUI_VM}  cosmic-files  ./window-close-neg.png  exact_match=true
 
-# GUI tests don't currently work on Orin (keywords expect that gui-vm is available)
-Start and close Firefox via GUI on Orin AGX
-    [Documentation]   Passing this test requires that display is connected to the target device
-    ...               Start Firefox via GUI test automation and verify related process started
-    ...               Close Firefox via GUI test automation and verify related process stopped
-    [Tags]            SP-T41-2   # orin-agx can be added after arranging display connection for Orin-AGX in the test setup
-    Get icon   ${ICONS}/Papirus/128x128/apps  firefox.svg  crop=30
-    Start app via GUI on Orin AGX   firefox
-    Close app via GUI on Orin AGX   firefox
-
 *** Keywords ***
 
 Start app via GUI on LenovoX1
@@ -92,10 +82,10 @@ Start app via GUI on LenovoX1
     Type string and press enter  ${display_name}
     Tab and enter   tabs=1
 
-    Connect to VM       ${app-vm}
+    Switch to vm    ${app-vm}
     Check that the application was started    ${app}  10  ${exact_match}
 
-    [Teardown]    Run Keywords    Switch to vm    gui-vm
+    [Teardown]    Run Keywords    Switch to vm    gui-vm  user=${USER_LOGIN}
     ...           AND             Move cursor to corner
 
 Open app menu
@@ -118,22 +108,21 @@ Close app via GUI on LenovoX1
     ...                ${windows_to_close}=1
     ...                ${iterations}=5
     ...                ${exact_match}=false
-    Connect to netvm
-    Connect to VM                             ${app-vm}
+    Switch to vm      ${app-vm}
     Check that the application was started    ${app}  exact_match=${exact_match}
-    Switch to vm    gui-vm
-    Log To Console                            Going to click the close button of the application window
-    Locate and click                          image  ${close_button}  0.8  iterations=${iterations}
-    Connect to VM                             ${app-vm}
-    ${status}           Run Keyword And Return Status  Check that the application is not running  ${app}  5  ${exact_match}
+    Switch to vm       gui-vm  user=${USER_LOGIN}
+    Log To Console     Going to click the close button of the application window
+    Locate and click   image  ${close_button}  0.8  iterations=${iterations}
+    Switch to vm       ${app-vm}
+    ${status}          Run Keyword And Return Status  Check that the application is not running  ${app}  5  ${exact_match}
     IF  "${windows_to_close}" != "1"
         # At first launch chrome opens window for selecting account.
         # If this window is closed the actual browser window still opens.
         # So need to prepare to close another window in chrome test case.
         IF  '${status}' != 'True'
-            Switch to vm    gui-vm
+            Switch to vm        gui-vm  user=${USER_LOGIN}
             Locate and click    image  ${close_button}  0.8  5
-            Connect to VM       ${app-vm}
+            Switch to vm        ${app-vm}
             ${status}           Run Keyword And Return Status  Check that the application is not running  ${app}  5  ${exact_match}
         END
     END
@@ -141,39 +130,5 @@ Close app via GUI on LenovoX1
         FAIL  Failed to close the application
     END
     # In case closing the app via GUI failed
-    [Teardown]     Run Keywords   Connect to VM   ${app-vm}   AND   Kill process   @{APP_PIDS}
-    ...            AND   Switch to vm    gui-vm   AND   Move cursor to corner
-
-Start app via GUI on Orin AGX
-    [Documentation]    Start Application via GUI test automation and verify related process started
-    ...                Only for ghaf builds where desktop is running on ghaf-host
-    [Arguments]        ${app}=firefox
-    ...                ${launch_icon}=../gui-ref-images/${app}/launch_icon.png
-
-    Connect
-
-    Start ydotoold
-
-    Log To Console    Going to click the app menu icon
-    Locate and click  image  ${APP_MENU_LAUNCHER}  0.95  5
-    Log To Console    Going to click the application launch icon
-    Locate and click  image  ${launch_icon}  0.95  5
-
-    Check that the application was started    ${app}  10
-
-    [Teardown]    Run Keywords    Move cursor to corner
-
-Close app via GUI on Orin AGX
-    [Documentation]    Close Application via GUI test automation and verify related process stopped
-    ...                Only for ghaf builds where desktop is running on ghaf-host
-    [Arguments]        ${app}=firefox
-    ...                ${close_button}=../gui-ref-images/${app}/close_button.png
-
-    Connect
-    Check that the application was started    ${app}
-    Start ydotoold
-
-    Log To Console    Going to click the close button of the application window
-    Locate and click  image  ${close_button}  0.999  5
-
-    Check that the application is not running    ${app}   5
+    [Teardown]     Run Keywords   Switch to vm   ${app-vm}   AND   Kill process   @{APP_PIDS}
+    ...            AND   Switch to vm   gui-vm  user=${USER_LOGIN}   AND   Move cursor to corner

--- a/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
@@ -8,6 +8,7 @@ Force Tags          gui   gui-power-menu
 Library             ../../lib/SwitchbotLibrary.py  ${SWITCH_TOKEN}  ${SWITCH_SECRET}
 Resource            ../../resources/gui_keywords.resource
 Resource            ../../resources/power_meas_keywords.resource
+Resource            ../../resources/setup_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
 Test Setup          GUI Power Test Setup
@@ -27,7 +28,7 @@ GUI Suspend and wake up
     Set start timestamp
     # Connect back to gui-vm after power measurement has been started
     Connect to netvm
-    Switch to vm    gui-vm
+    Switch to vm    gui-vm   user=${USER_LOGIN}
 
     Select power menu option   index=4
 
@@ -90,8 +91,8 @@ GUI Reboot
     END
     Sleep  30
     Connect   iterations=10
-    Switch to vm    gui-vm
     Start ydotoold
+    Switch to vm    gui-vm   user=${USER_LOGIN}
     Log in, unlock and verify   enable_dnd=True
 
 GUI Log out and log in
@@ -107,7 +108,7 @@ GUI Log out and log in
 
 GUI Power Test Setup
     Connect to netvm
-    Switch to vm    gui-vm
+    Switch to vm    gui-vm   user=${USER_LOGIN}
     Log in, unlock and verify
 
 Select power menu option
@@ -116,10 +117,11 @@ Select power menu option
     [Arguments]        ${text}=""   ${index}=0   ${confirmation}=false
     Log To Console     Opening power menu
     Locate and click   image  ./power.png  0.95  5
-    IF  $text != ""
+    IF  '$text != $EMPTY'
         Locate and click   text   ${text}
     ELSE
         Tab and enter      tabs=${index}
     END
     # Some options have a separate confirmation window that needs to be clicked.
     IF  '${confirmation}' == 'true'   Tab and enter   tabs=2
+    Sleep   1

--- a/Robot-Framework/test-suites/gui-tests/input_control.robot
+++ b/Robot-Framework/test-suites/gui-tests/input_control.robot
@@ -29,14 +29,14 @@ Change keyboard layout
     [Tags]              lenovo-x1   SP-T138
     Check cosmic config current layout value
     Launch Cosmic Term
-    Switch to vm    gui-vm
+    Sleep    1
     Type string and press enter                "echo "  enter=False
     Press Key(s)    APOSTROPHE
     Press test key and switch keyboard layout  repeat=3
     Press Key(s)    APOSTROPHE
     Type string and press enter                " > /tmp/key_check.txt"
     ${key_check}                               Execute Command  cat /tmp/key_check.txt
-    Execute Command                            rm /tmp/key_check.txt  sudo=True  sudo_password=${PASSWORD}
+    Execute Command                            rm /tmp/key_check.txt
     IF  $key_check != ';كö'
         FAIL    Failed to get the expected keyboard input ';كö'\nKeyboard input received: ${key_check}
     END
@@ -91,7 +91,6 @@ Check cosmic config current layout value
     [Documentation]           Check the value of current layout in the xkb_config file.
     ...                       If the current value is not 'us' toggle until it is set to 'us'.
     Log To Console            Checking current keyboard layout
-    Switch to vm    gui-vm  user=${USER_LOGIN}
     ${output}  ${rc}=         Execute Command  cat .config/cosmic/com.system76.CosmicComp/v1/xkb_config | grep -w layout  return_rc=True
     # If the keyboard layout has never been toggled the file doesn't exist and command fails with rc 1
     # Then we assume default keyboard layout: 'us'
@@ -101,14 +100,25 @@ Check cosmic config current layout value
         ${current_layout}   Parse keyboard layout  ${output}
         Log                 ${current_layout}   console=True
         ${placement}        Get From List   ${current_layout}   1
-        Switch to vm    gui-vm
         FOR   ${i}   IN RANGE  ${placement}
             Sleep   0.5
             Switch keyboard layout
         END
     END
-    [Teardown]    Switch to vm    gui-vm  user=${USER_LOGIN}
 
 Kill gui-vm apps
     Switch to vm    gui-vm
     Kill process    @{APP_PIDS}
+    Switch to vm    gui-vm  user=${USER_LOGIN}
+
+Get volume level
+    [Documentation]   Get and return current volume value
+    ${pamixer}        Execute Command    ls /nix/store/ | grep pamixer | grep -v .drv
+    ${volume}         Execute Command    /nix/store/${pamixer}/bin/pamixer --get-volume
+    RETURN            ${volume}
+
+Get mute status
+    [Documentation]   Get and return current mute status
+    ${pamixer}        Execute Command    ls /nix/store/ | grep pamixer | grep -v .drv
+    ${mute}           Execute Command    /nix/store/${pamixer}/bin/pamixer --get-mute
+    RETURN            ${mute}

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -17,12 +17,11 @@ Library             JSONLibrary
 
 Automatic suspension
     [Documentation]   Wait and check that
-    ...               in the beginning brightness is 96000
-    ...               in 4 min - the screen dims (brightness is 24000)
-    ...               in 5 min - the screen locks (brightness is 24000)
-    ...               in 7,5 min - screen turns off
+    ...               in the beginning brightness is 100 %
+    ...               in 4 min - the screen dims (brightness is 25 %)
+    ...               in 5 min - the screen locks (brightness is 25 %)
     ...               in 15 min - the laptop is suspended
-    ...               in 5 min press the button and check that laptop woke up
+    ...               in 20 min press the button and check that laptop woke up
     [Tags]            SP-T162    lenovo-x1
     [Setup]           Test setup
     [Teardown]        Test teardown
@@ -32,7 +31,7 @@ Automatic suspension
 
     Start power measurement       ${BUILD_ID}   timeout=1500
     Connect
-    Switch to vm    gui-vm
+    Switch to vm    gui-vm   user=${USER_LOGIN}
     Set start timestamp
 
     Wait     240
@@ -53,6 +52,7 @@ Automatic suspension
     Connect
     Generate power plot           ${BUILD_ID}   ${TEST NAME}
     Stop recording power
+    Switch to vm    gui-vm   user=${USER_LOGIN}
     Check the screen state   off
     # Screen wakeup requires a mouse move
     Move Cursor
@@ -88,6 +88,7 @@ Get expected brightness values
     Set Test Variable  ${dimmed_brightness}  ${dimmed}
 
 Set display to max brightness
+    [Setup]   Switch to vm    gui-vm
     ${current_brightness}    Get screen brightness   log_brightness=False
     IF   ${current_brightness} != ${max_brightness}
         Log           Brightness is ${current_brightness}, setting it to the maximum  console=True
@@ -96,6 +97,7 @@ Set display to max brightness
         ${current_brightness}    Get screen brightness
         Should be Equal As Numbers    ${current_brightness}   ${max_brightness}
     END
+    [Teardown]   Switch to vm    gui-vm  user=${USER_LOGIN}
 
 Check screen brightness
     [Arguments]       ${brightness}    ${timeout}=60
@@ -115,12 +117,10 @@ Check screen brightness
 
 Check the screen state
     [Arguments]         ${state}
-    [Setup]       Switch to vm    gui-vm  user=${USER_LOGIN}
     ${output}           Execute Command    ls /nix/store | grep wlopm | grep -v .drv
     ${output}  ${err}   Execute Command    WAYLAND_DISPLAY=wayland-1 /nix/store/${output}/bin/wlopm    return_stderr=True
     Log                 Screen state: ${output}  console=True
     Should Contain      ${output}    ${state}
-    [Teardown]    Switch to vm    gui-vm
 
 Check that device is suspended
     ${device_not_available}  Run Keyword And Return Status  Wait Until Keyword Succeeds  15s  2s  Check If Ping Fails


### PR DESCRIPTION
**Changes**
- Allow testuser to use ydotool. The only place ydotool still needs to be run with ghaf and sudo is during login. After login everything can be done with testuser without sudo. This saves a lot of time and removes the need to constantly switch between users.
- `gui_keywords.resource` now assumes the connection is to gui-vm as testuser (used to assume ghaf).
- Add `Run ydotool command` keyword to standardize the use of ydotool.
- Move some keywords from `gui_keywords` to more suitable files
- Remove AGX GUI keywords. They have not worked in a while.

**Potential issues**
- GUI tests are now sometimes too fast for Ghaf to keep up. I added some sleeps but the values might need adjusting.

**Stats**
- Gui tests now take ~4 minutes instead of ~12 minutes.
- Required connections in GUI tests drop from about 200 to under 100.

**Testruns**
- [Lenovo-X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/823/) regression&gui
- [Dell-7330](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/831/) bat