### PR TITLE
Refactor code due to taking network adapters into use for AGX devices.

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -102,10 +102,8 @@ Connect
     [Arguments]       ${IP}=${DEVICE_IP_ADDRESS}    ${PORT}=22    ${target_output}=None   ${iterations}=3
     IF  '${target_output}' != 'None'
         Log To Console    Expecting ${target_output} target output
-    ELSE IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        ${target_output}  Set Variable  ghaf@net-vm
     ELSE
-        ${target_output}  Set Variable  ghaf@ghaf-host
+        ${target_output}  Set Variable  ghaf@net-vm
     END
     # Iterations are necessary at boot for those targets which should expose net-vm to ethernet interface.
     # Ghaf-host is accessible on these targets for a short period of time at boot.
@@ -116,9 +114,7 @@ Connect
         ${pass_status}  ${output}        Run Keyword And Ignore Error  Should Contain     ${login_output}   ${target_output}
         IF    $pass_status=='PASS'
             Log To Console    Connected successfully to ${target_output}
-            IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}" or "Dell" in "${DEVICE}"
-                Set Global Variable  ${NETVM_SSH}    ${connection}
-            END
+            Set Global Variable  ${NETVM_SSH}    ${connection}
             RETURN  ${connection}
         ELSE
             Close All Connections
@@ -132,14 +128,9 @@ Connect to ghaf host
     [Documentation]      Open SSH connection to Ghaf Host
     ${connected}   Check ssh connection status   ghaf-host
     IF  not ${connected}
-        IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}" or "Dell" in "${DEVICE}"
-            ${connection}        Connect
-            Set Global Variable  ${NETVM_SSH}    ${connection}
-            ${connection}        Connect to VM       ghaf-host
-        ELSE
-            Log To Console       Connecting to Ghaf Host
-            ${connection}        Connect
-        END
+        ${connection}        Connect
+        Set Global Variable  ${NETVM_SSH}        ${connection}
+        ${connection}        Connect to VM       ghaf-host
         Set Global Variable  ${GHAF_HOST_SSH}    ${connection}
     END
     RETURN               ${GHAF_HOST_SSH}
@@ -148,13 +139,7 @@ Connect to netvm
     [Documentation]      Open ssh connection to net-vm
     ${connected}   Check ssh connection status   net-vm
     IF  not ${connected}
-        IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}" or "Dell" in "${DEVICE}"
-            ${connection}   Connect
-        ELSE
-            Connect to ghaf host
-            Log To Console       Connecting to NetVM
-            ${connection}        Connect to VM        ${NET_VM}
-        END
+        ${connection}   Connect
         Set Global Variable  ${NETVM_SSH}    ${connection}
         RETURN               ${NETVM_SSH}
     END
@@ -166,11 +151,7 @@ Connect to VM
     Check if ssh is ready on vm        ${vm_name}   ${timeout}
     ${failed_connection}  Set Variable  True
     ${start_time}  Get Time	epoch
-    IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}" or "Dell" in "${DEVICE}"
-        ${jumphost}   Set Variable  ${NETVM_SSH}
-    ELSE
-        ${jumphost}   Set Variable  ${GHAF_HOST_SSH}
-    END
+    ${jumphost}    Set Variable  ${NETVM_SSH}
     # Opening connection
     FOR    ${i}    IN RANGE    10
         TRY

--- a/Robot-Framework/test-suites/boot-test/boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/boot_test.robot
@@ -28,7 +28,7 @@ Verify booting after restart by power
     ELSE
         Log To Console  The device started
     END
-    IF  "NX" in "${DEVICE}"
+    IF  "NX" in "${DEVICE}" or "AGX" in "${DEVICE}"
         Sleep  30
     END
     IF  "${CONNECTION_TYPE}" == "ssh"

--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -31,7 +31,7 @@ Verify booting after restart by power
     ELSE
         Log To Console  The device started
     END
-    IF  "NX" in "${DEVICE}"
+    IF  "NX" in "${DEVICE}" or "AGX" in "${DEVICE}"
         Sleep  30
     END
     IF  "${CONNECTION_TYPE}" == "ssh"

--- a/Robot-Framework/test-suites/functional-tests/net-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/net-vm.robot
@@ -28,7 +28,9 @@ Verify NetVM is started
 
 Wifi passthrough into NetVM (Orin-AGX)
     [Documentation]     Verify that wifi works inside netvm
-    [Tags]              SP-T111  orin-agx  orin-agx-64
+    ...                 Test case not in use in CI/CD Pipeline.
+    ...                 Obsoleted when AGX devices use a network adapter.
+    [Tags]              # SP-T111  orin-agx  orin-agx-64
     [Setup]             Connect to netvm
     Configure wifi      ${NETVM_SSH}  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Get wifi IP
@@ -42,9 +44,9 @@ Wifi passthrough into NetVM (Orin-AGX)
     Sleep               1
     [Teardown]          Run Keyword  Remove Wifi configuration  ${TEST_WIFI_SSID}
 
-Wifi passthrough into NetVM (Lenovo-X1)
+Wifi passthrough into NetVM
     [Documentation]     Verify that wifi works inside netvm
-    [Tags]              SP-T101   lenovo-x1   dell-7330
+    [Tags]              SP-T101  orin-agx  orin-agx-64  lenovo-x1   dell-7330
     [Setup]             Connect to netvm
     Configure wifi      ${NETVM_SSH}  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Get wifi IP
@@ -60,14 +62,18 @@ Wifi passthrough into NetVM (Lenovo-X1)
 
 NetVM stops and starts successfully
     [Documentation]     Verify that NetVM stops properly and starts after that
-    [Tags]              SP-T47  SP-T90  nuc  orin-agx  orin-agx-64
+    ...                 Test case not in use in CI/CD Pipeline.
+    ...                 Obsoleted when AGX devices use a network adapter.
+    [Tags]              # SP-T47  SP-T90   orin-agx  orin-agx-64
     [Setup]             Connect to ghaf host
     Restart NetVM
     [Teardown]          Run Keywords  Start NetVM if dead   AND  Close All Connections
 
 NetVM is wiped after restarting
     [Documentation]     Verify that created file will be removed after restarting VM
-    [Tags]              SP-T48  nuc  orin-agx  orin-agx-64
+    ...                 Test case not in use in CI/CD Pipeline.
+    ...                 Obsoleted when AGX devices use a network adapter.
+    [Tags]              # SP-T48  nuc  orin-agx  orin-agx-64
     [Setup]             Connect to netvm
     Create file         /etc/test.txt    sudo=True
     Switch Connection   ${GHAF_HOST_SSH}

--- a/Robot-Framework/test-suites/functional-tests/timesync.robot
+++ b/Robot-Framework/test-suites/functional-tests/timesync.robot
@@ -29,8 +29,6 @@ Time synchronization
     ...                  - In this test we expect adapter is not used -> Set Wi-Fi ON to enable net-vm to address net.
     [Tags]            bat  regression  SP-T97   nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1   dell-7330  fmo
 
-    IF  "AGX" in "${DEVICE}"  Set Wifi passthrough into NetVM
-
     ${host}  Connect
     Check that time is correct  timezone=UTC
 
@@ -40,8 +38,6 @@ Time synchronization
 
     Start timesync daemon
     Check that time is correct
-
-    IF  "AGX" in "${DEVICE}"  Disable Wifi passthrough from NetVM
 
     [Teardown]  Timesync Teardown
 
@@ -158,16 +154,6 @@ Set system time
     Set Test Variable   ${original_time}  ${original_time}
     ${output}           Execute Command   sudo date -s '${time}'  sudo=True  sudo_password=${PASSWORD}
     ${output}           Execute Command   timedatectl -a
-
-Set Wifi passthrough into NetVM
-    [Documentation]     Verify that wifi works inside netvm.
-    ...              ORIN-AGX: Ghaf-host is directly connected to net if No internet adapter used!
-    ...                        Ghaf-host is connected to net via net-vm if internet adapter is used!
-    ...              Normally: Ghaf-host is connected to net via Net-VM
-    Connect to netvm
-    Configure wifi      ${NETVM_SSH}  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
-    Get wifi IP
-    Check Network Availability    8.8.8.8   expected_result=True
 
 Disable Wifi passthrough from NetVM
     Check Network Availability    8.8.8.8   expected_result=True

--- a/Robot-Framework/test-suites/performance-tests/boot_time_test.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time_test.robot
@@ -56,7 +56,7 @@ Measure Orin Soft Boot Time
     Soft Reboot Device
     Wait Until Keyword Succeeds  35s  2s  Check If Ping Fails
     Get Time To Ping
-    IF  "NX" in "${DEVICE}"      Sleep    30
+    IF  "NX" in "${DEVICE}" or "AGX" in "${DEVICE}"      Sleep    30
 
 Measure Orin Hard Boot Time
     [Documentation]  Measure how long it takes to device to boot up with hard reboot
@@ -68,7 +68,7 @@ Measure Orin Hard Boot Time
     Log To Console                Booting the device by switching the power on
     Turn Relay On                 ${RELAY_NUMBER}
     Get Time To Ping              plot_name=Hard Boot Times
-    IF  "NX" in "${DEVICE}"       Sleep    30
+    IF  "NX" in "${DEVICE}" or "AGX" in "${DEVICE}"       Sleep    30
 
 
 *** Keywords ***

--- a/Robot-Framework/test-suites/performance-tests/network.robot
+++ b/Robot-Framework/test-suites/performance-tests/network.robot
@@ -19,7 +19,7 @@ Resource            ../../resources/setup_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
 Suite Setup         Run Keywords  Connect to device
-...                 AND  Select network connection to use
+...                 AND  Connect to netvm
 ...                 AND  Run iperf server on DUT
 Suite Teardown      Run Keywords  Stop iperf server
 ...                 AND  Close port 5201 from iptables
@@ -157,16 +157,6 @@ Measure UDP Bidir Throughput Big Packets
     [Teardown]   Run Keyword If   "AGX" in "${DEVICE}"   Run Keyword If Test Failed   Skip   "Known issue: SSRCSP-6623 (AGX)"
 
 *** Keywords ***
-Select network connection to use
-    [Documentation]  Select the connection to be used. This cannot be done in Keyword 'Connect to device'
-     ...             since it then breaks the  other test suites.
-     IF  "Lenovo" in "${DEVICE}" or "NX" in "${DEVICE}" or "Dell" in "${DEVICE}"
-         ${CONNECTION}       Connect to netvm
-     ELSE
-         ${CONNECTION}       Connect to ghaf host
-     END
-     Set Global Variable  ${CONNECTION}
-
 Run iperf server on DUT
     [Documentation]   Run iperf on DUT in server mode
     Open port 5201 from iptables


### PR DESCRIPTION
Development target DEV Orin-AGX Device. 
Network adapters MAC set to match the static IP of DEV Orin- AGX.

Basically what was done was that most of 'IF "Orin-AGX" in ${DEVICE}' were removed and matched to the Lenovo-X1 branch case.

Noticed some failures with RelayBoot tests so added 30s sleep similar to "NX" for 'relayboot_test.robot' & 'boot_test.robot' (IF  "NX" in "${DEVICE}" or "AGX" in "${DEVICE}")

"net-vm" suite - **Took these 3 Orin AGX tests out of execution by commenting out the tags:**, since I think these are not valid when network adapter is used.

- Wifi passthrough into NetVM (Orin-AGX)  (using 'Lenovo test' 'Wifi passthrough into NetVM' -test instead
- NetVM stops and starts successfully
- NetVM is wiped after restarting

**Please let me know if you think starting/stopping/wiping cases needed to be used/modified for network adapter case.**

**Other notes!**
-The target hw (Orin-AGX) boot order is changed when network-adapter is attached. That needs to be changed manually for all Orin-AGX devices- so that SSD is used for booting

**Test Results:**
AGX-regression: [862](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/862/)
AGX performance: [866](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/866/)

- Note : network tests (throughput cases) mostly failed - tests were executed ok, but results were worse that without adapter and thats why tests are failind. Don'e know what should be the 'right' -level for measured values.

- Note 2: TEST nvpmodel check test failed  because of mode level. This may also affect on the throughput results. Originally the device reported that no power mode was set. I managed manually set it to be 2 but did not manage to set it to be 3 as expected. **EDIT**: Milla remembered that there has been problems with that Dev-AGX device with nvp-model. Nvp worked ok with some other AGX that I used for local testing.

`[ghaf@ghaf-host:~]$ sudo nvpmodel -m 3
NVPM ERROR: Error opening /sys/devices/platform/17000000.gpu/devfreq_dev/available_frequencies: 2
NVPM ERROR: failed to read PARAM GPU: ARG FREQ_TABLE: PATH /sys/devices/platform/17000000.gpu/devfreq_dev/available_frequencie
s
NVPM ERROR: failed to set power mode!
NVPM ERROR: optMask is 1, no request for power mode`


Lenovo-X1 regression: [868](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/868/)
