### PR TITLE
Record GUI tests

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -8,6 +8,7 @@ Documentation       Keywords for gui tests. Note: These keywords assume the conn
 Library             ../lib/GuiTesting.py    ${OUTPUT_DIR}/outputs/gui-temp/
 Library             Collections
 Library             DateTime
+Resource            ../resources/app_keywords.resource
 Resource            ../resources/file_keywords.resource
 Resource            ../resources/ssh_keywords.resource
 
@@ -279,6 +280,12 @@ Set do not disturb state
     [Arguments]       ${state}
     Log To Console    Setting Do Not Disturb to ${state}
     Execute Command   echo ${state} > ~/.config/cosmic/com.system76.CosmicNotifications/v1/do_not_disturb
+    # Make sure that currently shown notifications get closed
+    IF   $state == "true"
+        Execute Command   echo 0 > ~/.config/cosmic/com.system76.CosmicNotifications/v1/max_notifications
+    ELSE
+        Execute Command   echo 3 > ~/.config/cosmic/com.system76.CosmicNotifications/v1/max_notifications
+    END
 
 Get screen brightness
     [Documentation]   Get and return current brightness value
@@ -333,3 +340,42 @@ Change to gray wallpaper
 Restore default wallpaper
     Log To Console    Changing back to default wallpaper
     Remove file       ~/.config/cosmic/com.system76.CosmicBackground/v1/all
+
+Start screen recording
+    [Setup]          Kill screen recording
+    Log To Console   Starting screen recording
+    Press key(s)     LEFTCTRL+LEFTSHIFT+LEFTALT+R
+    Locate on screen   text   Share   iterations=5
+    # Select the display to record
+    Tab and enter    tabs=2
+    Tab and enter    tabs=2
+
+Stop screen recording
+    [Arguments]      ${test_status}   ${test_name}=""
+    ${pass_status}   ${output}    Run Keyword And Ignore Error   Check that the application was started   gpu-screen-recorder
+    IF  $pass_status=='FAIL'
+        Log To Console  Screen recording was not running
+        RETURN
+    END
+    Log To Console   Stopping screen recording
+    Press key(s)     LEFTCTRL+LEFTSHIFT+LEFTALT+R
+    @{pid}           Find pid by name   gpu-screen-recorder
+    Kill process     @{pid}   sudo=False
+    # Get the name of the last recording
+    ${video_file}    Execute Command   ls /home/${USER_LOGIN}/Videos -Art | tail -n 1
+    # Save the video file if the test failed
+    IF  $test_status=='FAIL'
+        Log To Console        Saving video file
+        ${name}               Replace String   ${test_name}   ${SPACE}   _
+        SSHLibrary.Get File   /home/${USER_LOGIN}/Videos/${video_file}   ${GUI_TEMP_DIR}${name}.mp4
+    END
+    Execute Command   rm /home/${USER_LOGIN}/Videos/${video_file}
+    [Teardown]        Kill screen recording
+
+Kill screen recording
+    ${pass_status}   ${output}    Run Keyword And Ignore Error   Check that the application is not running   gpu-screen-recorder   1
+    IF  $pass_status=='FAIL'
+        Log To Console   Recording is running, killing the process
+        @{pid}           Find pid by name   gpu-screen-recorder
+        Kill process     @{pid}   sudo=False
+    END

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -221,12 +221,16 @@ Find pid by name
     RETURN        @{pids}
 
 Kill process
-    [Arguments]    @{pids}    ${sig}=9
+    [Arguments]    @{pids}    ${sig}=9    ${sudo}=True
     FOR   ${pid}  IN  @{pids}
         IF  '${pid}' == '${EMPTY}'
             BREAK
         END
-        Execute Command    kill -${sig} ${pid}  sudo=True  sudo_password=${password}  timeout=15
+        IF  $sudo == "True"
+            Execute Command    kill -${sig} ${pid}  sudo=True  sudo_password=${password}  timeout=15
+        ELSE
+            Execute Command    kill -${sig} ${pid}  timeout=15
+        END
         FOR    ${i}    IN RANGE   5
             ${ps_exists}=    Is Process Started    ${pid}
             IF  ${ps_exists}

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -10,6 +10,8 @@ Resource            ../../resources/app_keywords.resource
 Resource            ../../resources/gui_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
+Test Setup          Start screen recording
+Test Teardown       Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
 *** Variables ***
 @{APP_PIDS}             ${EMPTY}
@@ -23,7 +25,8 @@ Start and close Google Chrome via GUI on LenovoX1
     [Tags]            SP-T41-2  lenovo-x1
     Start app via GUI on LenovoX1   ${CHROME_VM}  chrome  display_name=Chrome
     Close app via GUI on LenovoX1   ${CHROME_VM}  google-chrome  ./window-close-neg.png   2
-    [Teardown]        Run Keyword If Test Failed     Skip   "Known issue SSRCSP-6716: Chrome does not have top bar"
+    [Teardown]        Run Keywords   Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}   AND
+    ...               Run Keyword If Test Failed    Skip    "Known issue SSRCSP-6716: Chrome does not have top bar"
 
 Start and close PDF Viewer via GUI on LenovoX1
     [Documentation]   Start PDF Viewer via GUI test automation and verify related process started

--- a/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
@@ -65,11 +65,13 @@ GUI Lock and Unlock
     [Documentation]   Lock the screen via GUI power menu lock icon and check that the screen is locked.
     ...               Unlock lock screen by typing the password and check that desktop is available.
     [Tags]            lenovo-x1   SP-T208-3   SP-T208-4   lock
+    [Setup]           Run Keywords   GUI Power Test Setup   AND   Start screen recording
     Select power menu option   text=Lock
     ${lock}           Check if locked
     IF  not ${lock}   FAIL    Failed to lock the screen
     Unlock
     Verify desktop availability
+    [Teardown]        Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
 GUI Reboot
     [Documentation]   Reboot the device via GUI power menu reboot icon.

--- a/Robot-Framework/test-suites/gui-tests/input_control.robot
+++ b/Robot-Framework/test-suites/gui-tests/input_control.robot
@@ -10,6 +10,9 @@ Library             Collections
 Resource            ../../resources/app_keywords.resource
 Resource            ../../resources/gui_keywords.resource
 
+Test Setup          Start screen recording
+Test Teardown       Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
+
 
 *** Test Cases ***
 
@@ -40,7 +43,7 @@ Change keyboard layout
     IF  $key_check != ';كö'
         FAIL    Failed to get the expected keyboard input ';كö'\nKeyboard input received: ${key_check}
     END
-    [Teardown]  Kill gui-vm apps
+    [Teardown]   Run Keywords   Kill gui-vm apps    AND   Stop screen recording    ${TEST_STATUS}   ${TEST_NAME}
 
 Control audio volume with keyboard shortcuts
     [Documentation]      Check that volume level is increased by pressing F3,


### PR DESCRIPTION
**Changes**
- Record the screen while GUI test is running and save the video if the test fails. `GUI Log out and log in` is excluded since recording does not work on login screen.
- Small improvement to `Set do not disturb state` to make sure that it immediately closes any open notifications. Setting `do_not_disturb` only stopped new notifications.

**Notes**
- If screen recording fails it will also fail the test case. I have not seen this happen once so I am confident it should not be an issue. If we do see cases where the recording fails, we can switch to `Run Keyword And Ignore Error` when starting/stopping the recording. I would rather not do it right away, it makes noticing potential issues much harder.

**Testruns**
- [Lenovo-X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/883/) gui 
- [Lenovo-X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/884/) gui but I changed the code so that it saved all the recordings. Videos are [here](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/884/artifact/Robot-Framework/test-suites/outputs/gui-temp/). 