### PR TITLE
Add parallel sysbench cpu test

### DIFF
--- a/Robot-Framework/lib/performance_thresholds.py
+++ b/Robot-Framework/lib/performance_thresholds.py
@@ -53,5 +53,6 @@ thresholds = {
         'response_to_ping': 10,
         'time_to_desktop': 12
     },
-    'iperf': "40%"
+    'iperf': "40%",
+    'cpu_isolation': 7
 }

--- a/Robot-Framework/test-suites/performance-tests/parallel_cpu_test
+++ b/Robot-Framework/test-suites/performance-tests/parallel_cpu_test
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+THREADS="$1"
+TEST_TIME="$2"
+RESULT_DIR="$3"
+
+# Create a directory for the results with a timestamp
+echo -e "\nCreating directory for test results:"
+echo "${RESULT_DIR}"
+mkdir -p ${RESULT_DIR}
+
+# cpu tests
+echo -e "\nRunning CPU tests...\n"
+sysbench cpu --time=${TEST_TIME} --threads=${THREADS} --cpu-max-prime=20000 run | tee ${RESULT_DIR}/cpu_report
+
+echo -e "\nTest finished.\n"


### PR DESCRIPTION
Measure cpu resource isolation level by running cpu test in single vm and parallel in two vms. Calculate the
difference.

I tested it locally on Lenovo-X1 and got results ranging from 11% to 18%. 

Test run on Dell shows much higher impact because on that device there is only 8 harware cpus and 8 threads (while X1 has 12 cores / 20 threads) and all 21 virtual vcpus are shared among only 8 threads. So on Dell the VMs overlap on physical cpus is naturally higher.
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/927/