### PR TITLE
Remove 'Gala -vm' from test codes

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -60,10 +60,9 @@ Set Variables
     Set Global Variable  ${CHROME_VM}          chrome-vm
     Set Global Variable  ${COMMS_VM}           comms-vm
     Set Global Variable  ${DOCKER_VM}          docker-vm
-    Set Global Variable  ${GALA_VM}            gala-vm
     Set Global Variable  ${GUI_VM}             gui-vm
     Set Global Variable  ${ZATHURA_VM}         zathura-vm
-    Set Global Variable  @{VMS}                ${ADMIN_VM}  ${AUDIO_VM}  ${BUSINESS_VM}  ${CHROME_VM}  ${COMMS_VM}  ${GALA_VM}  ${GUI_VM}  ${ZATHURA_VM}
+    Set Global Variable  @{VMS}                ${ADMIN_VM}  ${AUDIO_VM}  ${BUSINESS_VM}  ${CHROME_VM}  ${COMMS_VM}  ${GUI_VM}  ${ZATHURA_VM}
     Set Global Variable  ${PERF_LOW_LIMIT}     1
 
     Set Log Level       NONE

--- a/Robot-Framework/test-suites/functional-tests/apps.robot
+++ b/Robot-Framework/test-suites/functional-tests/apps.robot
@@ -40,18 +40,6 @@ Start Zathura
     Check that the application was started    zathura
     [Teardown]  Kill Process And Save Logs    ${GUI_VM}    ${USER_LOGIN}    /home/testuser/output.log    ${ZATHURA_VM}
 
-Start Gala
-    [Documentation]   Start Gala in dedicated VM and verify process started
-    [Tags]            bat  regression  SP-T104
-    [Setup]           Check if ssh is ready on vm    ${GALA_VM}
-    Switch to vm           gui-vm  user=${USER_LOGIN}
-    Start XDG application  GALA
-    Connect to VM          ${GALA_VM}
-    Check that the application was started    gala
-    [Teardown]  Run Keywords
-    ...         Kill Process And Save Logs    ${GUI_VM}    ${USER_LOGIN}    /home/testuser/output.log    ${GALA_VM}    AND
-    ...         Run Keyword If Test Failed     Skip    "Known issue: SSRCSP-6434"
-
 Start Element
     [Documentation]   Start Element in dedicated VM and verify process started
     [Tags]            bat  regression  SP-T52

--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -50,7 +50,6 @@ Check systemctl status
         ...    Dell|ghaf-mem-manager-business-vm.service|SSRCSP-6853
         ...    Dell|ghaf-mem-manager-chrome-vm.service|SSRCSP-6853
         ...    Dell|ghaf-mem-manager-comms-vm.service|SSRCSP-6853
-        ...    Dell|ghaf-mem-manager-gala-vm.service|SSRCSP-6853
         ...    Dell|ghaf-mem-manager-zathura-vm.service|SSRCSP-6853
 
         Check systemctl status for known issues    ${known_issues}   ${failing_services}

--- a/Robot-Framework/test-suites/functional-tests/logging.robot
+++ b/Robot-Framework/test-suites/functional-tests/logging.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       Testing logging
-Force Tags          bat  regression  logging  lenovo-x1   dell-7330
+Force Tags          bat  regression  pre-merge  logging  lenovo-x1   dell-7330
 
 Library             DateTime
 Library             OperatingSystem

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -206,7 +206,6 @@ Sysbench test in VMs
     [Tags]               SP-T61-9   lenovo-x1   dell-7330
     &{threads}    	Create Dictionary    net-vm=1
     ...                                  gui-vm=2
-    ...                                  gala-vm=2
     ...                                  zathura-vm=1
     ...                                  chrome-vm=4
     ...                                  comms-vm=4

--- a/Robot-Framework/test-suites/security-tests/ip_spoofing_test.robot
+++ b/Robot-Framework/test-suites/security-tests/ip_spoofing_test.robot
@@ -15,7 +15,7 @@ ${ip_server}
 Test IP spoofing
     [Documentation]   Test if it's possible to steal packets via ip spoofing
     [Tags]            SP-T128  ipspoofing  #lenovo-x1   dell-7330  tags commented out so that these are not included when running all tests
-    Set Suite Variable                ${server_vm}   ${GALA_VM}
+    Set Suite Variable                ${server_vm}   ${BUSINESS_VM}
     Set Suite Variable                ${client_vm}   ${COMMS_VM}
     Set Suite Variable                ${stealer_vm}  ${CHROME_VM}
     Prepare netcat server script

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -17,7 +17,6 @@
 |            | NetVM is wiped after restarting -Orin AGX         | SSRCSP-5662,SSRCSP-6423                                                                         |
 |            | Check systemctl status                            | [Full list of skips in the test case](/Robot-Framework/test-suites/functional-tests/host.robot) |
 |            | Check Camera Application -DELL                    | SSRCSP-6450                                                                                     |
-|            | Start Gala -DELL & LenovoX1                       | SSRCSP-6434                                                                                     |
 
 ## TAGs removed
 


### PR DESCRIPTION
"https://github.com/tiiuae/ghaf/pull/1349 disables the gala."

A handful of tests failed in last night execution due to gala removal.

This PR removes all the test code that refers to gala.

Regression test execution are ongoing/started in DEV:

- [Lenovo-X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/978/)

- [Dell](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/979/)