### PR TITLE
Only logout before gui-tests if it is first login

### DIFF
--- a/Robot-Framework/lib/helper_functions.py
+++ b/Robot-Framework/lib/helper_functions.py
@@ -6,3 +6,7 @@ from robot.libraries.BuiltIn import BuiltIn
 def set_variable_by_name(name, value):
     var_name = '${' + name + '}'
     BuiltIn().set_global_variable(var_name, value)
+
+def count_lines(output):
+    lines = [line for line in output.splitlines()]
+    return len(lines)

--- a/Robot-Framework/test-suites/gui-tests/__init__.robot
+++ b/Robot-Framework/test-suites/gui-tests/__init__.robot
@@ -5,6 +5,7 @@
 Documentation       GUI tests
 
 Library             ../../lib/GuiTesting.py   ${OUTPUT_DIR}/outputs/gui-temp/
+Library             ../../lib/helper_functions.py
 Resource            ../../resources/setup_keywords.resource
 Resource            ../../resources/gui_keywords.resource
 
@@ -21,9 +22,21 @@ GUI Tests Setup
 
     # There's a bug that occasionally causes the app menu to freeze on Cosmic, especially on the first login. 
     # Logging out once before running tests helps reduce the chances of it happening. (SSRCSP-6684)
-    Log out and verify   disable_dnd=True
-    Log in, unlock and verify   enable_dnd=True
+    ${first_login}   Is first graphical login
+    IF  ${first_login}
+        Log To Console   First login detected. Logging out and back in to go around a Cosmic bug.
+        Log out and verify   disable_dnd=True
+        Log in, unlock and verify   enable_dnd=True
+    END
 
 GUI Tests Teardown
     [Timeout]    5 minutes
     Clean Up Test Environment   disable_dnd=True
+
+Is first graphical login
+    [Documentation]   Returns True if there has only been one graphical login and False if there has been more than one
+    ${result}   Execute Command    journalctl --user -u graphical-session.target | grep "Reached target Current graphical user session"
+    Log         ${result}
+    ${lines}    Count lines    ${result}
+    IF  ${lines} <= 1   RETURN   True
+    RETURN      False


### PR DESCRIPTION
There is a Cosmic bug that often causes the app menu to freeze on the first login. To work around this, we always log out and back in before running GUI tests. With this PR the extra logout happens only if it’s actually the first login.

[First login](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/984/)
[Fourth login](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/986/)