### PR TITLE
Add Gala test to business-vm

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/business-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/business-vm.robot
@@ -50,6 +50,12 @@ Start Video Editor
     Switch to vm    business-vm
     Check that the application was started    lossless
 
+Start Gala
+    [Documentation]   Start Gala in Business-vm and verify process started
+    [Tags]  gala  SP-T104
+    Start XDG application   gala
+    Switch to vm    business-vm
+    Check that the application was started    gala
 
 *** Keywords ***
 


### PR DESCRIPTION
Gala is back, now in business-vm (https://github.com/tiiuae/ghaf/pull/1377)

[Testrun](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1000/)