### PR TITLE
Appropriate teardown for cpu isolation test

### DIFF
--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -72,6 +72,8 @@ CPU resource isolation test
     [Tags]                  cpu_isolation  SP-T298  lenovo-x1  darter-pro  dell-7330
     # Overshoot the sysbench cpu thread number in the attacking VM although qemu will/should limit it to 4.
     Single vs Parallel CPU test       reference-vm=${BUSINESS_VM}   ref_threads=4   attack-vm=${CHROME_VM}   attack_threads=20
+    [Teardown]              Run Keywords    Close All Connections
+    ...                     AND             Connect to ghaf host
 
 Memory Read One thread test
     [Documentation]         Run a memory benchmark using Sysbench for 60 seconds with a SINGLE thread.


### PR DESCRIPTION
The following test cases require existing ssh connection to ghaf-host. So the connection must be returned to ghaf-host in the end of CPU isolation test.

https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1005/