### PR TITLE
Skip Falcon AI test

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -77,6 +77,8 @@ Start Falcon AI
 
     ${answer}  Ask the question     2+2=? Return just the number.
     Should Be Equal As Integers     ${answer}   4
+    [Teardown]  Run Keyword If   "Lenovo" in "${DEVICE}" or "Darter" in "${DEVICE}"
+    ...         Run Keyword If Test Failed   Skip   "Known issue SSRCSP-6769: [Lenovo-X1] Falcon AI finds no models even though the model was installed"
 
 
 Check user systemctl status

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -3,7 +3,8 @@
 ## Active SKIPS
 
 | DATE SET   | TEST CASE                                         | TICKET / Additional Data.                                                                       |
-|------------|---------------------------------------------------| ----------------------------------------------------------------------------------------------- |
+|------------|---------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| 09.09.2025 | Start Falcon AI (Lenovo-x1, Darter-PRO)           | SSRCSP-6769                                                                                     |
 | 27.06.2025 | Measure UDP Bidir Throughput Small Packets (Dell) | SSRCSP-6774                                                                                     |
 | 17.06.2025 | Start and close Google Chrome via GUI on LenovoX1 | SSRCSP-6716                                                                                     |
 | 13.06.2025 | Record Video With Camera (Dell)                   | SSRCSP-6694                                                                                     |


### PR DESCRIPTION
Skipping Falcon AI test from Lenovo-X1& Darter-Pro.


Test run: [Dev#1054](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1054/)