### PR TITLE
Add Falcon AI to SKIP in Dell

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -77,7 +77,7 @@ Start Falcon AI
 
     ${answer}  Ask the question     2+2=? Return just the number.
     Should Be Equal As Integers     ${answer}   4
-    [Teardown]  Run Keyword If   "Lenovo" in "${DEVICE}" or "Darter" in "${DEVICE}"
+    [Teardown]  Run Keyword If   "Lenovo" in "${DEVICE}" or "Darter" in "${DEVICE}" or "Dell" in "${DEVICE}"
     ...         Run Keyword If Test Failed   Skip   "Known issue SSRCSP-6769: [Lenovo-X1] Falcon AI finds no models even though the model was installed"
 
 


### PR DESCRIPTION
Falcon AI failed also on Dell-7330 last night. [nightly](https://ci-prod.vedenemo.dev/artifacts/ghaf-nightly/20250910_200007433-commit_0f77dad08e5a26c96ae65b356874e9ec01a5cfaf/test-results/packages.x86_64-linux.dell-latitude-7330-debug/Robot-Framework/test-suites/regression/log.html)

Include Dell to SKIP.

Test Result: [1077](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1077/)