### PR TITLE
Modify ipspoofing test

### DIFF
--- a/Robot-Framework/test-suites/security-tests/ip_spoofing_test.robot
+++ b/Robot-Framework/test-suites/security-tests/ip_spoofing_test.robot
@@ -3,6 +3,7 @@
 
 *** Settings ***
 Resource            ../../resources/ssh_keywords.resource
+Force Tags          security    regression
 
 
 *** Variables ***
@@ -13,68 +14,87 @@ ${ip_server}
 *** Test Cases ***
 
 Test IP spoofing
-    [Documentation]   Test if it's possible to steal packets via ip spoofing
-    [Tags]            SP-T128  ipspoofing  #lenovo-x1   dell-7330  tags commented out so that these are not included when running all tests
-    Set Suite Variable                ${server_vm}   ${BUSINESS_VM}
-    Set Suite Variable                ${client_vm}   ${COMMS_VM}
-    Set Suite Variable                ${stealer_vm}  ${CHROME_VM}
-    Prepare netcat server script
-    Prepare netcat client script
-    Prepare netcat stealer script
-    Launch netcat test script         ${server_vm}   nc_server
-    Launch netcat test script         ${client_vm}   nc_client
-    Launch netcat test script         ${stealer_vm}  nc_stealer
-    Log To Console                    Waiting 40 sec for the test to finish
-    Sleep                             40
-    Check the result files
-    Close All Connections
+    [Tags]            SP-T128  ipspoofing  lenovo-x1  dell-7330  darter-pro
+    Set Suite Variable      ${file_path}   /home/appuser/'Unsafe share'
+    Set Suite Variable      ${server_vm}   ${BUSINESS_VM}
+    Set Suite Variable      ${client_vm}   ${COMMS_VM}
+    Set Suite Variable      ${stealer_vm}  ${CHROME_VM}
+    Test IP spoofing
 
 
 *** Keywords ***
 
+Test IP spoofing
+    [Documentation]   Test if it's possible to steal packets via ip spoofing
+    Prepare netcat server script
+    Prepare netcat client script
+    Prepare netcat stealer script
+    Launch netcat test script       ${server_vm}   nc_server
+    Launch netcat test script       ${client_vm}   nc_client
+    Launch netcat test script       ${stealer_vm}  nc_stealer
+
+    # When nc_stealer script starts to flip IP address ssh connection can get stuck. Drop all connections.
+    Close All Connections
+
+    Log To Console                  Waiting 40 sec for the test to finish
+    Connect
+    Sleep                           40
+    Check the result files
+    [Teardown]                      Spoofing Test Teardown
+
 Prepare netcat server script
-    Connect to VM                     ${server_vm}
+    Switch to vm                      ${server_vm}
     ${ip_server}                      Get Virtual Network Interface IP
     Set Suite Variable                ${ip_server}  ${ip_server}
     Put File                          security-tests/nc_server   /tmp
-    Execute Command                   chmod 777 /tmp/nc_server
+    Execute Command                   cp /tmp/nc_server ${file_path}   sudo=True  sudo_password=${PASSWORD}
+    Execute Command                   chmod 777 ${file_path}/nc_server   sudo=True  sudo_password=${PASSWORD}
 
 Prepare netcat client script
-    Connect to VM                     ${client_vm}
+    Switch to vm                      ${client_vm}
     Put File                          security-tests/nc_client   /tmp
     Execute Command                   echo 'ip_server=${ip_server}' > /tmp/tmp_file
     Execute Command                   cat /tmp/nc_client >> /tmp/tmp_file
-    Execute Command                   cp /tmp/tmp_file /tmp/nc_client
-    Execute Command                   chmod 777 /tmp/nc_client
+    Execute Command                   cp /tmp/tmp_file ${file_path}/nc_client  sudo=True  sudo_password=${PASSWORD}
+    Execute Command                   chmod 777 ${file_path}/nc_client  sudo=True  sudo_password=${PASSWORD}
 
 Prepare netcat stealer script
-    Connect to VM                     ${stealer_vm}
+    Switch to vm                      ${stealer_vm}
     ${ip_stealer}                     Get Virtual Network Interface IP
     Put File                          security-tests/nc_stealer   /tmp
     Execute Command                   echo 'ip_server=${ip_server}\nip_stealer=${ip_stealer}' > /tmp/tmp_file
     Execute Command                   cat /tmp/nc_stealer >> /tmp/tmp_file
-    Execute Command                   cp /tmp/tmp_file /tmp/nc_stealer
-    Execute Command                   chmod 777 /tmp/nc_stealer
+    Execute Command                   cp /tmp/tmp_file ${file_path}/nc_stealer  sudo=True  sudo_password=${PASSWORD}
+    Execute Command                   chmod 777 ${file_path}/nc_stealer  sudo=True  sudo_password=${PASSWORD}
 
 Launch netcat test script
     [Arguments]                       ${vm}  ${script_name}
-    Connect to VM                     ${vm}
-    Run Keyword And Ignore Error      Execute Command  -b /tmp/${script_name}  sudo=True  sudo_password=${PASSWORD}  timeout=3
+    Switch to vm                      ${vm}
+    Run Keyword And Ignore Error      Execute Command  -b ${file_path}/${script_name} ${file_path}  sudo=True  sudo_password=${PASSWORD}  timeout=3
 
 Check the result files
-    Connect to VM                     ${stealer_vm}
-    ${stolen}                         Execute Command    cat /tmp/stolen.txt | grep packet
-    Log                               ${stolen}
-    ${stealer_log}                    Execute Command    cat /tmp/stolen.txt
+    Switch to vm                      ${GUI_VM}
+    ${stealer_log}                    Execute Command    cat /Shares/'Unsafe ${stealer_vm} share'/stolen.txt  sudo=True  sudo_password=${PASSWORD}
     Log                               ${stealer_log}
-    Connect to VM                     ${server_vm}
-    ${server_received}                Execute Command    cat /tmp/server_received.txt | grep packet
-    Log                               ${server_received}
-    ${server_log}                     Execute Command    cat /tmp/server_received.txt
+    ${stolen}                         Execute Command    cat /Shares/'Unsafe ${stealer_vm} share'/stolen.txt | grep packet  sudo=True  sudo_password=${PASSWORD}
+    Log                               ${stolen}
+    ${server_log}                     Execute Command    cat /Shares/'Unsafe ${server_vm} share'/server_received.txt  sudo=True  sudo_password=${PASSWORD}
     Log                               ${server_log}
+    ${server_received}                Execute Command    cat /Shares/'Unsafe ${server_vm} share'/server_received.txt | grep packet  sudo=True  sudo_password=${PASSWORD}
+    Log                               ${server_received}
+    IF  $stealer_log == '${EMPTY}' or $server_log == '${EMPTY}'
+        FAIL    Server and/or stealer script was not able to write to output file. Test might be broken.
+    END
     IF  $stolen != '${EMPTY}'
         FAIL    Stealer VM managed to receive packets via ip spoofing
     END
     IF  $server_received == '${EMPTY}' and $stolen == '${EMPTY}'
-        FAIL    No packets received by server or stealer VM
+        FAIL    No packets received by server or stealer VM. Test might be broken.
     END
+
+Spoofing Test Teardown
+    [Documentation]   Switching of IP address can make stealer VM inaccessible for further tests.
+    ...               Restart the stealer vm.
+    Connect to ghaf host
+    Execute Command         systemctl restart microvm@${stealer_vm}.service  sudo=True  sudo_password=${PASSWORD}
+    Close All Connections

--- a/Robot-Framework/test-suites/security-tests/nc_client
+++ b/Robot-Framework/test-suites/security-tests/nc_client
@@ -4,8 +4,8 @@
 # This will be automatically written to the file when running the test
 # ip_server=
 
-for i in {1..35}
+for i in {1..40}
 do
   echo " ---- packet $i " | nc -w 1 ${ip_server} 5201
-  sleep 1.5
+  sleep 1.2
 done

--- a/Robot-Framework/test-suites/security-tests/nc_server
+++ b/Robot-Framework/test-suites/security-tests/nc_server
@@ -1,14 +1,18 @@
 # SPDX-FileCopyrightText: 2022-2025 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
+FILE_PATH=$1
+
 sudo iptables -A ghaf-fw-in-filter -p tcp --dport 5201 -j ACCEPT
 
-echo "" > /tmp/server_received.txt
+echo "" > "${FILE_PATH}"/server_received.txt
 
 for i in {1..30}
 do
-  echo "" >> /tmp/server_received.txt
-  echo "iteration $i - $(date)" >> /tmp/server_received.txt
-  timeout 1.7 nc -l 5201 >> /tmp/server_received.txt 2>&1
+  echo "" >> "${FILE_PATH}"/server_received.txt
+  echo "iteration $i - $(date)" >> "${FILE_PATH}"/server_received.txt
+  timeout 1.7 nc -l 5201 >> "${FILE_PATH}"/server_received.txt 2>&1
   sleep 0.5
 done
+
+sudo iptables -A ghaf-fw-in-filter -p tcp --dport 5201 -j DROP

--- a/Robot-Framework/test-suites/security-tests/nc_stealer
+++ b/Robot-Framework/test-suites/security-tests/nc_stealer
@@ -5,19 +5,25 @@
 # ip_server=
 # ip_stealer=
 
+FILE_PATH=$1
+
 sudo iptables -A ghaf-fw-in-filter -p tcp --dport 5201 -j ACCEPT
 
-echo "" > /tmp/stolen.txt
+echo "" > "${FILE_PATH}"/stolen.txt
 
 for i in {1..30}
 do
-  echo "" >> /tmp/stolen.txt
-  echo "iteration $i - $(date)" >> /tmp/stolen.txt
+  echo "" >> "${FILE_PATH}"/stolen.txt
+  echo "iteration $i - $(date)" >> "${FILE_PATH}"/stolen.txt
   sudo ifconfig ethint0 ${ip_server} netmask 255.255.255.0 up
-  sleep 0.3
+  sleep 0.8
   sudo ifconfig ethint0 ${ip_server} netmask 255.255.255.0 up
-  sleep 0.3
-  timeout 1 nc -l 5201 >> /tmp/stolen.txt 2>&1
+  sleep 0.8
+  ifconfig ethint0 | grep 'inet ' >> "${FILE_PATH}"/stolen.txt
+  timeout 2 nc -l 5201 >> "${FILE_PATH}"/stolen.txt 2>&1
   sudo ifconfig ethint0 ${ip_stealer} netmask 255.255.255.0 up
-  sleep 0.3
+  sleep 0.8
+  ifconfig ethint0 | grep 'inet ' >> "${FILE_PATH}"/stolen.txt
 done
+
+sudo iptables -A ghaf-fw-in-filter -p tcp --dport 5201 -j DROP


### PR DESCRIPTION
Execute the scripts in Unsafe share folders. That way report files can be read in case stealer vm becomes inaccessible via ssh.

Created more generic keywords to make further modifications easier. 

Later it might be possible to add the test to Orins too which probably requires ability to write to some shared directory from stealer vm as ssh access to stealer vm is usually lost in the test.

Vulnerability to IP spoofing was fixed in https://github.com/tiiuae/ghaf/pull/1319. As the test is passing it is now added to regression set.

I had to change also the timing in the scripts to make the test fail with old ghaf image.

**Test runs fail consistently without the spoofing fix (ghaf image built from a Aug 28 commit 108b57bf3e0e254687a1b2c5cd38e9ab03491510, before the spoofing fix):**
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1212/
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1213/
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1214/

**With current mainline ghaf image (after the spoofing fix):**
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1215/
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1220/