### PR TITLE
Log journalctl for failed services

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -55,12 +55,20 @@ Verify Systemctl status
     FAIL    Systemctl is not running after ${diff} sec! Status is ${status}. Failed processes?: ${failed_units}
 
 Check systemctl status for known issues
-    [Arguments]    ${known_issues_list}   ${failing_services}
+    [Arguments]    ${known_issues_list}   ${failing_services}   ${user}=False
     [Documentation]    Check if failing services contain issues that are not listed as known
+    IF    ${user}
+        ${unit_logs_cmd}     Set Variable   journalctl --user -u
+    ELSE
+        ${unit_logs_cmd}     Set Variable   journalctl -u
+    END
+
     ${old_issues}=    Create List
     ${new_issues}=    Create List
     FOR    ${failing_service}    IN    @{failing_services}
         ${known}=    Set Variable    False
+        ${unit_logs}   Execute command    ${unit_logs_cmd} ${failing_service}
+        Log            ${unit_logs}
         FOR    ${entry}    IN    @{known_issues_list}
             ${list_device}  ${service}  ${issue}   Parse Known Issue   ${entry}
 

--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -83,14 +83,14 @@ Start Falcon AI
 
 Check user systemctl status
     [Documentation]   Verify systemctl status --user is running
-    [Tags]            bat   pre-merge  SP-T260  lenovo-x1  darter-pro  dell-7330  fmo
+    [Tags]            bat   pre-merge  SP-T260  systemctl  lenovo-x1  darter-pro  dell-7330  fmo
 
     ${known_issues}=    Create List
     # Add any known failing services here with the target device and bug ticket number.
     # ...    device|service-name|ticket-number
     Verify Systemctl status    range=3   user=True
 
-    [Teardown]   Run Keyword If Test Failed   Check systemctl status for known issues  ${known_issues}  ${failed_units}
+    [Teardown]   Run Keyword If Test Failed   Check systemctl status for known issues  ${known_issues}  ${failed_units}   user=True
 
 Start Firefox GPU on FMO
     [Documentation]   Start Firefox GPU and verify process started

--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -34,7 +34,7 @@ Check QSPI version
 
 Check systemctl status
     [Documentation]    Verify systemctl status is running on host
-    [Tags]             SP-T98  nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1  darter-pro  dell-7330  fmo
+    [Tags]             SP-T98  systemctl  nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1  darter-pro  dell-7330  fmo
     ${status}   ${output}   Run Keyword And Ignore Error    Verify Systemctl status
     Log   ${output}
 

--- a/Robot-Framework/test-suites/functional-tests/vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/vm.robot
@@ -34,7 +34,7 @@ Check internet connection in every VM
 
 Check systemctl status in every VM
     [Documentation]    Check that systemctl status is running in every vm.
-    [Tags]             SP-T98-2
+    [Tags]             SP-T98-2   systemctl
     ${failed_new_services}=    Create List
     ${failed_old_services}=    Create List
     ${known_issues}=    Create List
@@ -72,7 +72,9 @@ Check VM systemctl status for known issues
     ${old_issues}=    Create List
     ${new_issues}=    Create List
     FOR    ${failing_service}    IN    @{failing_services}
-        ${known}=    Set Variable    False
+        ${known}=     Set Variable    False
+        ${unit_logs}  Execute command   journalctl -u ${failing_service}
+        Log            ${unit_logs}
         FOR    ${entry}    IN    @{known_issues_list}
             ${list_vm}  ${service}  ${issue}   Parse Known Issue   ${entry}
 


### PR DESCRIPTION
Log `journalctl -u` for failed systemctl services. Helps a lot with debugging randomly failing services.

**Testruns**
- `Check systemctl status` (systemctl status in host) finds a failing service https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1159/

Was not able to reproduce other systemctl check failures in Jenkins. Here is a local run where the `Check user systemctl status` (systemctl --user status in gui-vm) fails.
[log.html](https://github.com/user-attachments/files/22336184/log.html)
[output.xml](https://github.com/user-attachments/files/22336185/output.xml)
[report.html](https://github.com/user-attachments/files/22336186/report.html)
