### PR TITLE
Try to violate memory limit in ballooning test

### DIFF
--- a/Robot-Framework/test-suites/performance-tests/consume_memory
+++ b/Robot-Framework/test-suites/performance-tests/consume_memory
@@ -3,30 +3,36 @@
 
 # Script for consuming memory of a virtual machine fast but not too fast,
 # giving ballooning monitor time to react and increase the available memory.
-# Speed of consuming the memory depends on the size of the copied source file.
-# Setting source file size to greater than 2,5MB can enable too fast memory
-# consumption causing the script to be killed before finishing.
 
-write_iterations=$1
-robot_status_file="$2"
-script_status_file="$3"
+target_dir="$1"
+test_dir="$2"
 
-echo "stage0" > ${script_status_file}
+write_iterations=50000
 
-# Create a 2MB source file
-mkdir /dev/shm/test
-for i in $(seq 76923); do
-    echo "fillthememorywiththisdata" >> /dev/shm/test/source
+# Create a 4MB source file
+mkdir ${target_dir}/test
+for i in $(seq 153846); do
+    echo "fillthememorywiththisdata" >> ${target_dir}/test/source
 done
 
 # Fill the memory by copying the source file
 for index in $(seq ${write_iterations}); do
-    if [[ $(cat ${robot_status_file}) != "stage0" ]]
-    then
+    last_index=${index}
+    cp ${target_dir}/test/source ${target_dir}/test/file${index}
+
+    # Make writing slower if available memory is low -> mem-manager has more time to increase memory
+    free_mem=$(free --mebi | awk -F: 'NR==2 {print $2}' | awk '{print $6}')
+    if [ $free_mem -lt 500 ]; then
+        sleep 0.2
+    fi
+
+    # Exit from the loop when copying file does not succeed
+    file_size=$(wc -c ${target_dir}/test/file${index} | awk '{print $1}')
+    if [ "$file_size" -lt "1" ]; then
         break
     fi
-    cp /dev/shm/test/source /dev/shm/test/file${index}
 done
 
 sleep 1
-echo "stage1" > ${script_status_file}
+status_file_name=$(echo ${target_dir} | tr --delete /)
+echo "finished" > ${test_dir}/script_status/${status_file_name}${last_index}

--- a/Robot-Framework/test-suites/performance-tests/log_memory
+++ b/Robot-Framework/test-suites/performance-tests/log_memory
@@ -14,7 +14,7 @@ for i in $(seq 1000); do
     used=$(free --mega | awk -F: 'NR==2 {print $2}' | awk '{print $2}')
     avail=$(free --mega | awk -F: 'NR==2 {print $2}' | awk '{print $6}')
     echo "${elapsed_time},${total},${used},${avail}" >> ${test_dir}/ballooning_${id}.csv
-    if [[ $(cat ${status_file}) == "stage2" ]]
+    if [[ $(cat ${status_file}) == "finished" ]]
     then
         break
     fi


### PR DESCRIPTION
Changed ballooning test a lot. Now it tries to use memory as much as possible (even more than VM mem quota) by running the memory consume script simultaneously in three separate memory mounted directories.

Ballooning test checks that
- memory deflates at boot to defined (idle) level (vms start at fully ballooned state)
- memory manager allocates more memory to the vm when its available memory becomes small
- memory manager cannot allocate more memory than is defined by the VM mem quota + ballooning 
- memory deflates back to normal (idle) state after used memory is released

Test requires now 3 arguments:
- vm name
- mem quota (`vm.ramMb`) defined for the vm in ghaf repository
- max_inflate_ratio (currently default `balloonRatio`=2 which makes the max mem limit `3 x ramMb` -> max_inflate_ratio=3, see `mem = vm.ramMb * (vm.balloonRatio + 1);`) in `modules/microvm/appvm.nix`

Internal timeouts for inflate and deflate are now calculated from the amount of memory to be consumed.

Since the test is now trying to violate memory limits I had to pay more attention to units of memory.
- ghaf repository defines `vm.ramMb` in mebibytes (MiB)
- 1 MiB = 1024 x 1024 bits
- Use the same units in memory monitoring (`free --mebi`)

Tested locally on Lenovo-X1 multiple times.

Test run on Darter Pro
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1283/

Testing revealed that with the current VM configuration Dell-7330 target does not survive memory stress test in a single VM. Ghaf seems to crash when memory of chrome-vm is consumed as much as possible: GUI freezes, ssh connections drop (however I didn't find OOM errors in journalctls). Dell-7330 has only 16GB of HW memory and it's memory is very overloaded already at idle state few minutes after boot:
```
[ghaf@ghaf-host:~]$ free --mega
               total        used        free      shared  buff/cache   available
Mem:           16494       16188         191       15079       15501         306
Swap:          12884        2965        9919
```

I monitored memory in ghaf-host during ballooning_chrome_vm test on Dell-7330 
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1282/

The test gets stuck at 
`11:28:49  Used memory: 9424 / Total memory: 11909`

At that moment all memory resources (also 12GB swap) of ghaf-host are depleted:
```
Every 1.0s: free --mebi                                                                                                                                                            ghaf-host: Fri Sep 19 08:28:52 2025

               total        used        free      shared  buff/cache   available
Mem:           15730       15598         138       14559       14857         132
Swap:          12287       12279           8
```

Clearly ghaf VM configuration (mem quotas, balloonin ratios) should be tuned to more target specific (also fine tune among x86 targets). For now I exclude Dell-7330 from the ballooning tests. However, I improved Teardown so that even Dell-7330 can now survive test FAIL because of target device getting stuck (separate handling for SSHException) --> following tests can run.