### PR TITLE
Add skip for setup-ghaf-user

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/vm.robot
@@ -40,6 +40,7 @@ Check systemctl status in every VM
     ${known_issues}=    Create List
     # Add any known failing services here with the vm name and bug ticket number.
     # ...    vm|service-name|ticket-number
+    ...    gui-vm|setup-ghaf-user.service|SSRCSP-7234
 
     FOR  ${vm}  IN  @{VM_LIST}
         Connect to VM    ${vm}

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -4,6 +4,7 @@
 
 | DATE SET   | TEST CASE                                         | TICKET / Additional Data.                                                                       |
 | ---------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| 16.09.2025 | Check systemctl status in every VM                | SSRCSP-7234                                                                                     |
 | 09.09.2025 | Start Falcon AI (Lenovo-x1, Darter-PRO)           | SSRCSP-6769                                                                                     |
 | 27.06.2025 | Measure UDP Bidir Throughput Small Packets (Dell) | SSRCSP-6774                                                                                     |
 | 13.06.2025 | Record Video With Camera (Dell)                   | SSRCSP-6694                                                                                     |


### PR DESCRIPTION
Issue was fixed and skip removed a month ago (https://github.com/tiiuae/ci-test-automation/pull/411), now the service is failing again.