### PR TITLE
Prevent ipspoof test stuck

### DIFF
--- a/Robot-Framework/test-suites/security-tests/ip_spoofing_test.robot
+++ b/Robot-Framework/test-suites/security-tests/ip_spoofing_test.robot
@@ -4,6 +4,7 @@
 *** Settings ***
 Resource            ../../resources/ssh_keywords.resource
 Force Tags          security    regression
+Test Timeout        3 minutes
 
 
 *** Variables ***
@@ -36,9 +37,13 @@ Test IP spoofing
     # When nc_stealer script starts to flip IP address ssh connection can get stuck. Drop all connections.
     Close All Connections
 
-    Log To Console                  Waiting 40 sec for the test to finish
+    Log To Console                  Waiting 50 sec for the test to finish   no_newline=true
+    FOR    ${i}    IN RANGE    10
+        Log To Console   .  no_newline=true
+        Sleep       5
+    END
+
     Connect
-    Sleep                           40
     Check the result files
     [Teardown]                      Spoofing Test Teardown
 
@@ -70,7 +75,7 @@ Prepare netcat stealer script
 Launch netcat test script
     [Arguments]                       ${vm}  ${script_name}
     Switch to vm                      ${vm}
-    Run Keyword And Ignore Error      Execute Command  -b ${file_path}/${script_name} ${file_path}  sudo=True  sudo_password=${PASSWORD}  timeout=3
+    Run Keyword And Ignore Error      Execute Command  -b ${file_path}/${script_name} ${file_path}  sudo=True  sudo_password=${PASSWORD}  timeout=2
 
 Check the result files
     Switch to vm                      ${GUI_VM}

--- a/Robot-Framework/test-suites/security-tests/nc_client
+++ b/Robot-Framework/test-suites/security-tests/nc_client
@@ -4,6 +4,8 @@
 # This will be automatically written to the file when running the test
 # ip_server=
 
+sleep 6
+
 for i in {1..40}
 do
   echo " ---- packet $i " | nc -w 1 ${ip_server} 5201

--- a/Robot-Framework/test-suites/security-tests/nc_server
+++ b/Robot-Framework/test-suites/security-tests/nc_server
@@ -3,11 +3,13 @@
 
 FILE_PATH=$1
 
+sleep 8
+
 sudo iptables -A ghaf-fw-in-filter -p tcp --dport 5201 -j ACCEPT
 
 echo "" > "${FILE_PATH}"/server_received.txt
 
-for i in {1..30}
+for i in {1..40}
 do
   echo "" >> "${FILE_PATH}"/server_received.txt
   echo "iteration $i - $(date)" >> "${FILE_PATH}"/server_received.txt

--- a/Robot-Framework/test-suites/security-tests/nc_stealer
+++ b/Robot-Framework/test-suites/security-tests/nc_stealer
@@ -7,22 +7,24 @@
 
 FILE_PATH=$1
 
+sleep 4
+
 sudo iptables -A ghaf-fw-in-filter -p tcp --dport 5201 -j ACCEPT
 
 echo "" > "${FILE_PATH}"/stolen.txt
 
-for i in {1..30}
+for i in {1..15}
 do
   echo "" >> "${FILE_PATH}"/stolen.txt
   echo "iteration $i - $(date)" >> "${FILE_PATH}"/stolen.txt
   sudo ifconfig ethint0 ${ip_server} netmask 255.255.255.0 up
-  sleep 0.8
+  sleep 0.4
   sudo ifconfig ethint0 ${ip_server} netmask 255.255.255.0 up
-  sleep 0.8
+  sleep 0.4
   ifconfig ethint0 | grep 'inet ' >> "${FILE_PATH}"/stolen.txt
   timeout 2 nc -l 5201 >> "${FILE_PATH}"/stolen.txt 2>&1
   sudo ifconfig ethint0 ${ip_stealer} netmask 255.255.255.0 up
-  sleep 0.8
+  sleep 0.4
   ifconfig ethint0 | grep 'inet ' >> "${FILE_PATH}"/stolen.txt
 done
 


### PR DESCRIPTION
- Add delays
- Exit stealer VM before stealer script starts executing
- Add test timeout
- Tune the number of iterations and sleeps

With old ghaf image without ipspoofing protection
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1238/

With current ghaf mainline
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1235/