### PR TITLE
Refactor app tests

### DIFF
--- a/Robot-Framework/resources/app_keywords.resource
+++ b/Robot-Framework/resources/app_keywords.resource
@@ -9,6 +9,21 @@ Resource            ../resources/ssh_keywords.resource
 
 *** Keywords ***
 
+Start application in VM
+    [Arguments]    ${app_name}   ${vm_name}   ${process_name}   ${exact_match}=false
+    Check that appVM is running   ${vm_name}
+    Switch to vm   ${GUI_VM}  user=${USER_LOGIN}
+    Start XDG application   ${app_name}
+    IF   '${vm_name}' != '${GUI_VM}'   Switch to vm   ${vm_name}
+    Check that the application was started    ${process_name}   exact_match=${exact_match}
+
+Check that appVM is running
+    [Arguments]    ${vm_name}
+    Check if ssh is ready on vm   ${vm_name}   timeout=60
+    Switch to vm      ${vm_name}
+    # Wait until systemctl status is running (ignore error in case the status is degraded)
+    ${status}   Run Keyword and Ignore Error    Verify Systemctl status
+
 Start XDG application
     [Arguments]      ${app_name}
     Log To Console   ${\n}Starting ${app_name}
@@ -43,8 +58,7 @@ Check that the application is not running
     Log To Console    ${app_name} not running
 
 Launch Cosmic Term
-    Start XDG application   com.system76.CosmicTerm
-    Check that the application was started    cosmic-term  exact_match=true
+    Start application in VM   com.system76.CosmicTerm   ${GUI_VM}   cosmic-term   exact_match=true
 
 Log and remove app output
     [Documentation]    Specify the VM from which the app was started and the user (the owner of the file)

--- a/Robot-Framework/test-suites/functional-tests/apps.robot
+++ b/Robot-Framework/test-suites/functional-tests/apps.robot
@@ -22,42 +22,25 @@ Suite Setup         Connect to netvm
 Start Chrome
     [Documentation]   Start Chrome in dedicated VM and verify process started
     [Tags]            bat  regression   pre-merge   SP-T92
-    [Setup]           Run Keywords    Switch Connection    ${CONNECTION}    AND
-    ...               Verify service status  range=15  service=microvm@chrome-vm.service
-    Switch to vm           gui-vm  user=${USER_LOGIN}
-    Start XDG application  'Google Chrome'
-    Connect to VM          ${CHROME_VM}
-    Check that the application was started    chrome
+    Start application in VM   'Google Chrome'   ${CHROME_VM}   chrome
     [Teardown]  Kill Process And Save Logs    ${GUI_VM}    ${USER_LOGIN}    /home/testuser/output.log    ${CHROME_VM}
 
 Start Zathura
     [Documentation]   Start Zathura in dedicated VM and verify process started
     [Tags]            bat  regression  pre-merge   SP-T105
-    [Setup]           Check if ssh is ready on vm    ${ZATHURA_VM}
-    Switch to vm           gui-vm  user=${USER_LOGIN}
-    Start XDG application  'PDF Viewer'
-    Connect to VM          ${ZATHURA_VM}
-    Check that the application was started    zathura
+    Start application in VM   'PDF Viewer'   ${ZATHURA_VM}   zathura
     [Teardown]  Kill Process And Save Logs    ${GUI_VM}    ${USER_LOGIN}    /home/testuser/output.log    ${ZATHURA_VM}
 
 Start Element
     [Documentation]   Start Element in dedicated VM and verify process started
     [Tags]            bat  regression  SP-T52
-    [Setup]           Check if ssh is ready on vm    ${COMMS_VM}
-    Switch to vm           gui-vm  user=${USER_LOGIN}
-    Start XDG application  Element
-    Connect to VM          ${COMMS_VM}
-    Check that the application was started    element
+    Start application in VM   Element   ${COMMS_VM}   element
     [Teardown]  Kill Process And Save Logs    ${GUI_VM}    ${USER_LOGIN}    /home/testuser/output.log    ${COMMS_VM}
 
 Start Slack
     [Documentation]   Start Slack in dedicated VM and verify process started
     [Tags]            bat  regression  pre-merge  SP-T181
-    [Setup]           Check if ssh is ready on vm    ${COMMS_VM}
-    Switch to vm           gui-vm  user=${USER_LOGIN}
-    Start XDG application  Slack
-    Connect to VM          ${COMMS_VM}
-    Check that the application was started    slack
+    Start application in VM   Slack   ${COMMS_VM}   slack
     [Teardown]  Kill Process And Save Logs    ${GUI_VM}    ${USER_LOGIN}    /home/testuser/output.log    ${COMMS_VM}
 
 Open PDF from chrome-vm

--- a/Robot-Framework/test-suites/functional-tests/business-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/business-vm.robot
@@ -9,7 +9,6 @@ Resource            ../../resources/app_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
 Suite Setup         Connect to netvm
-Test Setup          Business Apps Test Setup
 Test Teardown       Business Apps Test Teardown
 
 
@@ -18,49 +17,34 @@ Test Teardown       Business Apps Test Teardown
 Start Microsoft Outlook
     [Documentation]   Start Microsoft Outlook in Business-vm and verify process started
     [Tags]  outlook  SP-T176
-    Start XDG application   "Microsoft Outlook"
-    Switch to vm    business-vm
-    Check that the application was started    outlook
+    Start application in VM   "Microsoft Outlook"   ${BUSINESS_VM}   outlook
 
 Start Microsoft 365
     [Documentation]   Start Microsoft 365 in Business-vm and verify process started
     [Tags]  microsoft365  SP-T178
-    Start XDG application   "Microsoft 365"
-    Switch to vm    business-vm
-    Check that the application was started    microsoft365
+    Start application in VM   "Microsoft 365"   ${BUSINESS_VM}   microsoft365
 
 Start Microsoft Teams
     [Documentation]   Start Microsoft Teams in Business-vm and verify process started
     [Tags]  teams  SP-T177
-    Start XDG application   Teams
-    Switch to vm    business-vm
-    Check that the application was started    teams
+    Start application in VM   Teams   ${BUSINESS_VM}   teams
 
 Start Trusted Browser
     [Documentation]   Start Trusted Browser in Business-vm and verify process started
     [Tags]  trusted_browser  SP-T179
-    Start XDG application   "Trusted Browser"
-    Switch to vm    business-vm
-    Check that the application was started    chrome
+    Start application in VM   "Trusted Browser"  ${BUSINESS_VM}   chrome
 
 Start Video Editor
     [Documentation]   Start Video Editor in Business-vm and verify process started
     [Tags]  video_editor  SP-T244
-    Start XDG application   "Video Editor"
-    Switch to vm    business-vm
-    Check that the application was started    lossless
+    Start application in VM   "Video Editor"  ${BUSINESS_VM}   lossless
 
 Start Gala
     [Documentation]   Start Gala in Business-vm and verify process started
     [Tags]  gala  SP-T104
-    Start XDG application   gala
-    Switch to vm    business-vm
-    Check that the application was started    gala
+    Start application in VM   gala   ${BUSINESS_VM}   gala
 
 *** Keywords ***
-
-Business Apps Test Setup
-    Switch to vm    gui-vm  user=${USER_LOGIN}
 
 Business Apps Test Teardown
     Kill process  @{APP_PIDS}

--- a/Robot-Framework/test-suites/functional-tests/docker-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/docker-vm.robot
@@ -8,7 +8,6 @@ Force Tags          bat  regression  docker-vm  fmo
 Resource            ../../resources/app_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
-Test Setup          Docker Apps Test Setup
 Test Teardown       Docker Apps Test Teardown
 
 
@@ -17,24 +16,17 @@ Test Teardown       Docker Apps Test Teardown
 Start FMO Onboarding Agent
     [Documentation]   Start FMO Onboarding Agent in docker-vm and verify process started
     [Tags]            onboarding
-    Start XDG application   "FMO Onboarding Agent"
-    Connect to VM       ${DOCKER_VM}
-    Check that the application was started    fmo-onboarding
+    Start application in VM   "FMO Onboarding Agent"   ${DOCKER_VM}   fmo-onboarding
 
 Start FMO Offboarding
     [Documentation]   Start FMO Offboarding Agent in docker-vm and verify process started
     [Tags]            offboarding
-    Start XDG application   "FMO Offboarding"
-    Connect to VM       ${DOCKER_VM}
-    Check that the application was started    fmo-offboarding
+    Start application in VM   "FMO Offboarding"   ${DOCKER_VM}   fmo-offboarding
 
 
 *** Keywords ***
 
-Docker Apps Test Setup
-    Connect to netvm
-    Connect to VM       ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
-
 Docker Apps Test Teardown
     Kill process       @{APP_PIDS}
-    Close All Connections
+    Log and remove app output   output.log   ${GUI_VM}   ${USER_LOGIN}
+    Run Keyword If Test Failed   Log app vm journalctl   ${DOCKER_VM}

--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -23,44 +23,42 @@ Test Teardown       Gui-vm Test Teardown
 Start Calculator
     [Documentation]   Start Calculator and verify process started
     [Tags]            bat   pre-merge  calculator  SP-T202  lenovo-x1  darter-pro  dell-7330  fmo
-    Start XDG application  Calculator
-    Check that the application was started    calculator
+    Start application in VM   Calculator   ${GUI_VM}   calculator
 
 Start Sticky Notes
     [Documentation]   Start Sticky Notes and verify process started
     [Tags]            bat   pre-merge  sticky_notes  SP-T201-1  lenovo-x1  darter-pro  dell-7330  fmo
-    Start XDG application  'Sticky Notes'
-    Check that the application was started    sticky-wrapped
+    Start application in VM   'Sticky Notes'   ${GUI_VM}   sticky-wrapped
 
 Start Ghaf Control Panel
     [Documentation]   Start Ghaf Control Panel and verify process started
     [Tags]            bat   pre-merge  control_panel  SP-T205  lenovo-x1  darter-pro  dell-7330  fmo
-    Start XDG application  'Ghaf Control Panel'
-    Check that the application was started    ctrl-panel
+    Start application in VM   'Ghaf Control Panel'   ${GUI_VM}   ctrl-panel
 
 Start Bluetooth Settings
     [Documentation]   Start Bluetooth Settings and verify process started
     [Tags]            bat   pre-merge  bluetooth_settings  SP-T204  lenovo-x1  darter-pro  dell-7330  fmo
-    Start XDG application  'Bluetooth Settings'
-    Check that the application was started    blueman-manager-wrapped-wrapped
+    Start application in VM   'Bluetooth Settings'   ${GUI_VM}   blueman-manager-wrapped-wrapped
 
 Start COSMIC Files
     [Documentation]   Start Cosmic Files and verify process started
     [Tags]            bat   pre-merge  cosmic_files  SP-T206  lenovo-x1  darter-pro  dell-7330  fmo
-    Start XDG application  com.system76.CosmicFiles
-    Check that the application was started    cosmic-files %U  exact_match=true
+    Start application in VM   com.system76.CosmicFiles   ${GUI_VM}   cosmic-files %U   exact_match=true
+
+Start COSMIC Media Player
+    [Documentation]   Start Cosmic Media Player and verify process started
+    [Tags]            bat   cosmic_player  SP-T294  lenovo-x1  darter-pro  dell-7330
+    Start application in VM   com.system76.CosmicPlayer   ${GUI_VM}   cosmic-player %U   exact_match=true
 
 Start COSMIC Settings
     [Documentation]   Start Cosmic Settings and verify process started
     [Tags]            bat   pre-merge  cosmic_settings  SP-T254  lenovo-x1  darter-pro  dell-7330  fmo
-    Start XDG application  com.system76.CosmicSettings
-    Check that the application was started    cosmic-settings  exact_match=true
+    Start application in VM   com.system76.CosmicSettings   ${GUI_VM}   cosmic-settings   exact_match=true
 
 Start COSMIC Text Editor
     [Documentation]   Start Cosmic Text Editor and verify process started
     [Tags]            bat   pre-merge  cosmic_editor  SP-T243  lenovo-x1  darter-pro  dell-7330  fmo
-    Start XDG application   com.system76.CosmicEdit
-    Check that the application was started    cosmic-edit %F  exact_match=true
+    Start application in VM   com.system76.CosmicEdit   ${GUI_VM}   cosmic-edit %F   exact_match=true
 
 Start COSMIC Terminal
     [Documentation]   Start Cosmic Terminal and verify process started
@@ -80,6 +78,10 @@ Start Falcon AI
     [Teardown]  Run Keyword If   "Lenovo" in "${DEVICE}" or "Darter" in "${DEVICE}" or "Dell" in "${DEVICE}"
     ...         Run Keyword If Test Failed   Skip   "Known issue SSRCSP-6769: [Lenovo-X1] Falcon AI finds no models even though the model was installed"
 
+Start GPU Screen Recorder
+    [Documentation]   Start GPU Screen Recorder and verify process started
+    [Tags]            bat   screen_recorder  SP-T293  lenovo-x1  dell-7330
+    Start application in VM   com.dec05eba.gpu_screen_recorder   ${GUI_VM}   gpu-screen-recorder
 
 Check user systemctl status
     [Documentation]   Verify systemctl status --user is running
@@ -95,20 +97,17 @@ Check user systemctl status
 Start Firefox GPU on FMO
     [Documentation]   Start Firefox GPU and verify process started
     [Tags]            bat   firefox_gpu  fmo
-    Start XDG application  'Firefox GPU'
-    Check that the application was started    firefox
+    Start application in VM   'Firefox GPU'   ${GUI_VM}   firefox
 
 Start Google Chrome GPU on FMO
     [Documentation]   Start Google Chrome GPU and verify process started
     [Tags]            bat   chrome_gpu  fmo
-    Start XDG application  'Google Chrome GPU'
-    Check that the application was started    chrome
+    Start application in VM   'Google Chrome GPU'   ${GUI_VM}   chrome
 
 Start Display Settings on FMO
     [Documentation]   Start Display Settings and verify process started
     [Tags]            bat   display_settings  fmo
-    Start XDG application  'Display Settings'
-    Check that the application was started    wdisplays
+    Start application in VM   'Display Settings'   ${GUI_VM}   wdisplays
 
 *** Keywords ***
 


### PR DESCRIPTION
**Changes**
- Add `Start application in VM` to launch apps. It checks that the VM is running, launches the app and checks that the app is running. No need to do all that separately for every app.
- `Check that appVM is running` will hopefully fix the issue where zathura launch fails. Zathura-vm is the only VM that starts booting only after login. While other VMs have already been running for over a minute when tests start running, zathura-vm is still booting. 
- Add launch test for COSMIC Media Player and GPU Screen Recorder.

**Testruns**
- Darter Pro [bat](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1337/)
- Dell-7330 [bat](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1336/)

**Future development**
- App launch teardowns could also be unified. Now each robot has their own way of calling the same keywords. This PR started as an attempt to fix Zathura launch issue so I decided to leave that one out.
- It could make sense to move all app launch tests to the apps.robot and then move everything that is not an app test to some other robot (files.robot (?)). That would simplify the teardowns and the current division does not really make sense.