### PR TITLE
Show correct string as build type

### DIFF
--- a/Robot-Framework/lib/PerformanceDataProcessing.py
+++ b/Robot-Framework/lib/PerformanceDataProcessing.py
@@ -23,7 +23,10 @@ class PerformanceDataProcessing:
         self.config_path = config_path
         self.plot_dir = plot_dir
         self.data_dir = self._create_result_dirs()
-        self.build_type = job.split(".")[0]
+        if len(job.split(".")) > 1:
+            self.build_type = job.split(".")[1]
+        else:
+            self.build_type = "unknown"
         self.zero_result_flag = -100
         self.low_limit = float(low_limit)
 


### PR DESCRIPTION
Currently build_type gets always value "packages" in the runs which have image url defined or include building the image. In the manual runs where url is not defined and the device is booted from an existing image build_type gets directly the device tag.

Modify initialization of self.build_type so that it gets something more reasonable:
- builder architecture if job variable includes full target name (e.g. packages.x86_64-linux.system76-darp11-b-debug)
- "unknown" if job variable includes only device tag

Test with only device tag, no image url given
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1377/
("Build type: unknown" in the plot titles.)

Test with image url defined
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1378/
("Build type: unknown" in the plot titles.)

If performance test is run on prod or release jenkins the build type will be actual build architecture. This is because dev jenkins has
            `echo { \\\"Job\\\": \\\"${env.DEVICE_TAG}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json`
in `hosts/hetzci/vm/casc/pipelines/ghaf-hw-test-manual.groovy`

but prod and rel jenkins pipelines have
            `echo { \\\"Job\\\": \\\"${env.TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json`
in `hosts/hetzci/prod/casc/pipelines/ghaf-hw-test.groovy` and `hosts/hetzci/release/casc/pipelines/ghaf-hw-test.groovy`

and env.TARGET is the full target string extracted from the image url whereas env.DEVICE_TAG is only the device name matched from the deviceMap dictionary.