### PR TITLE
Add lock test to Darter Pro

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -263,7 +263,7 @@ Unlock
     Locate and click   image  ${LOCK_ICON}   0.95  5
     Log To Console     Typing password to unlock
     Type string and press enter  ${USER_PASSWORD}  confidential=True
-    Sleep   1
+    Sleep   2
 
 Stop swayidle
     [Documentation]    Stop swayidle to prevent automatic suspension

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -60,6 +60,30 @@ Automatic suspension
     ${locked}         Check if locked
     Should Be True    ${locked}    Lock screen didn't appear
 
+Automatic lock (Darter Pro)
+    [Documentation]   Suspension is disabled on Darter Pro but automatic lock works
+    ...               Wait and check that
+    ...               in the beginning brightness is 100 %
+    ...               in 4 min - the screen dims (brightness is 25 %)
+    ...               in 5 min - the screen locks (brightness is 25 %)
+    [Tags]            SP-T269    darter-pro
+    [Setup]           Test setup
+
+    Check the screen state   on
+    Check screen brightness  ${max_brightness}
+
+    Set start timestamp
+
+    Wait     240
+    Check screen brightness  ${dimmed_brightness}
+
+    Wait     10
+
+    Check the screen state   on
+    Wait    50
+    ${locked}         Check if locked
+    Should Be True    ${locked}
+
 *** Keywords ***
 
 Test setup


### PR DESCRIPTION
Suspension is disabled on Darter Pro, but we can still test the automatic lock.

To be merged after release has been done.

[Testrun](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1363/)