### PR TITLE
Skip audio volume test (lenovo installer)

### DIFF
--- a/Robot-Framework/test-suites/gui-tests/input_control.robot
+++ b/Robot-Framework/test-suites/gui-tests/input_control.robot
@@ -79,6 +79,7 @@ Control audio volume with keyboard shortcuts
     ${vol_after_mute}    Get volume level
     Should Be Equal      ${vol_after_mute}    ${volume_down}    Volume level after mute status changing is different
 
+    [Teardown]  Run Keyword If   "Lenovo" in "${DEVICE}"   Run Keyword If Test Failed   Skip   "Known issue: SSRCSP-7294"
 
 *** Keywords ***
 

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -3,7 +3,8 @@
 ## Active SKIPS
 
 | DATE SET   | TEST CASE                                         | TICKET / Additional Data.                                                                       |
-| ---------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+|------------| ------------------------------------------------- |-------------------------------------------------------------------------------------------------|
+| 24.09.2025 | Control audio volume with keyboard shortcuts      | SSRCSP-7294 (Lenovo installer}                                                                  |
 | 16.09.2025 | Check systemctl status in every VM                | SSRCSP-7234                                                                                     |
 | 09.09.2025 | Start Falcon AI (Lenovo-x1, Darter-PRO)           | SSRCSP-6769                                                                                     |
 | 27.06.2025 | Measure UDP Bidir Throughput Small Packets (Dell) | SSRCSP-6774                                                                                     |


### PR DESCRIPTION
Skip for 'Control audio volume with keyboard shortcuts'.
'Lenovo-installer' -image gets into some unknown state after the device has been suspended. 
In nightly run 'suspension test' is executed before 'Control audio volume with keyboard shortcuts' -test and latter test fails.

Tested locally:
[lenovo_installer_volume_fail_log.html](https://github.com/user-attachments/files/22515041/lenovo_installer_volume_fail_log.html)
[volume_pass_log.html](https://github.com/user-attachments/files/22515042/volume_pass_log.html)
