### PR TITLE
Set limit for power during suspension

### DIFF
--- a/Robot-Framework/lib/ParsePowerData.py
+++ b/Robot-Framework/lib/ParsePowerData.py
@@ -21,16 +21,20 @@ class ParsePowerData:
             os.makedirs(self.plot_dir, exist_ok=True)
         return
 
-    def extract_time_interval(self, csv_file, start_time, end_time):
+    def extract_time_interval(self, csv_file, start_time, end_time, output_filename, check_freq):
         columns = ['time', 'meas_counter', 'power']
         data = pd.read_csv(self.power_meas_dir + csv_file, names=columns)
         interval = data.query("{} < time < {}".format(start_time, end_time))
-        interval.to_csv(self.power_meas_dir + 'power_interval.csv', index=False)
+        interval.to_csv(self.power_meas_dir + output_filename, index=False)
+        if check_freq:
+            self.check_measurement_frequency(data)
 
+    def check_measurement_frequency(self, data):
         # Check if measurement frequency was within normal limits
         # Reset the flag file
         with open(self.power_meas_dir + "low_frequency_flag", 'w'):
             pass
+
         normal_meas_frequency = 312
         tolerance = 50
         low_frequency = data[data['meas_counter'] < normal_meas_frequency - tolerance]
@@ -76,6 +80,14 @@ class ParsePowerData:
 
         plt.savefig(self.plot_dir + f'power_{test_name}.png')
         return
+
+    def measured_max(self, csv_file):
+        data = pd.read_csv(self.power_meas_dir + csv_file)
+        max_value = 0
+        for value in data['power']:
+            if value > max_value:
+                max_value = value
+        return max_value
 
     def mean_power(self, csv_file):
         columns = ['time', 'meas_counter', 'power']

--- a/Robot-Framework/resources/power_meas_keywords.resource
+++ b/Robot-Framework/resources/power_meas_keywords.resource
@@ -10,7 +10,6 @@ Resource            ../resources/common_keywords.resource
 
 *** Variables ***
 ${SSH_MEASUREMENT}        ${EMPTY}
-${start_timestamp}        ${EMPTY}
 ${RPI_IP_ADDRESS}         ${EMPTY}
 
 
@@ -34,6 +33,7 @@ Start power measurement
     # Multiple logging processes not allowed (for now)
     Stop recording power
     Start recording power      ${id}  ${timeout}
+    Set timestamp              power_meas_start
 
 Connect to measurement agent
     [Documentation]         Set up SSH connection to the measurement agent
@@ -69,7 +69,7 @@ Get power record
 
 Save power measurement interval
     [Documentation]   Extract measurement data within given time interval
-    [Arguments]       ${file_name}   ${start_time}   ${end_time}
+    [Arguments]       ${file_name}   ${start_time}   ${end_time}   ${output_filename}=power_interval.csv  ${check_freq}=${True}
     IF  $SSH_MEASUREMENT=='${EMPTY}'
         Log To Console    No connection to power measurement device. Ignoring all power measurement related keywords.
         RETURN
@@ -80,10 +80,10 @@ Save power measurement interval
         Log To Console    Invalid timestamp critera for extracting power data
         RETURN
     END
-    Run Keyword And Ignore Error    Extract time interval   ${file_name}  ${start_time}   ${end_time}
+    Run Keyword And Ignore Error  Extract time interval  ${file_name}  ${start_time}  ${end_time}  ${output_filename}  ${check_freq}
 
 Generate power plot
-    [Documentation]   Extract power data from start_timestamp to current time.
+    [Documentation]   Extract power data from start timestamp to current time.
     ...               Plot power vs time and save to png file.
     [Arguments]       ${id}   ${test_name}
     IF  $SSH_MEASUREMENT=='${EMPTY}'
@@ -92,18 +92,31 @@ Generate power plot
     END
     ${end_timestamp}                  Get current timestamp
     Get power record                  ${id}.csv
-    Save power measurement interval   ${id}.csv  '${start_timestamp}'  '${end_timestamp}'
+    Save power measurement interval   ${id}.csv  '${power_meas_start}'  '${end_timestamp}'
     Generate graph                    power_interval.csv  ${test_name}
     Log                               <img src="${REL_PLOT_DIR}power_${test_name}.png" alt="Power plot" width="1200">    HTML
 
-Set start timestamp
-    ${current_time}   DateTime.Get Current Date   UTC  exclude_millis=yes
-    Set Global Variable  ${start_timestamp}    ${current_time}
-    Log To Console       ${start_timestamp}
+Set timestamp
+    [Arguments]          ${timestamp_variable_name}
+    ${current_time}      DateTime.Get Current Date   UTC  exclude_millis=yes
+    Set Global Variable  ${${timestamp_variable_name}}    ${current_time}
+    Log                  ${${timestamp_variable_name}}    console=True
 
 Get current timestamp
     ${current_time}   DateTime.Get Current Date  UTC  exclude_millis=yes
     RETURN            ${current_time}
+
+Check power during suspension
+    [Arguments]       ${id}
+    IF  $SSH_MEASUREMENT=='${EMPTY}'
+        Log To Console    No connection to power measurement device. Ignoring all power measurement related keywords.
+        RETURN
+    END
+    Save power measurement interval   ${id}.csv  '${suspend_start}'  '${suspend_end}'  suspend_interval.csv  ${False}
+    ${max_power_during_suspension}  Measured max    suspend_interval.csv
+    IF   ${max_power_during_suspension} > 2500
+        FAIL    Power consumption exceptionally high during suspension
+    END
 
 Log average power
     [Arguments]       ${file_name}

--- a/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
@@ -25,7 +25,6 @@ GUI Suspend and wake up
     ...               if power measurement tooling is set.
     [Tags]            SP-T208-2   #lenovo-x1  The X1 in the lab gets stuck when a suspension is attempted. Needs further investigation.
     Start power measurement       ${BUILD_ID}   timeout=180
-    Set start timestamp
     # Connect back to gui-vm after power measurement has been started
     Connect to netvm
     Switch to vm    gui-vm   user=${USER_LOGIN}

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -29,36 +29,40 @@ Automatic suspension
     Check the screen state   on
     Check screen brightness  ${max_brightness}
 
-    Start power measurement       ${BUILD_ID}   timeout=1500
+    Start power measurement  ${BUILD_ID}   timeout=1500
     Connect
     Switch to vm    gui-vm   user=${USER_LOGIN}
-    Set start timestamp
 
-    Wait     240
+    Wait                     240
     Check screen brightness  ${dimmed_brightness}
 
-    Wait     10
+    Wait                     10
 
     Check the screen state   on
-    Wait    50
-    ${locked}         Check if locked
-    Should Be True    ${locked}
+    Wait                     50
+    ${locked}                Check if locked
+    Should Be True           ${locked}
 
-    Wait     610
+    Wait                     610
 
     Check that device is suspended
-    Wait     300
+    Wait                     60
+    Set timestamp            suspend_start
+    Wait                     240
+    Set timestamp            suspend_end
     Wake up device
+    Wait                     180
     Connect
-    Generate power plot           ${BUILD_ID}   ${TEST NAME}
+    Generate power plot      ${BUILD_ID}   ${TEST NAME}
     Stop recording power
-    Switch to vm    gui-vm   user=${USER_LOGIN}
+    Check power during suspension          ${BUILD_ID}
+    Switch to vm             gui-vm   user=${USER_LOGIN}
     Check the screen state   off
     # Screen wakeup requires a mouse move
     Move Cursor
     Check the screen state   on
-    ${locked}         Check if locked
-    Should Be True    ${locked}    Lock screen didn't appear
+    ${locked}                Check if locked
+    Should Be True           ${locked}    Lock screen didn't appear
 
 Automatic lock (Darter Pro)
     [Documentation]   Suspension is disabled on Darter Pro but automatic lock works
@@ -71,8 +75,6 @@ Automatic lock (Darter Pro)
 
     Check the screen state   on
     Check screen brightness  ${max_brightness}
-
-    Set start timestamp
 
     Wait     240
     Check screen brightness  ${dimmed_brightness}


### PR DESCRIPTION
Fail suspension test cases if the measured
power does not drop below certain limit during
suspension.

Monitor power longer after automated suspension

(To be done in another PR: check that power consumption does not change
significantly from the level before suspension.)

https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/315/

<img width="2000" height="1000" alt="image" src="https://github.com/user-attachments/assets/2e6e10b7-fa0e-42d7-9f0e-a8427ce0f0a6" />
