### PR TITLE
Options for custom and default low limit

### DIFF
--- a/Robot-Framework/lib/PerformanceDataProcessing.py
+++ b/Robot-Framework/lib/PerformanceDataProcessing.py
@@ -29,6 +29,15 @@ class PerformanceDataProcessing:
             self.build_type = "unknown"
         self.zero_result_flag = -100
         self.low_limit = float(low_limit)
+        self.default_low_limit = float(low_limit)
+
+    @keyword
+    def set_custom_low_limit(self, new_value):
+        self.low_limit = float(new_value)
+
+    @keyword
+    def set_default_low_limit(self):
+        self.low_limit = self.default_low_limit
 
     def _get_job_name(self):
         if self.config_path != "None":

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -184,6 +184,9 @@ FileIO write isolation test
     ...                 Report the impact of another fileio benchmark in separate VM to the reference VM.
     [Tags]              fileio_write_isolation  SP-T303-1  lenovo-x1  darter-pro  dell-7330
 
+    Set custom low limit   -100
+    Set Global Variable    ${PERF_LOW_LIMIT}   -100
+
     ${reference-vm}=       Set Variable     ${COMMS_VM}
     ${attacker-vm}=        Set Variable     ${CHROME_VM}
     ${test_dir}=           Set Variable     /guestStorage/fileio
@@ -233,6 +236,9 @@ FileIO read isolation test
     [Documentation]     Run a sysbench fileio read benchmark first in a single VM then parallel in two VMs.
     ...                 Report the impact of another fileio benchmark in separate VM to the reference VM.
     [Tags]              fileio_read_isolation  SP-T303-2  lenovo-x1  darter-pro  dell-7330
+
+    Set custom low limit   -100
+    Set Global Variable    ${PERF_LOW_LIMIT}   -100
 
     ${reference-vm}=       Set Variable     ${COMMS_VM}
     ${attacker-vm}=        Set Variable     ${CHROME_VM}
@@ -510,5 +516,7 @@ Teardown of Fileio Read Isolation Test
     Teardown of Fileio Isolation Test
 
 Teardown of Fileio Isolation Test
+    Set default low limit
+    Set Global Variable  ${PERF_LOW_LIMIT}   1
     Close All Connections
     Connect to ghaf host


### PR DESCRIPTION
Create keywords for changing temporarily class
variable low_limit of PerformanceDataProcessing.py.

Set low limit for fileio isolation tests very low
to allow both positive and negative results.

https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1464/