### PR TITLE
Clean files more explicitely

### DIFF
--- a/Robot-Framework/test-suites/performance-tests/ballooning.robot
+++ b/Robot-Framework/test-suites/performance-tests/ballooning.robot
@@ -182,9 +182,12 @@ Procedure After Timeout
     ${rebooted}=             Set Variable  True
 
 Clean Test Files
-    Run Keyword And Ignore Error  Execute Command   -b rm /dev/shm/test/*;rm -r /dev/shm/test  sudo=True  sudo_password=${PASSWORD}  timeout=1
-    Run Keyword And Ignore Error  Execute Command   -b rm /dev/test/*;rm -r /dev/test    sudo=True  sudo_password=${PASSWORD}  timeout=1
-    Run Keyword And Ignore Error  Execute Command   -b rm /run/test/*;rm -r /run/test    sudo=True  sudo_password=${PASSWORD}  timeout=1
+    Execute Command   rm /dev/shm/test/*      sudo=True  sudo_password=${PASSWORD}
+    Execute Command   rm /dev/test/*          sudo=True  sudo_password=${PASSWORD}
+    Execute Command   rm /run/test/*          sudo=True  sudo_password=${PASSWORD}
+    Execute Command   rm -r /dev/shm/test     sudo=True  sudo_password=${PASSWORD}
+    Execute Command   rm -r /dev/test         sudo=True  sudo_password=${PASSWORD}
+    Execute Command   rm -r /run/test         sudo=True  sudo_password=${PASSWORD}
 
 Ballooning Test Teardown
     [Documentation]    If test gets stuck, reboot device and connect to netvm (the next test can be executed).


### PR DESCRIPTION
Ballooning test has got sometimes stuck on darter-pro at
Clean Test Files.

Try to run the cleaning commands one by one.

It has been noticed already before that attempting
rm -r /dev/shm/test
while the folder was still full led sometimes to failure. That is why we delete files first and after that the folders.

https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1459/
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1460/