### PR TITLE
Allow switching to net-vm

### DIFF
--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -43,7 +43,7 @@ Soft Reboot Device
     [Documentation]  Reboot device from command line
     ${device_is_available}   Ping Host   ${DEVICE_IP_ADDRESS}
     IF  ${device_is_available}
-        Connect to ghaf host
+        Switch to vm   ghaf-host
         ${output}  Execute Command  reboot  sudo=True  sudo_password=${password}
         Log  ${output}
         Log To Console  Rebooting device from command line

--- a/Robot-Framework/resources/setup_keywords.resource
+++ b/Robot-Framework/resources/setup_keywords.resource
@@ -29,7 +29,7 @@ Prepare Test Environment
 Clean Up Test Environment
     [Timeout]     5 minutes
     [Arguments]   ${disable_dnd}=False
-    Connect to ghaf host
+    Switch to vm   ghaf-host
     Stop journalctl recording
     IF  "Lenovo" in "${DEVICE}" or "Darter" in "${DEVICE}" or "Dell" in "${DEVICE}"
         Start ydotoold
@@ -47,7 +47,7 @@ Connect to device
     IF  ${port_22_is_available} == False
         FAIL    Failed because port 22 of device was not available, tests can not be run.
     END
-    Connect to ghaf host
+    Switch to vm   ghaf-host
 
 Start journalctl recording
     ${output}     Execute Command    nohup journalctl -f >> /tmp/jrnl.txt 2>&1 &

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -114,7 +114,7 @@ Connect
         ${pass_status}  ${output}        Run Keyword And Ignore Error  Should Contain     ${login_output}   ${target_output}
         IF    $pass_status=='PASS'
             Log To Console    Connected successfully to ${target_output}
-            Set Global Variable  ${NETVM_SSH}    ${connection}
+            Set Global Variable  ${NET-VM_GHAF_SSH}    ${connection}
             RETURN  ${connection}
         ELSE
             # If connection was opened to a wrong VM collect logs to find out why
@@ -138,32 +138,31 @@ Connect
     END
     FAIL   Failed to connect
 
+# Only used in performance tests
 Connect to ghaf host
     [Documentation]      Open SSH connection to Ghaf Host
     ${connected}   Check ssh connection status   ghaf-host
     IF  not ${connected}
-        ${connection}        Connect
-        Set Global Variable  ${NETVM_SSH}        ${connection}
+        Connect
         Switch to vm         ghaf-host
     END
 
+# Only used in performance tests
 Connect to netvm
     [Documentation]      Open ssh connection to net-vm
     ${connected}   Check ssh connection status   net-vm
-    IF  not ${connected}
-        ${connection}   Connect
-        Set Global Variable  ${NETVM_SSH}    ${connection}
-        RETURN               ${NETVM_SSH}
-    END
+    IF   not ${connected}   Connect
+
 
 Connect to VM
     [Documentation]      Connect to any VM or ghaf-host over internal virtual network
     [Arguments]          ${vm_name}    ${user}=${LOGIN}   ${pw}=${PASSWORD}   ${timeout}=60
+    Switch to vm   ${NET_VM}
     Log                  Connecting to ${vm_name} as ${user}...   console=True
     Check if ssh is ready on vm        ${vm_name}   ${timeout}
     ${failed_connection}  Set Variable  True
     ${start_time}  Get Time	epoch
-    ${jumphost}    Set Variable  ${NETVM_SSH}
+    ${jumphost}    Set Variable  ${NET-VM_GHAF_SSH}
     # Opening connection
     FOR    ${i}    IN RANGE    10
         TRY
@@ -391,15 +390,6 @@ Check ssh connection status
         RETURN  ${False}
     END
 
-Connect to VM if not already connected
-    [Documentation]    Connect only if there is not already an active connection
-    [Arguments]        ${vm_name}
-    ${connected}   Check ssh connection status   ${vm_name}
-    IF  not ${connected}
-        Connect to netvm
-        Connect to VM   ${vm_name}
-    END
-
 Switch to vm
     [Arguments]         ${hostname}   ${user}=ghaf
 
@@ -425,8 +415,11 @@ Switch to vm
             RETURN
         END
     END
-
-    ${connection_index}      Connect to VM          ${hostname}     ${user}     ${pw}
+    IF  '${hostname}' == '${NET_VM}'
+        ${connection_index}      Connect
+    ELSE
+        ${connection_index}      Connect to VM          ${hostname}     ${user}     ${pw}
+    END
     Set Variable By Name     ${ssh_connection}    ${connection_index}
 
 Try to switch to active vm connection

--- a/Robot-Framework/resources/virtualization_keywords.resource
+++ b/Robot-Framework/resources/virtualization_keywords.resource
@@ -11,9 +11,9 @@ Library             String
 Verify microvm PCI device passthrough
     [Documentation]     Verify that proper PCI devices have been passed through to the VM
     [Arguments]    ${vmname}
-    Connect to VM if not already connected   ${vmname}
+    Switch to vm   ${vmname}
     @{pciids}=    Get list of PCI IDs
-    Connect to ghaf host
+    Switch to vm   ghaf-host
     @{pcipassthrus}=    Get microvm PCI passthrough list    vmname=${vmname}
     FOR    ${pcipass}    IN    @{pcipassthrus}
         ${pciidpass}=    Get PCI ID from PCI Address    address=${pcipass}

--- a/Robot-Framework/resources/wifi_keywords.resource
+++ b/Robot-Framework/resources/wifi_keywords.resource
@@ -4,8 +4,8 @@
 *** Keywords ***
 
 Configure wifi
-    [Arguments]         ${netvm_ssh}  ${SSID}  ${passw}
-    Switch Connection   ${netvm_ssh}
+    [Arguments]         ${SSID}  ${passw}
+    Switch to vm        ${NET_VM}
     Log To Console      Configuring Wifi
     Set Log Level       NONE
     Execute Command     nmcli dev wifi connect ${SSID} password ${passw}   sudo=True    sudo_password=${PASSWORD}
@@ -13,7 +13,7 @@ Configure wifi
 
 Remove Wifi configuration
     [Arguments]         ${SSID}
-    Switch Connection   ${netvm_ssh}
+    Switch to vm        ${NET_VM}
     Log To Console      Removing Wifi configuration
     ${stdout}  ${stderr}  ${rc}=  Execute Command  nmcli connection delete id ${SSID}
     ...   sudo=True   sudo_password=${PASSWORD}   return_stdout=True   return_stderr=True   return_rc=True
@@ -21,13 +21,13 @@ Remove Wifi configuration
 
 Turn OFF WiFi
     [Arguments]         ${SSID}
-    Switch Connection   ${netvm_ssh}
+    Switch to vm        ${NET_VM}
     Log To Console      Turning off Wifi
     Execute Command     nmcli con down id ${SSID}   sudo=True    sudo_password=${PASSWORD}
 
 Turn ON WiFi
     [Arguments]         ${SSID}
-    Switch Connection   ${netvm_ssh}
+    Switch to vm        ${NET_VM}
     Log To Console      Turning on Wifi
     Execute Command     nmcli con up id ${SSID}    sudo=True    sudo_password=${PASSWORD}
 

--- a/Robot-Framework/test-suites/functional-tests/__init__.robot
+++ b/Robot-Framework/test-suites/functional-tests/__init__.robot
@@ -20,7 +20,6 @@ ${DISABLE_LOGOUT}     ${EMPTY}
 Functional tests setup
     [Timeout]    5 minutes
     Prepare Test Environment
-    Switch to vm         ghaf-host
 
 Functional tests teardown
     [Timeout]    5 minutes

--- a/Robot-Framework/test-suites/functional-tests/apps.robot
+++ b/Robot-Framework/test-suites/functional-tests/apps.robot
@@ -10,7 +10,7 @@ Resource            ../../resources/app_keywords.resource
 Resource            ../../resources/file_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
-Suite Setup         Connect to netvm
+Suite Setup         Switch to vm   ${NET_VM}
 
 
 *** Variables ***
@@ -82,7 +82,7 @@ Open image with Oculante
 
     Open Image         ${img_file}
 
-    Connect to VM      ${ZATHURA_VM}
+    Switch to vm       ${ZATHURA_VM}
     Check that the application was started    oculante    10
     [Teardown]  Run Keywords  Remove the file in VM       ${img_file}  ${GUI_VM}    AND
     ...                       Kill Process And Save Logs  ${GUI_VM}    ${USER_LOGIN}    /tmp/out.log    ${ZATHURA_VM}

--- a/Robot-Framework/test-suites/functional-tests/audio.robot
+++ b/Robot-Framework/test-suites/functional-tests/audio.robot
@@ -9,8 +9,7 @@ Library             DateTime
 Resource            ../../resources/file_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
-Suite Setup         Connect to netvm
-Suite Teardown      Switch Connection   ${NETVM_SSH}
+Suite Setup         Switch to vm   ${NET_VM}
 Test Timeout        3 minutes
 
 

--- a/Robot-Framework/test-suites/functional-tests/business-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/business-vm.robot
@@ -8,7 +8,7 @@ Force Tags          bat  regression  pre-merge  business-vm  lenovo-x1  darter-p
 Resource            ../../resources/app_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
-Suite Setup         Connect to netvm
+Suite Setup         Switch to vm   ${NET_VM}
 Test Teardown       Business Apps Test Teardown
 
 

--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -9,7 +9,7 @@ Resource            ../../resources/app_keywords.resource
 Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
-Suite Setup         Connect to netvm
+Suite Setup         Switch to vm   ${NET_VM}
 Test Setup          Gui-vm Test Setup
 Test Teardown       Gui-vm Test Teardown
 

--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -10,7 +10,7 @@ Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/serial_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
-Suite Setup         Connect to ghaf host
+Suite Setup         Switch to vm   ghaf-host
 
 
 *** Test Cases ***

--- a/Robot-Framework/test-suites/functional-tests/logging.robot
+++ b/Robot-Framework/test-suites/functional-tests/logging.robot
@@ -9,12 +9,10 @@ Library             DateTime
 Library             OperatingSystem
 Resource            ../../resources/ssh_keywords.resource
 
-Suite Setup         Connect to netvm
-Suite Teardown      Switch Connection   ${NETVM_SSH}
+Suite Setup         Switch to vm   ${NET_VM}
 
 
 *** Variables ***
-${NETVM_SSH}          ${EMPTY}
 ${GRAFANA_LOGS}       https://loki.ghaflogs.vedenemo.dev
 
 
@@ -24,7 +22,7 @@ Check Grafana logs
     [Documentation]  Check that all virtual machines are sending logs to Grafana
     [Tags]           SP-T172
     Check Internet Connection
-    Connect to VM    ${ADMIN_VM}
+    Switch to vm    ${ADMIN_VM}
     ${id}           Execute Command  cat /etc/common/device-id  sudo=True  sudo_password=${PASSWORD}
     ${date}          DateTime.Get Current Date  result_format=%Y-%m-%d
     Wait Until Keyword Succeeds  60s  2s  Check Logs Are available  ${date}  ${id}

--- a/Robot-Framework/test-suites/functional-tests/optee.robot
+++ b/Robot-Framework/test-suites/functional-tests/optee.robot
@@ -6,7 +6,7 @@ Documentation       Test OP-TEE PKCS#11 through pkcs11-tool wrappers
 
 Resource            ../../resources/ssh_keywords.resource
 
-Suite Setup         Connect to ghaf host
+Suite Setup         Switch to vm   ghaf-host
 
 
 *** Test Cases ***

--- a/Robot-Framework/test-suites/functional-tests/shares.robot
+++ b/Robot-Framework/test-suites/functional-tests/shares.robot
@@ -10,7 +10,6 @@ Resource            ../../resources/ssh_keywords.resource
 
 Test Template       File sharing test
 Suite Setup         Shares setup
-Suite Teardown      Close All Connections
 
 
 *** Test Cases ***
@@ -47,11 +46,11 @@ File sharing test
     [Arguments]        ${vm1}    ${vm2}
     Set Test Variable  ${vm1_in_guivm}    /Shares/'Unsafe ${vm1} share'
     Set Test Variable  ${vm2_in_guivm}    /Shares/'Unsafe ${vm2} share'
-    Connect to VM      ${vm1}
+    Switch to vm       ${vm1}
     Create file        ${path_in_vm}/${file_name}   sudo=True
-    Connect to VM      ${GUI_VM}   ${USER_LOGIN}   ${USER_PASSWORD}
+    Switch to vm       ${GUI_VM}   ${USER_LOGIN}
     Copy file          ${vm1_in_guivm}/${file_name}    ${vm2_in_guivm}/${file_name}
-    Connect to VM      ${vm2}
+    Switch to vm       ${vm2}
     Check file exists  ${path_in_vm}/${file_name}   sudo=True
     [Teardown]         Run Keywords
     ...                Remove the file in VM    ${path_in_vm}/${file_name}    ${vm1}    AND
@@ -60,9 +59,9 @@ File sharing test
 Shares setup
     Set Suite Variable     ${path_in_vm}         /home/appuser/'Unsafe share'
     Set Suite Variable     ${file_name}          test.txt
-    Connect
+    Switch to vm           ${NET_VM}
 
 Remove the file in VM
     [Arguments]        ${file_name}    ${vm}
-    Connect to VM      ${vm}
+    Switch to vm       ${vm}
     Remove file        ${file_name}    sudo=True

--- a/Robot-Framework/test-suites/functional-tests/timesync.robot
+++ b/Robot-Framework/test-suites/functional-tests/timesync.robot
@@ -29,7 +29,7 @@ Time synchronization
     ...                  - In this test we expect adapter is not used -> Set Wi-Fi ON to enable net-vm to address net.
     [Tags]            bat  regression  SP-T97   nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1  darter-pro  dell-7330  fmo
 
-    ${host}  Connect
+    Switch to vm   ghaf-host
     Check that time is correct  timezone=UTC
 
     Stop timesync daemon
@@ -173,7 +173,7 @@ Unblock internet traffic
     Execute Command    iptables -D OUTPUT -p udp -m multiport --dports 80,443 -j DROP  sudo=True  sudo_password=${PASSWORD}
 
 Timesync Teardown
-     Connect
+     Switch to vm   ghaf-host
      Run Keyword If Test Failed  Check If Known Error
      Set RTC from system clock
      Start timesync daemon

--- a/Robot-Framework/test-suites/functional-tests/video.robot
+++ b/Robot-Framework/test-suites/functional-tests/video.robot
@@ -9,8 +9,7 @@ Library             Collections
 Library             OperatingSystem
 Resource            ../../resources/ssh_keywords.resource
 
-Test Setup          Connect to netvm
-Test Teardown       Close All Connections
+Test Setup          Switch to vm   ${NET_VM}
 Test Timeout        2 minutes
 
 
@@ -24,7 +23,7 @@ Check Camera Application
     [Documentation]  Check that camera application is available in business-vm and not in other vm
     [Tags]  SP-T235
     FOR  ${vm}  IN  @{VMS}
-        Connect to VM       ${vm}
+        Switch to vm        ${vm}
         ${out}  Execute Command  v4l2-ctl --list-devices  sudo=True  sudo_password=${PASSWORD}
         Log  ${out}
         IF  '${vm}' == '${BUSINESS_VM}'  Should Contain  ${out}  /dev/video  ELSE  Should Not Contain  ${out}  /dev/video
@@ -34,7 +33,7 @@ Check Camera Application
 Record Video With Camera
     [Documentation]  Start Camera application and record short video
     [Tags]  SP-T236
-    Connect to VM           ${BUSINESS_VM}
+    Switch to vm            ${BUSINESS_VM}
     Execute Command         rm /tmp/video*  sudo=True  sudo_password=${PASSWORD}
     @{recorded_video_ids}   Create List
     ${listed_devices}       Execute Command  v4l2-ctl --list-devices  sudo=True  sudo_password=${PASSWORD}

--- a/Robot-Framework/test-suites/functional-tests/vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/vm.robot
@@ -11,7 +11,6 @@ Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
 Suite Setup         VM Suite Setup
-Suite Teardown      Close All Connections
 
 
 *** Test Cases ***
@@ -94,8 +93,7 @@ Check user account is only in gui-vm
 *** Keywords ***
 
 VM Suite Setup
-    Connect to netvm
-    Connect to ghaf host
+    Switch to vm    ghaf-host
     ${output}       Execute Command    microvm -l
     @{VM_LIST}      Extract VM names   ${output}
     Should Not Be Empty     ${VM_LIST}   VM list is empty

--- a/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power_options.robot
@@ -27,7 +27,7 @@ GUI Suspend and wake up
     Start power measurement       ${BUILD_ID}   timeout=180
     Set start timestamp
     # Connect back to gui-vm after power measurement has been started
-    Connect to netvm
+    Switch to vm   ${NET_VM}
     Switch to vm    gui-vm   user=${USER_LOGIN}
 
     Select power menu option   index=4
@@ -109,7 +109,7 @@ GUI Log out and log in
 *** Keywords ***
 
 GUI Power Test Setup
-    Connect to netvm
+    Switch to vm   ${NET_VM}
     Switch to vm    gui-vm   user=${USER_LOGIN}
     Log in, unlock and verify
 

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -320,7 +320,7 @@ Sysbench test in VMs
             ${output}       Execute Command      /tmp/sysbench_test ${threads_n}  sudo=True  sudo_password=${PASSWORD}
             Run Keyword If    ${threads_n} > 1   Save sysbench results   ${vm}
             Save sysbench results   ${vm}   _1thread
-            Switch Connection    ${netvm_ssh}
+            Switch Connection    ${NET-VM_GHAF_SSH}
         END
     END
 

--- a/Robot-Framework/test-suites/security-tests/ip_spoofing_test.robot
+++ b/Robot-Framework/test-suites/security-tests/ip_spoofing_test.robot
@@ -100,6 +100,6 @@ Check the result files
 Spoofing Test Teardown
     [Documentation]   Switching of IP address can make stealer VM inaccessible for further tests.
     ...               Restart the stealer vm.
-    Connect to ghaf host
+    Switch to vm   ghaf-host
     Execute Command         systemctl restart microvm@${stealer_vm}.service  sudo=True  sudo_password=${PASSWORD}
     Close All Connections


### PR DESCRIPTION
**Changes**
- `Switch to vm` can switch to `net-vm`.
- Replace `Connect to VM`, `Connect to ghaf host` and `Connect to netvm` with `Switch to vm` in regression and GUI tests.
- Rename `${NETVM_SSH}` -> `${NET-VM_GHAF_SSH}` to align with the variable names used for other SSH connections.
- `Connect to VM` makes sure there is an active net-vm connection before connecting to a VM (if there is not it will create it). Consequently, `Switch to vm` keyword can be used even if there is no active net-vm connection beforehand. 

**Testruns**
- [Main pipeline](https://ci-dev.vedenemo.dev/job/ghaf-main/82/)
- Lenovo-X1 [regression & GUI](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1480/)
- Lenovo-X1 [performance](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1481/)

**Future development**
- `Connect to ghaf host` and `Connect to netvm` are still used in performance tests. I tried to change them as well but ran into some issues. To keep the scope of this PR reasonable I left them unchanged for now. Maybe @leivos-unikie can take a look at some point?
- There are some unnecessary `Switch to vm net-vm` that can be removed. After this change it is unnecessary to manually connect to net-vm before connecting to another VM. Again, to keep the scope reasonable I did not start removing them in this PR.