### PR TITLE
Use systemctl show

### DIFF
--- a/Robot-Framework/lib/output_parser.py
+++ b/Robot-Framework/lib/output_parser.py
@@ -22,7 +22,18 @@ def get_service_status(output):
         return match.group(1), match.group(2)
     else:
         raise Exception("Couldn't parse systemctl status")
+    
+def get_service_state(output):
+    match = re.search(r'^ActiveState=(\w+)', output, re.MULTILINE)
+    if match:
+        return match.group(1)
+    raise Exception(f"Couldn't parse ActiveState from systemctl show output")
 
+def get_service_substate(output):
+    match = re.search(r'^SubState=(\w+)', output, re.MULTILINE)
+    if match:
+        return match.group(1)
+    raise Exception(f"Couldn't parse SubState from systemctl show output")
 
 def find_pid(output, proc_name):
     output = output.split('\n')

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -249,28 +249,28 @@ Kill process
 
 Verify service status
     [Documentation]   Check if service is running with given loop ${range}
-    [Arguments]       ${range}=45  ${service}=${EMPTY}   ${expected_status}=active   ${expected_state}=running  ${expected_rc}=0
+    [Arguments]       ${range}=45  ${service}=${EMPTY}   ${expected_state}=active   ${expected_substate}=running  ${expected_rc}=0
     ${vmservice}      Run Keyword And Return Status  Should Contain  ${service}  microvm@
     ${finished}       Set Variable  False
 
     ${welcome_check}  Set Variable If  "Lenovo" in "${DEVICE}" or "Darter" in "${DEVICE}" or "Dell" in "${DEVICE}"    False    True
 
     FOR    ${i}    IN RANGE    ${range}
-        ${output}  ${stderr}  ${rc}=   Execute Command  systemctl status ${service}  return_stderr=True  return_rc=True
+        ${output}  ${stderr}  ${rc}=   Execute Command  systemctl show ${service}  return_stderr=True  return_rc=True
         Log           stdout: ${output}\nstderr: ${stderr}
         Should Not Be Equal As Integers	    ${rc}	4   Stderr: "${stderr}", Return code
-        ${result}     Get Service Status    ${output}
-        ${status}     ${state}    Get Service Status    ${output}
-        ${status}     Run Keyword And Return Status    Should Be True	'${status}' == '${expected_status}'  Expected ${expected_status} but in fact ${status}
-        ${state}      Run Keyword And Return Status    Should Be True	'${state}' == '${expected_state}'    Expected ${expected_state} but in fact ${state}
+        ${state}             Get Service State     ${output}
+        ${substate}          Get Service Substate  ${output}
+        ${state_status}      Run Keyword And Return Status    Should Be True	'${state}' == '${expected_state}'  Expected ${expected_state} but in fact ${state}
+        ${substate_status}   Run Keyword And Return Status    Should Be True	'${substate}' == '${expected_substate}'    Expected ${expected_substate} but in fact ${substate}
 
         # 'Welcome to NixOS' is not got if 'non-vm service' or if service is expected to be inactive/dead.
-        IF  ${vmservice} and '${expected_state}' == 'running' and ${status} and ${state} and ${welcome_check}
+        IF  ${vmservice} and '${expected_substate}' == 'running' and ${state_status} and ${substate_status} and ${welcome_check}
             ${finished}    Run Keyword And Return Status    Should Contain    ${output}    Welcome to NixOS
             IF  ${finished}
                 BREAK
             END
-        ELSE IF  ${status} and ${state}
+        ELSE IF  ${state_status} and ${substate_status}
             ${finished}     Set Variable  True
             BREAK
         END
@@ -278,12 +278,13 @@ Verify service status
     END
 
     IF  ${finished}
-        Log To Console  ${\n}systemctl status ${service} ${result}
+        Log To Console  ${\n}systemctl status ${service}: ${state} (${substate})
     ELSE
-        Log To Console  Verify service status failed. Last lines of systemctl status -log: ${output[-300:]}
-        Fail  systemctl status ${service} ${result}, expected: ${expected_status} and ${expected_state}
+        ${output}       Execute Command  journalctl -b -u ${service}
+        Log             ${output}
+        Fail            systemctl status ${service}: ${state} (${substate}), expected: ${expected_state} (${expected_substate})
     END
-    RETURN    ${status}  ${state}
+    RETURN    ${state}  ${substate}
 
 Verify service shutdown status
     [Documentation]   Check if service was stopped properly

--- a/Robot-Framework/test-suites/functional-tests/net-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/net-vm.robot
@@ -102,21 +102,21 @@ Restart NetVM
 Stop NetVM
     [Documentation]     Ensure that NetVM is started, stop it and check the status.
     ...                 Pre-condition: requires active ssh connection to ghaf host.
-    Verify service status   service=${netvm_service}   expected_status=active   expected_state=running
+    Verify service status   service=${netvm_service}   expected_state=active   expected_substate=running
     Log To Console          Going to stop NetVM
     Execute Command         systemctl stop ${netvm_service}  sudo=True  sudo_password=${PASSWORD}  timeout=120  output_during_execution=True
     Sleep    3
-    ${status}  ${state}=    Verify service status  service=${netvm_service}  expected_status=inactive  expected_state=dead
+    ${state}  ${substate}=    Verify service status  service=${netvm_service}  expected_state=inactive  expected_substate=dead
     Verify service shutdown status   service=${netvm_service}
-    Log To Console          NetVM is ${state}
+    Log To Console          NetVM is ${substate}
 
 Start NetVM
     [Documentation]     Try to start NetVM service
     ...                 Pre-condition: requires active ssh connection to ghaf host.
     Log To Console          Going to start NetVM
     Execute Command         systemctl start ${netvm_service}  sudo=True  sudo_password=${PASSWORD}  timeout=120  output_during_execution=True
-    ${status}  ${state}=    Verify service status  service=${netvm_service}  expected_status=active  expected_state=running
-    Log To Console          NetVM is ${state}
+    ${state}  ${substate}=    Verify service status  service=${netvm_service}  expected_state=active  expected_substate=running
+    Log To Console          NetVM is ${substate}
     Wait until NetVM service started
 
 Configure wifi via wpa_supplicant

--- a/Robot-Framework/test-suites/functional-tests/optee.robot
+++ b/Robot-Framework/test-suites/functional-tests/optee.robot
@@ -82,7 +82,7 @@ Check caml-crush service is running
     # but caml-crush is not included in basic ghaf builds
     [Tags]  caml-crush
 
-    ${status}  ${state}=    Verify service status  service="caml-crush.service"  expected_status=active  expected_state=running
+    ${state}  ${substate}=    Verify service status  service="caml-crush.service"  expected_state=active  expected_substate=running
 
 
 Basic pkcs11-tool-caml-crush RSA and ECDSA key test

--- a/Robot-Framework/test-suites/functional-tests/timesync.robot
+++ b/Robot-Framework/test-suites/functional-tests/timesync.robot
@@ -70,16 +70,16 @@ Update system time from internet in ${vm}
 
 Stop timesync daemon
     Execute Command        systemctl stop systemd-timesyncd.service  sudo=True  sudo_password=${PASSWORD}
-    Verify service status  service=systemd-timesyncd.service  expected_status=inactive  expected_state=dead
+    Verify service status  service=systemd-timesyncd.service  expected_state=inactive  expected_substate=dead
 
 Start timesync daemon
     Execute Command        systemctl start systemd-timesyncd.service  sudo=True  sudo_password=${PASSWORD}
-    Verify service status  service=systemd-timesyncd.service  expected_status=active  expected_state=running
+    Verify service status  service=systemd-timesyncd.service  expected_state=active  expected_substate=running
     ${output}              Execute Command    timedatectl -a
 
 Restart timesync daemon
     Execute Command        systemctl restart systemd-timesyncd.service  sudo=True  sudo_password=${PASSWORD}
-    Verify service status  service=systemd-timesyncd.service  expected_status=active  expected_state=running
+    Verify service status  service=systemd-timesyncd.service  expected_state=active  expected_substate=running
     ${output}              Execute Command    timedatectl -a
 
 Check that time is correct


### PR DESCRIPTION
**Changes**
- Use `systemctl show` instead of `systemctl status` in `Verify service status`. `show` is easier to read and exits automatically. I am hoping this might solve the issue where `systemctl status microvm@vm` gets stuck on X1 ([example](https://ci-prod.vedenemo.dev/job/ghaf-hw-test/6161/artifact/Robot-Framework/test-suites/pre-merge/log.html#s1-s1-s5-t4)).
- Rename `status` -> `state` and `state` -> `substate` to follow the official systemctl terms.

**Testruns**
- [Lenovo-X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1551/)

**Notes**
- `Get Service Status` is still used by `Verify init.scope status via serial`. I did not want to touch serial keywords since it has not caused issues.