### PR TITLE
Set QSPI Check back to pre-merge set.

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -29,10 +29,8 @@ Test nixos version format
 
 Check QSPI version
     [Documentation]    QSPI version should be up-to-date
-    [Tags]             SP-T95  orin-agx  orin-agx-64  orin-nx
+    [Tags]             SP-T95  orin-agx  orin-agx-64  orin-nx  pre-merge
     Check QSPI Version is up to date
-
-    [Teardown]    Run Keyword If Test Failed  SKIP  "Known issue: Updating QSPI for Orin HWs still ongoing"
 
 Check systemctl status
     [Documentation]    Verify systemctl status is running on host

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -4,7 +4,6 @@
 
 | DATE SET   | TEST CASE                                         | TICKET / Additional Data.                                                                       |
 | ---------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| 01.10.2025 | Check QSPI version                                | Removed from pre-merge until devices have been flashed                                          |
 | 24.09.2025 | Control audio volume with keyboard shortcuts      | SSRCSP-7294 (Lenovo installer)                                                                  |
 | 16.09.2025 | Check systemctl status in every VM                | SSRCSP-7234, SSRCSP-7306, SSRCSP-7321                                                           |
 | 09.09.2025 | Start Falcon AI (Lenovo-x1, Darter-PRO)           | SSRCSP-6769                                                                                     |


### PR DESCRIPTION
QSPI should now be updated to all Lab's Orin-NX and Orin-AGX devices.

Setting ' pre-merge ' tag back to QSPI Check -test  and also removal of temporary skip of that test.

I did not use the original way i.e. setting the pre-merge -tag via Force Tags but just added also the tag directly to the test case.  I thought that next time QSPI version is changed, one just needs to take the tag out of the test case, nothing more.

If that is not Ok, I'll change the PR to use Force Tags- method

[TestRun](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1573/)