### PR TITLE
Use is-system-running to check status

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -22,18 +22,16 @@ Verify Systemctl status
     [Documentation]    Check is systemctl running with given loop ${range}
 
     IF    ${user}
-        ${cmd}               Set Variable   systemctl status --user
+        ${cmd}               Set Variable   systemctl is-system-running --user
         ${failed_units_cmd}  Set Variable   systemctl list-units --state=failed --user
     ELSE
-        ${cmd}               Set Variable   systemctl status
+        ${cmd}               Set Variable   systemctl is-system-running
         ${failed_units_cmd}  Set Variable   systemctl list-units --state=failed
     END
 
     ${start_time}=    Get Time	epoch
     FOR    ${i}    IN RANGE    ${range}
-        ${output}=    Execute Command    ${cmd}
-        ${status}=    Get Systemctl Status    ${output}
-        Log  ${output}
+        ${status}=    Execute Command    ${cmd}
 
         ${data_failed_units}   Execute Command    ${failed_units_cmd}
         Log  ${data_failed_units}
@@ -57,6 +55,9 @@ Verify Systemctl status
 Check systemctl status for known issues
     [Arguments]    ${known_issues_list}   ${failing_services}   ${user}=False
     [Documentation]    Check if failing services contain issues that are not listed as known
+
+    Should Not Be Empty    ${failing_services}     Failing services list is empty.
+
     IF    ${user}
         ${unit_logs_cmd}     Set Variable   journalctl --user -u
     ELSE

--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -32,7 +32,7 @@ Check QSPI version
     [Tags]             SP-T95  orin-agx  orin-agx-64  orin-nx  pre-merge
     Check QSPI Version is up to date
 
-Check systemctl status
+Check host systemctl status
     [Documentation]    Verify systemctl status is running on host
     [Tags]             SP-T98  systemctl  nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1  darter-pro  dell-7330  fmo  pre-merge
     ${status}   ${output}   Run Keyword And Ignore Error    Verify Systemctl status


### PR DESCRIPTION
Another try to fix the issue related to systemctl status checks.
- Use `systemctl is-system-running` to get the systemctl status.
- Fix an issue where the host systemctl status check was skipped if `systemctl status` command timed out.

[Lenovo-X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1599/)
[Orin-AGX](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1600/)