### PR TITLE
Fix GUI power tests

### DIFF
--- a/Robot-Framework/test-suites/gui-tests/__init__.robot
+++ b/Robot-Framework/test-suites/gui-tests/__init__.robot
@@ -31,6 +31,8 @@ GUI Tests Setup
 
 GUI Tests Teardown
     [Timeout]    5 minutes
+    # In case the screen recording was not stopped
+    Kill screen recording
     Clean Up Test Environment   disable_dnd=True
 
 Is first graphical login

--- a/Robot-Framework/test-suites/gui-tests/input_control.robot
+++ b/Robot-Framework/test-suites/gui-tests/input_control.robot
@@ -79,7 +79,8 @@ Control audio volume with keyboard shortcuts
     ${vol_after_mute}    Get volume level
     Should Be Equal      ${vol_after_mute}    ${volume_down}    Volume level after mute status changing is different
 
-    [Teardown]  Run Keyword If   "Lenovo" in "${DEVICE}"   Run Keyword If Test Failed   Skip   "Known issue: SSRCSP-7294"
+    [Teardown]  Run Keywords   Stop screen recording    ${TEST_STATUS}   ${TEST_NAME}   AND
+    ...    Run Keyword If   "Lenovo" in "${DEVICE}"   Run Keyword If Test Failed   Skip   "Known issue: SSRCSP-7294"
 
 *** Keywords ***
 

--- a/Robot-Framework/test-suites/performance-tests/boot_time_test.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time_test.robot
@@ -38,7 +38,7 @@ Measure Soft Boot Time
 
 Measure Hard Boot Time
     [Documentation]  Measure how long it takes to device to boot up with hard reboot
-    [Tags]  SP-T182  lenovo-x1  darter-pro  dell-7330
+    [Tags]  SP-T182  lenovo-x1  darter-pro  dell-7330  lab-only
     Log To Console                Shutting down by pressing the power button
     Press Button                  ${SWITCH_BOT}-OFF
     Wait Until Keyword Succeeds   15s  2s  Check If Ping Fails
@@ -60,7 +60,7 @@ Measure Orin Soft Boot Time
 
 Measure Orin Hard Boot Time
     [Documentation]  Measure how long it takes to device to boot up with hard reboot
-    [Tags]  SP-T182  orin-agx  orin-agx-64  orin-nx
+    [Tags]  SP-T182  orin-agx  orin-agx-64  orin-nx  lab-only
     Log To Console                Shutting down by switching the power off
     Turn Relay Off                ${RELAY_NUMBER}
     Wait Until Keyword Succeeds   15s  2s  Check If Ping Fails

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -22,7 +22,7 @@ Automatic suspension
     ...               in 5 min - the screen locks (brightness is 25 %)
     ...               in 15 min - the laptop is suspended
     ...               in 20 min press the button and check that laptop woke up
-    [Tags]            SP-T162    lenovo-x1
+    [Tags]            SP-T162    lenovo-x1   lab-only
     [Setup]           Test setup
     [Teardown]        Test teardown
 

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -16,16 +16,12 @@
 |            | OP-TEE xtest 1033 -orin-agx & orin-nx             | Known issue encountered, skipping the test                                                      |
 |            | OP-TEE xtest 1008 -orin-agx & orin-nx             | Known issue encountered, skipping the test                                                      |
 |            | Verify NetVM PCI device passthrough -Orin AGX     | SSRCSP-5662, SSRCSP-6423                                                                        |
-|            | NetVM is wiped after restarting -Orin AGX         | SSRCSP-5662,SSRCSP-6423                                                                         |
 |            | Check systemctl status                            | [Full list of skips in the test case](/Robot-Framework/test-suites/functional-tests/host.robot) |
 |            | Check Camera Application -DELL                    | SSRCSP-6450                                                                                     |
 
 ## TAGs removed
 
-| DATE SET   | TEST CASE                             | TICKET / Additional Data.                                                                 |
-| ---------- | ------------------------------------- | ----------------------------------------------------------------------------------------- |
-| 03.09.2025 | Performance/network suite (AGX)       | SSRCSP-7160. Network-adapter usage had impact on results Needs further investigation.     |
-| 08.05.2025 | GUI Reboot                            | The X1 in the lab gets stuck when a reboot is attempted. Needs further investigation.     |
-| 08.05.2025 | GUI Suspend and wake up               | The X1 in the lab gets stuck when a suspension is attempted. Needs further investigation. |
-| 03/2025    | Performance Network.robot - ‘orin-nx’ | SSRCSP-6372 - Works locally but problems when Jenkins used, fails all..                   |
-| 22.01.2025 | Start Firefox - ‘nuc, orin-agx        | Firefox is temporarily disabled from SW                                                   |
+| DATE SET   | TEST CASE                             | TICKET / Additional Data.                                                             |
+| ---------- | ------------------------------------- | ------------------------------------------------------------------------------------- |
+| 03.09.2025 | Performance/network suite (AGX)       | SSRCSP-7160. Network-adapter usage had impact on results Needs further investigation. |
+| 03/2025    | Performance Network.robot - ‘orin-nx’ | SSRCSP-6372 - Works locally but problems when Jenkins used, fails all..               |


### PR DESCRIPTION
After https://github.com/tiiuae/ghaf/pull/1434 reboot and suspend from the power menu work again in the lab.

**Changes**
- Re-enable `GUI Suspend and wake up` and `GUI Reboot` tests on X1. Added the reboot test for the Darter Pro too.
- Use coordinates to click the suspend/reboot buttons in the power menu. This is not an ideal solution but it works. Because of the theme we use, finding these buttons through image recognition is difficult. Previously the tests used Tab+Enter to select the options, but that no longer works. I confirmed that this issue also occurs in Cosmic Beta.
- Add a `lab-only` tag to cases that require fingers or relay connection. When running manually it is easier to exclude one tag than to have a list of cases to skip. There might be some cases that I missed, please let me know.
- Bug fix: Stop screen recording after `Control audio volume with keyboard shortcuts`. Since a skip was added the normal teardown is not used leaving the recording running.

**Testruns**
- Lenovo-X1 [GUI](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1613/) in dev
- Lenovo-X1 [GUI](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/341/) in prod (used to get stuck because does not have battery)
- Darter-Pro [GUI](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1614/) in dev