### PR TITLE
Check host systemctl status in vm tests

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -34,7 +34,7 @@ Check QSPI version
 
 Check host systemctl status
     [Documentation]    Verify systemctl status is running on host
-    [Tags]             SP-T98  systemctl  nuc  orin-agx  orin-agx-64  orin-nx  riscv  lenovo-x1  darter-pro  dell-7330  fmo  pre-merge
+    [Tags]             SP-T98  systemctl  nuc  orin-agx  orin-agx-64  orin-nx  riscv  fmo  pre-merge
     ${status}   ${output}   Run Keyword And Ignore Error    Verify Systemctl status
     Log   ${output}
 
@@ -45,12 +45,7 @@ Check host systemctl status
         ...    NUC|ANY|SSRCSP-4632
         ...    Orin|nvfancontrol.service|SSRCSP-6303
         ...    AGX|systemd-rfkill.service|SSRCSP-6303
-        ...    Dell|autovt@ttyUSB0.service|SSRCSP-6667
         ...    Orin|systemd-oomd.service|SSRCSP-6685
-        ...    ANY|ghaf-mem-manager-business-vm.service|SSRCSP-6853
-        ...    ANY|ghaf-mem-manager-chrome-vm.service|SSRCSP-6853
-        ...    ANY|ghaf-mem-manager-comms-vm.service|SSRCSP-6853
-        ...    ANY|ghaf-mem-manager-zathura-vm.service|SSRCSP-6853
 
         Check systemctl status for known issues    ${known_issues}   ${failing_services}
     END

--- a/Robot-Framework/test-suites/functional-tests/vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/vm.robot
@@ -39,11 +39,16 @@ Check systemctl status in every VM
     ${known_issues}=    Create List
     # Add any known failing services here with the vm name and bug ticket number.
     # ...    vm|service-name|ticket-number
-    ...    gui-vm|setup-ghaf-user.service|SSRCSP-7234
-    ...    gui-vm|plymouth-quit.service|SSRCSP-7306
     ...    audio-vm|systemd-rfkill.service|SSRCSP-7321
+    ...    ghaf-host|autovt@ttyUSB0.service|SSRCSP-6667
+    ...    ghaf-host|ghaf-mem-manager-business-vm.service|SSRCSP-6853
+    ...    ghaf-host|ghaf-mem-manager-chrome-vm.service|SSRCSP-6853
+    ...    ghaf-host|ghaf-mem-manager-comms-vm.service|SSRCSP-6853
+    ...    ghaf-host|ghaf-mem-manager-zathura-vm.service|SSRCSP-6853
+    ...    gui-vm|plymouth-quit.service|SSRCSP-7306
+    ...    gui-vm|setup-ghaf-user.service|SSRCSP-7234
 
-    FOR  ${vm}  IN  @{VM_LIST}
+    FOR  ${vm}  IN  @{VM_LIST_WITH_HOST}
         Switch to vm     ${vm}
         ${status}  ${output}   Run Keyword And Ignore Error   Verify Systemctl status
         IF  $status=='FAIL'

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -5,7 +5,7 @@
 | DATE SET   | TEST CASE                                         | TICKET / Additional Data.                                                                       |
 | ---------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | 24.09.2025 | Control audio volume with keyboard shortcuts      | SSRCSP-7294 (Lenovo installer)                                                                  |
-| 16.09.2025 | Check systemctl status in every VM                | SSRCSP-7234, SSRCSP-7306, SSRCSP-7321                                                           |
+| 16.09.2025 | Check systemctl status in every VM                | [Full list of skips in the test case](/Robot-Framework/test-suites/functional-tests/vm.robot)   |
 | 09.09.2025 | Start Falcon AI (Lenovo-x1, Darter-PRO)           | SSRCSP-6769                                                                                     |
 | 27.06.2025 | Measure UDP Bidir Throughput Small Packets (Dell) | SSRCSP-6774                                                                                     |
 | 13.06.2025 | Record Video With Camera (Dell)                   | SSRCSP-6694                                                                                     |


### PR DESCRIPTION
Check the host systemctl status as part of `Check systemctl status in every VM` for laptop targets. Orins still use `Check host systemctl status`.

[Lenovo-X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/1633/)