### PR TITLE
Save logs using serial

### DIFF
--- a/Robot-Framework/test-suites/gui-tests/gui_power_menu.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power_menu.robot
@@ -12,6 +12,7 @@ Resource            ../../resources/gui-vm_keywords.resource
 Resource            ../../resources/measurement_keywords.resource
 Resource            ../../resources/setup_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
+Resource            ../../resources/serial_keywords.resource
 
 Test Setup          GUI Power Test Setup
 Test Teardown       GUI Power Test Teardown
@@ -113,6 +114,7 @@ GUI Power Test Setup
 GUI Power Test Teardown
     Stop screen recording   ${TEST_STATUS}   ${TEST_NAME} 
     IF  $TEST_STATUS == 'FAIL'
+        Run keyword and continue on failure    serial_keywords.Save log
         Reboot Laptop
         Connect After Reboot
         IF    ${IS_AVAILABLE}


### PR DESCRIPTION
Added save log for GUI suspend failures investigation 

[Saving logs if failed](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5144/artifact/Robot-Framework/test-suites/SP-T75-3/log.html#s1-s1-s1-t1-k23-k2-k1-k1)
[Not saving if passed](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5143/artifact/Robot-Framework/test-suites/SP-T75-3/log.html#s1-s1-s1-t1-k22-k2)