### PR TITLE
Support different ethernet ports

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -35,12 +35,54 @@ Check If Ping Fails
     ${result}  Run Process  ping  ${DEVICE_IP_ADDRESS}  -c1  timeout=1s
     Should Not Be Equal   ${result.rc}  ${0}
 
+Get Ethernet Interface By Type
+    [Documentation]    Returns ethernet interface filtered by usb or non-usb.
+    [Arguments]        ${usb}=True
+    IF    ${usb}
+        ${if_name}    Run Command    for i in /sys/class/net/*; do [ "$(cat "$i/type" 2>/dev/null)" = "1" ] || continue; path=$(readlink -f "$i"); echo "$path" | grep -q usb && basename "$i"; done | head -n 1
+    ELSE
+        ${if_name}    Run Command    for i in /sys/class/net/*; do [ "$(cat "$i/type" 2>/dev/null)" = "1" ] || continue; path=$(readlink -f "$i"); echo "$path" | grep -q usb || basename "$i"; done | head -n 1
+    END
+    ${if_name}    Strip String    ${if_name}
+    RETURN        ${if_name}
+
+Get First Interface By Nmcli Type
+    [Documentation]    Returns first interface by nmcli type (wifi/ethernet).
+    [Arguments]        ${type}
+    ${if_name}    Run Command    nmcli -t -f DEVICE,TYPE device status | awk -F: '$2=="${type}" {print $1; exit}'
+    ${if_name}    Strip String    ${if_name}
+    RETURN        ${if_name}
+
 Get Interface name
-    [Documentation]    Returns system interface name for given type using nmcli
-    ...                ${interface} must be either 'wifi' or 'eth'
+    [Documentation]    Returns system interface name for given type.
+    ...                Supported values for ${interface}: wifi, eth, native-eth, usb-eth
+    ...                For 'eth', USB ethernet is preferred. If no USB ethernet is found, any ethernet is returned.
     [Arguments]    ${interface}
-    ${if_name}     Run Command    nmcli device status | grep ${interface} | head -n 1 | awk '{print $1}'
-    RETURN         ${if_name}
+
+    IF    '${interface}' == 'wifi'
+        ${if_name}    Get First Interface By Nmcli Type    wifi
+
+    ELSE IF    '${interface}' == 'eth'
+        ${usb_eth}    Get Ethernet Interface By Type    usb=True
+
+        IF    '${usb_eth}' != ''
+            ${if_name}    Set Variable    ${usb_eth}
+        ELSE
+            ${if_name}    Get First Interface By Nmcli Type    ethernet
+        END
+
+    ELSE IF    '${interface}' == 'native-eth'
+        ${if_name}    Get Ethernet Interface By Type    usb=False
+
+    ELSE IF    '${interface}' == 'usb-eth'
+        ${if_name}    Get Ethernet Interface By Type    usb=True
+
+    ELSE
+        Fail    Unsupported interface type '${interface}'
+    END
+
+    Should Not Be Empty    ${if_name}    No interface found for type '${interface}'
+    RETURN    ${if_name}
 
 Check Network Availability
     [Documentation]    Checks ${host} availability using ping
@@ -291,6 +333,7 @@ Get VM IP
     [Arguments]   ${if_name}=eth
     ${output}     Run Command    ifconfig
     ${ip}         Get ip from ifconfig    ${output}   ${if_name}
+    Should Not Be Empty    ${ip}    Couldn't get IP for the interface ${if_name}
     RETURN        ${ip}
 
 Transfer Shell Script To DUT

--- a/Robot-Framework/test-suites/functional-tests/net-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/net-vm.robot
@@ -45,7 +45,7 @@ Wifi passthrough into NetVM
 
 Ethernet passthrough into NetVM
     [Documentation]     Verify that ethernet connection works inside netvm and internet is available
-    [Tags]              SP-T62  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  lab-only
+    [Tags]              SP-T62  SP-T62-1  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  lab-only
     [Setup]             Switch to vm   ${NET_VM}
     Check Network Availability   8.8.8.8   limit_freq=${False}   interface=eth
 
@@ -58,15 +58,31 @@ Verify NetVM PCI device passthrough
 Check net-vm hostname
     [Documentation]    Compare actual net-vm hostname with expected one from the config file,
     ...                It should never change.
-    [Tags]             SP-352  pre-merge  bat  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  orin-nx  lab-only
+    [Tags]             SP-352  SP-352-1  pre-merge  bat  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  orin-nx  lab-only
     Switch to vm       ${NET_VM}
     Log                Comparing actual net-vm hostname ${NETVM_NAME} and expected ${STATIC_NETVM_NAME}     console=True
     Should Be Equal As Strings   ${NETVM_NAME}    ${STATIC_NETVM_NAME}    ignore_case=True
     ...                          msg=Actual NetVM hostname != Expected
     [Teardown]         Run Keyword If Test Failed    Check net-vm hostname failure
 
+Verify native ethernet is present and in the same network as USB ethernet
+    [Documentation]    Verify that native ethernet exists, both interfaces have IPs,
+    ...                and belong to the same /24 subnet.
+    [Tags]             SP-T62  SP-T62-2  darter-pro  lab-only
+    ${usb_eth}         Get Interface name   usb-eth
+    ${usb_ip}          Get VM IP            ${usb_eth}
+    ${native_eth}      Get Interface name   native-eth
+    ${native_ip}       Get VM IP            ${native_eth}
+    Interfaces Should Be In Same Network    ${usb_ip}    ${native_ip}
 
 *** Keywords ***
+
+Interfaces Should Be In Same Network
+    [Documentation]    Verify that two interfaces are in the same /24 subnet.
+    [Arguments]        ${ip1}    ${ip2}
+    ${ip1_net}         Evaluate    ".".join("${ip1}".split(".")[:3])
+    ${ip2_net}         Evaluate    ".".join("${ip2}".split(".")[:3])
+    Should Be Equal    ${ip1_net}    ${ip2_net}
 
 Check net-vm hostname failure
     IF    "system76-darp11-b-storeDisk-debug-installer" in "${JOB}"

--- a/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
+++ b/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
@@ -35,7 +35,7 @@ Check device-id persistence over nixos-rebuild
 
 Check net-vm hostname persistence over nixos-rebuild
     [Documentation]         Verify that net-vm hostname has not changed over nixos-rebuild and reboot
-    [Tags]                  SP-T352
+    [Tags]                  SP-T352  SP-352-2
     [Timeout]               1 minutes
     IF  "${netvm_hostname_before}" != "${NETVM_NAME}"
         FAIL    Net-vm hostname has changed over nixos-rebuild and reboot


### PR DESCRIPTION
Added test for native ethernet on DarterPro targets, changed the way of getting interface, so now supports native eth and usb eth types (usb by default)
Regression tests results:
[Darter (two ethernet connected)](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5378/artifact/Robot-Framework/test-suites/darter-proANDregressionNOTsuspensionNOTupdateNOTinstaller-onlyNOTstoreDisk-only/log.html#s1-s1-s8-t5)
[LenovoX1 (one usb ethernet connected)](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5386/artifact/Robot-Framework/test-suites/lenovo-x1ANDregressionNOTsuspensionNOTupdateNOTinstaller-onlyNOTstoreDisk-onlyNOTsecboot-only/log.html)
[AGX (one usb ethernet connected)](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5387/artifact/Robot-Framework/test-suites/orin-agxANDregression/log.html)