### PR TITLE
Test givc policy update

### DIFF
--- a/Robot-Framework/resources/service_keywords.resource
+++ b/Robot-Framework/resources/service_keywords.resource
@@ -7,6 +7,18 @@ Resource            ../resources/ssh_keywords.resource
 
 
 *** Keywords ***
+
+Service should not be failed
+    [Arguments]    ${service}
+    ${result}    Run Command    systemctl show -p Result --value ${service}    rc_match=skip
+    ${state}    Run Command    systemctl show -p ActiveState --value ${service}    rc_match=skip
+    IF    'failed' in '${result}' or 'failed' in '${state}'
+        ${service_journalctl}=    Run Command    journalctl -b -u ${service} --no-pager -n 200    rc_match=skip
+        Log                       ${service_journalctl}
+    END
+    Should Not Contain    ${result}    failed
+    Should Not Contain    ${state}    failed
+
 Verify service status
     [Documentation]   Check if service is running with given loop ${range}
     [Arguments]       ${range}=45  ${service}=${EMPTY}   ${expected_state}=active   ${expected_substate}=running  ${expected_rc}=0

--- a/Robot-Framework/test-suites/security-tests/givc_policy.robot
+++ b/Robot-Framework/test-suites/security-tests/givc_policy.robot
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2022-2026 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Settings ***
+Documentation       Validate GIVC policy initialization and live policy update handling
+Test Tags           givc-policy  security  lenovo-x1  darter-pro  dell-7330
+
+Resource            ../../resources/common_keywords.resource
+Resource            ../../resources/ssh_keywords.resource
+
+Suite Setup         GIVC policy suite setup
+
+
+*** Variables ***
+${POLICY_BACKUP_DIR}    /tmp
+
+
+*** Test Cases ***
+
+GIVC policy init on boot in policy-enabled VMs
+    [Documentation]  Verify givc-policy-init exists and did not fail in VMs where policy client is enabled.
+    [Template]       Verify givc policy init in ${vm}
+    FOR    ${vm}    IN    @{VM_LIST_WITH_HOST}
+        ${vm}
+    END
+
+GIVC policy update triggers handler in policy-enabled VMs
+    [Documentation]  Modify an active policy file and verify its handler runs.
+    [Template]       Verify givc policy update handler in ${vm}
+    FOR    ${vm}    IN    @{VM_LIST_WITH_HOST}
+        ${vm}
+    END
+
+
+*** Keywords ***
+
+GIVC policy suite setup
+    @{VM_LIST_WITH_HOST}    Get VM list    with_host=True
+    Set Suite Variable      @{VM_LIST_WITH_HOST}
+
+Verify givc policy init in ${vm}
+    Switch to vm    ${vm}
+    ${rc}    Run Command    systemctl is-enabled givc-policy-init    return=rc    rc_match=skip
+    IF    ${rc}[0] != 0
+        SKIP    givc-policy-init not enabled in ${vm}
+    END
+    ${result}    Run Command    systemctl show -p Result --value givc-policy-init    rc_match=skip
+    ${state}     Run Command    systemctl show -p ActiveState --value givc-policy-init    rc_match=skip
+    Should Not Contain    ${result}    failed
+    Should Not Contain    ${state}     failed
+
+Verify givc policy update handler in ${vm}
+    Switch to vm    ${vm}
+    ${service}    ${path_unit}    ${policy_path}    Get GIVC policy handler details
+    IF    "${service}" == "${EMPTY}" or "${policy_path}" == "${EMPTY}"
+        SKIP    No givc policy handler detected in ${vm}
+    END
+
+    ${backup}    Set Variable    ${POLICY_BACKUP_DIR}/givc_policy_backup_${vm}
+    Run Command    cp ${policy_path} ${backup}    sudo=True
+
+    ${before}    Run Command    systemctl show -p ExecMainExitTimestampUSec --value ${service}    rc_match=skip
+    Run Command    sh -c "echo '# ci-test-automation policy update '$(date +%s)' ' | tee -a ${policy_path} >/dev/null"    sudo=True
+
+    Wait Until Keyword Succeeds    6x    5s    Policy handler should run    ${service}    ${before}
+
+    [Teardown]    Run Keywords
+    ...    Restore policy file    ${policy_path}    ${backup}    AND
+    ...    Run Command    rm -f ${backup}    sudo=True
+
+Policy handler should run
+    [Arguments]    ${service}    ${before}
+    ${after}    Run Command    systemctl show -p ExecMainExitTimestampUSec --value ${service}    rc_match=skip
+    ${before_is_empty}    Run Keyword And Return Status    Should Be True    '${before}' in ['','0','n/a','N/A']
+    IF    ${before_is_empty}
+        Should Not Be True    '${after}' in ['','0','n/a','N/A']
+    ELSE
+        Should Not Be Equal As Strings    ${after}    ${before}
+    END
+
+Get GIVC policy handler details
+    ${services_out}    Run Command    systemctl list-units --type=service 'givc-policy-*' --no-legend --no-pager --all    rc_match=skip
+    ${service}    Set Variable    ${EMPTY}
+    ${path_unit}  Set Variable    ${EMPTY}
+    ${policy_path}    Set Variable    ${EMPTY}
+
+    @{lines}    Split To Lines    ${services_out}
+    FOR    ${line}    IN    @{lines}
+        ${line}    Strip String    ${line}
+        IF    '${line}' == ''
+            CONTINUE
+        END
+        ${tokens}    Split String    ${line}
+        ${candidate_service}    Set Variable    ${tokens}[0]
+        ${candidate_path}    Replace String    ${candidate_service}    .service    .path
+        ${path_out}    Run Command    systemctl list-units --type=path ${candidate_path} --no-legend --no-pager --all    rc_match=skip
+        ${path_status}    Run Keyword And Return Status    Should Contain    ${path_out}    ${candidate_path}
+        IF    ${path_status}
+            ${path_value}    Run Command    systemctl show -p PathModified --value ${candidate_path}    rc_match=skip
+            IF    '${path_value}' != ''
+                ${service}    Set Variable    ${candidate_service}
+                ${path_unit}  Set Variable    ${candidate_path}
+                ${policy_path}    Set Variable    ${path_value}
+                EXIT FOR LOOP
+            END
+        END
+    END
+
+    RETURN    ${service}    ${path_unit}    ${policy_path}
+
+Restore policy file
+    [Arguments]    ${policy_path}    ${backup}
+    Run Command    cp ${backup} ${policy_path}    sudo=True

--- a/Robot-Framework/test-suites/security-tests/givc_policy.robot
+++ b/Robot-Framework/test-suites/security-tests/givc_policy.robot
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2022-2026 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Settings ***
+Documentation       Validate GIVC policy initialization, delivery integrity and firewall apply wiring
+Test Tags           givc-policy  lenovo-x1  darter-pro  dell-7330
+
+Resource            ../../resources/common_keywords.resource
+Resource            ../../resources/service_keywords.resource
+Resource            ../../resources/ssh_keywords.resource
+
+Suite Setup         GIVC policy suite setup
+
+
+*** Variables ***
+
+${POLICY_BACKUP_DIR}    /tmp
+
+
+*** Test Cases ***
+
+GIVC policy init on boot in policy-enabled VMs
+    [Documentation]  Verify givc-policy-init completed without known errors and created policy files.
+    [Tags]           SP-T365
+    FOR    ${vm}    IN    @{POLICY_CLIENT_VMS}
+        Verify givc policy init in ${vm}
+    END
+
+*** Keywords ***
+
+GIVC policy suite setup
+    @{VM_LIST_WITH_HOST}    Get VM list    with_host=True
+    @{POLICY_CLIENT_VMS}    Create List
+    FOR    ${vm}    IN    @{VM_LIST_WITH_HOST}
+        ${status}    ${message}    Run Keyword And Ignore Error    Switch to vm    ${vm}
+        IF    '${status}' != 'PASS'
+            Log To Console    Excluding inaccessible VM from GIVC tests: ${vm}
+            CONTINUE
+        END
+        ${status}    ${config_raw}    Run Keyword And Ignore Error    Run Command    cat /etc/givc-agent/config.json
+        IF    '${status}' != 'PASS'
+            Log To Console    Excluding VM without readable GIVC config from GIVC tests: ${vm}
+            CONTINUE
+        END
+        ${policy_cfg}    Evaluate    json.loads($config_raw).get("capabilities", {}).get("policy", {})    json
+        ${enabled}    Evaluate    bool($policy_cfg.get("enable"))
+        IF    not ${enabled}
+            CONTINUE
+        END
+        Append To List    ${POLICY_CLIENT_VMS}    ${vm}
+    END
+    List Should Contain Value    ${POLICY_CLIENT_VMS}    ${BUSINESS_VM}
+    List Should Contain Value    ${POLICY_CLIENT_VMS}    ${CHROME_VM}
+    Set Suite Variable      @{VM_LIST_WITH_HOST}
+    Set Suite Variable      @{POLICY_CLIENT_VMS}
+
+Get current VM policy config
+    ${config_raw}    Run Command    cat /etc/givc-agent/config.json
+    ${config}    Evaluate    json.loads($config_raw)    json
+    ${policy_cfg}    Evaluate    $config["capabilities"]["policy"]
+    RETURN    ${policy_cfg}
+
+Get configured policy destination
+    [Arguments]    ${policy_cfg}    ${policy_name}
+    ${policies}    Evaluate    $policy_cfg.get("policies", {})
+    ${has_policy}    Evaluate    $policy_name in $policies
+    IF    not ${has_policy}
+        FAIL    Policy ${policy_name} not configured in current VM
+    END
+    ${destination}    Evaluate    $policies[$policy_name]
+    RETURN    ${destination}
+
+Get stored policy path
+    [Arguments]    ${policy_cfg}    ${policy_name}
+    ${store_path}    Evaluate    $policy_cfg["storePath"]
+    RETURN    ${store_path}/${policy_name}/policy.bin
+
+Verify givc policy init in ${vm}
+    Switch to vm    ${vm}
+    ${policy_cfg}    Get current VM policy config
+
+    ${rc}    Run Command    systemctl is-enabled givc-policy-init    return=rc    rc_match=skip
+    IF    ${rc}[0] != 0
+        FAIL    givc-policy-init is not enabled in ${vm}
+    END
+
+    Service should not be failed    givc-policy-init
+    ${journal}    Run Command    journalctl -u givc-policy-init -b --no-pager    rc_match=skip
+    Should Not Contain    ${journal}    Error! file not found
+
+    ${policy_names}    Evaluate    list($policy_cfg.get("policies", {}).keys())
+    Should Not Be Empty    ${policy_names}
+    FOR    ${policy_name}    IN    @{policy_names}
+        ${destination}    Get configured policy destination    ${policy_cfg}    ${policy_name}
+        Run Command    test -f ${destination}
+        ${stored_path}    Get stored policy path    ${policy_cfg}    ${policy_name}
+        # Check stored_path == destination only if stored_path exists.
+        ${stored_rc}    Run Command    test -f ${stored_path}    return=rc    rc_match=skip
+        IF    ${stored_rc}[0] == 0
+            Stored policy file should match destination    ${stored_path}    ${destination}
+        END
+    END
+
+Stored policy file should match destination
+    [Arguments]    ${stored_path}    ${destination}
+    Run Command    test -f ${stored_path}
+    Run Command    test -f ${destination}
+    Run Command    cmp -s ${stored_path} ${destination}


### PR DESCRIPTION
Add a test case `GIVC policy init on boot in policy-enabled VMs`
It checks that givc-policy-init
- is enabled
- is not failed
- journal does not show missing-file error
- configured policy destination files exist
- if stored_path exists, it matches the destination

For now ghaf givc policy is not mature for further tests but in the future more related test cases could be added as it develops.

Darter-Pro
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6743/

Lenovo-X1
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6744/