### PR TITLE
Tools for monitoring mem consumption

### DIFF
--- a/Robot-Framework/lib/MemRecordingProcessing.py
+++ b/Robot-Framework/lib/MemRecordingProcessing.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2022-2026 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import pandas
+import logging
+from robot.api.deco import keyword
+from memory_plotting import add_percentage_columns, plot_grouped_metric, plot_grouped_metric_pair
+
+
+class MemRecordingProcessing:
+    """
+    Utilities for merging per-VM memory recordings and plotting them.
+
+    Input CSVs are expected to have the format:
+      datetime,mem_total_kb,mem_avail_kb,swap_total_kb,swap_free_kb
+    """
+
+    def __init__(self, out_dir, plot_dir):
+        self.out_dir = out_dir
+        self.plot_dir = plot_dir
+        os.makedirs(self.out_dir, exist_ok=True)
+        os.makedirs(self.plot_dir, exist_ok=True)
+
+    @keyword("Merge Mem Recordings And Plot")
+    def merge_mem_recordings_and_plot(self, input_files, output_basename):
+        """
+        Merge per-VM recordings into one CSV and generate a plot.
+
+        Args:
+          input_files: Robot list of file paths (local) like [".../admin-vm.csv", ".../chrome-vm.csv"].
+                       The VM name is taken from the filename stem after the last "__".
+          output_basename: File base name (without extension) for outputs.
+
+        Outputs:
+          - <out_dir>/<output_basename>.csv
+          - <plot_dir>/<output_basename>.png
+        """
+        if not input_files:
+            raise AssertionError("No input mem recording files to merge")
+
+        frames = []
+        for path in input_files:
+            path = str(path)
+            if not os.path.exists(path):
+                raise AssertionError(f"Mem recording file not found: {path}")
+
+            vm = os.path.splitext(os.path.basename(path))[0]
+            # Common naming is "memrec__<id>__<vm>.csv" but keep fallback.
+            if "__" in vm:
+                vm = vm.split("__")[-1]
+
+            df = pandas.read_csv(path)
+            required = {"datetime", "mem_total_kb", "mem_avail_kb", "swap_total_kb", "swap_free_kb"}
+            missing = required - set(df.columns)
+            if missing:
+                raise AssertionError(f"{path} missing columns: {sorted(missing)}")
+
+            df["vm"] = vm
+            frames.append(df)
+
+        plot_df = self._prepare_plot_df(pandas.concat(frames, ignore_index=True))
+
+        out_csv = os.path.join(self.out_dir, f"{output_basename}.csv")
+        plot_df.drop(columns=["datetime_dt"]).to_csv(out_csv, index=False)
+        logging.info("Wrote merged mem recording to %s", out_csv)
+
+        self._plot(plot_df, os.path.join(self.plot_dir, output_basename))
+        for path in input_files:
+            path = str(path)
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                logging.warning("Mem recording file already removed: %s", path)
+            except OSError as exc:
+                logging.warning("Failed to remove mem recording file %s: %s", path, exc)
+        return out_csv
+
+    def _add_usage_columns(self, df):
+        df["mem_avail_mib"] = pandas.to_numeric(df["mem_avail_kb"], errors="coerce") / 1024.0
+        df["mem_total_mib"] = pandas.to_numeric(df["mem_total_kb"], errors="coerce") / 1024.0
+        df["swap_free_mib"] = pandas.to_numeric(df["swap_free_kb"], errors="coerce") / 1024.0
+        df["swap_total_mib"] = pandas.to_numeric(df["swap_total_kb"], errors="coerce") / 1024.0
+        add_percentage_columns(
+            df,
+            [
+                ("mem_avail_mib", "mem_total_mib", "mem_avail_pct"),
+                ("swap_free_mib", "swap_total_mib", "swap_free_pct"),
+            ],
+        )
+
+    def _prepare_plot_df(self, df):
+        plot_df = df.copy()
+        plot_df["datetime_dt"] = pandas.to_datetime(plot_df["datetime"], errors="coerce")
+        invalid_datetime_rows = int(plot_df["datetime_dt"].isna().sum())
+        if invalid_datetime_rows:
+            logging.warning(
+                "Dropping %d mem recording row(s) with invalid datetime values",
+                invalid_datetime_rows,
+            )
+        plot_df = plot_df.dropna(subset=["datetime_dt"])
+        plot_df["datetime"] = plot_df["datetime_dt"].dt.strftime("%Y-%m-%d %H:%M:%S")
+        self._add_usage_columns(plot_df)
+        return plot_df
+
+    def _plot(self, df, out_base):
+        pair_plots = [
+            ("mem_avail_mib", "mem_total_mib", "mem_avail", "Mem Available/Total (MiB)", "avail"),
+            ("swap_free_mib", "swap_total_mib", "swap_free", "Swap Free/Total (MiB)", "free"),
+        ]
+        for value_col, total_col, file_suffix, title, value_label in pair_plots:
+            plot_grouped_metric_pair(
+                df,
+                "datetime_dt",
+                value_col,
+                total_col,
+                f"{out_base}__{file_suffix}.png",
+                title,
+                "Time",
+                value_label=value_label,
+            )
+
+        pct_plots = [
+            ("mem_avail_pct", "mem_avail_pct", "Mem Available (%)"),
+            ("swap_free_pct", "swap_free_pct", "Swap Free (%)"),
+        ]
+        for value_col, file_suffix, title in pct_plots:
+            plot_grouped_metric(
+                df,
+                "datetime_dt",
+                value_col,
+                f"{out_base}__{file_suffix}.png",
+                title,
+                "Time",
+                y_limits=(0, 100),
+            )

--- a/Robot-Framework/lib/PerformanceDataProcessing.py
+++ b/Robot-Framework/lib/PerformanceDataProcessing.py
@@ -10,6 +10,12 @@ import matplotlib.pyplot as plt
 import logging
 from robot.api.deco import keyword
 from performance_thresholds import *
+from memory_plotting import (
+    add_percentage_columns,
+    build_unique_labels,
+    plot_grouped_metric,
+    plot_grouped_metric_pair,
+)
 
 
 class PerformanceDataProcessing:
@@ -944,6 +950,146 @@ class PerformanceDataProcessing:
     def save_app_launch_time_data(self, test_name, data):
         self.write_test_data_to_csv(test_name, data)
         return self.read_applaunch_csv_and_plot(test_name)
+
+    @keyword("Save VM Memory Snapshot Data")
+    def save_vm_memory_snapshot_data(self, test_name, vm_mem_data):
+        """
+        Save a snapshot of per-VM memory usage for the current build and plot it across builds.
+
+        Expected input keys:
+          - mem_avail_mib__<vmname>: available memory in MiB
+          - mem_total_mib__<vmname>: total memory in MiB
+          - swap_free_mib__<vmname>: free swap in MiB
+          - swap_total_mib__<vmname>: total swap in MiB
+        """
+        file_path = os.path.join(self.data_dir, f"{self.device}_{test_name}.csv")
+        commit_id = self.build_number + "-" + self.commit
+
+        # Keep columns stable across builds, but allow the set of VMs to grow.
+        row = {"commit": commit_id, "device": self.device} | dict(vm_mem_data)
+        if os.path.exists(file_path):
+            df = pandas.read_csv(file_path)
+            for col in row.keys():
+                if col not in df.columns:
+                    df[col] = pandas.NA
+            for col in df.columns:
+                if col not in row:
+                    row[col] = pandas.NA
+            df = pandas.concat([df, pandas.DataFrame([row], columns=df.columns)], ignore_index=True)
+        else:
+            df = pandas.DataFrame([row])
+
+        df.to_csv(file_path, index=False)
+        self._plot_vm_memory_snapshot(test_name, df)
+        return
+
+    def _plot_vm_memory_snapshot(self, test_name, df):
+        plot_limit = 40
+        if len(df.index) > plot_limit:
+            df = df.tail(plot_limit)
+
+        build_df = df.copy()
+        build_df["build_index"] = list(range(len(build_df.index)))
+        x_labels = build_unique_labels(build_df["commit"].tolist())
+        plot_df = self._normalize_vm_memory_snapshot_df(build_df)
+        if plot_df.empty:
+            logging.warning("No VM memory snapshot data to plot for %s", test_name)
+            return
+
+        title_suffix = f"\nBuild type: {self.build_type}, Device: {self.device}"
+        plot_grouped_metric_pair(
+            plot_df,
+            "build_index",
+            "mem_avail_mib",
+            "mem_total_mib",
+            self.plot_dir + f"{self.device}_{test_name}__mem_avail.png",
+            f"{test_name} - Mem Available/Total (MiB){title_suffix}",
+            "Build Number",
+            group_col="vm",
+            value_label="avail",
+            sort_col=None,
+            x_labels=x_labels,
+            x_time_format=None,
+        )
+        plot_grouped_metric_pair(
+            plot_df,
+            "build_index",
+            "swap_free_mib",
+            "swap_total_mib",
+            self.plot_dir + f"{self.device}_{test_name}__swap_free.png",
+            f"{test_name} - Swap Free/Total (MiB){title_suffix}",
+            "Build Number",
+            group_col="vm",
+            value_label="free",
+            sort_col=None,
+            x_labels=x_labels,
+            x_time_format=None,
+        )
+        plot_grouped_metric(
+            plot_df,
+            "build_index",
+            "mem_avail_pct",
+            self.plot_dir + f"{self.device}_{test_name}__mem_avail_pct.png",
+            f"{test_name} - Mem Available (%){title_suffix}",
+            "Build Number",
+            group_col="vm",
+            sort_col=None,
+            x_labels=x_labels,
+            x_time_format=None,
+            y_limits=(0, 100),
+        )
+        plot_grouped_metric(
+            plot_df,
+            "build_index",
+            "swap_free_pct",
+            self.plot_dir + f"{self.device}_{test_name}__swap_free_pct.png",
+            f"{test_name} - Swap Free (%){title_suffix}",
+            "Build Number",
+            group_col="vm",
+            sort_col=None,
+            x_labels=x_labels,
+            x_time_format=None,
+            y_limits=(0, 100),
+        )
+        return
+
+    def _normalize_vm_memory_snapshot_df(self, df):
+        rows = []
+        avail_cols = [col for col in df.columns if col.startswith("mem_avail_mib__")]
+        for _, row in df.iterrows():
+            commit = row["commit"]
+            build_index = row["build_index"]
+            for avail_col in avail_cols:
+                vm = avail_col.split("__", 1)[1]
+                mem_total_col = f"mem_total_mib__{vm}"
+                swap_free_col = f"swap_free_mib__{vm}"
+                swap_total_col = f"swap_total_mib__{vm}"
+                if mem_total_col not in df.columns:
+                    continue
+                rows.append(
+                    {
+                        "commit": commit,
+                        "build_index": build_index,
+                        "vm": vm,
+                        "mem_avail_mib": row.get(avail_col, pandas.NA),
+                        "mem_total_mib": row.get(mem_total_col, pandas.NA),
+                        "swap_free_mib": row.get(swap_free_col, pandas.NA),
+                        "swap_total_mib": row.get(swap_total_col, pandas.NA),
+                    }
+                )
+
+        if not rows:
+            return pandas.DataFrame()
+
+        plot_df = pandas.DataFrame(rows)
+        add_percentage_columns(
+            plot_df,
+            [
+                ("mem_avail_mib", "mem_total_mib", "mem_avail_pct"),
+                ("swap_free_mib", "swap_total_mib", "swap_free_pct"),
+            ],
+        )
+        return plot_df
 
 
     # ---------------------------------------------------------------------

--- a/Robot-Framework/lib/memory_plotting.py
+++ b/Robot-Framework/lib/memory_plotting.py
@@ -1,0 +1,162 @@
+import logging
+from itertools import cycle
+
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import pandas
+
+
+PLOT_FIGSIZE = (20, 10)
+PLOT_LINEWIDTH = 2.5
+
+
+def configure_time_axis(fig, ax, x_time_format):
+    if x_time_format is None:
+        return
+    # Treat the x-axis as dates
+    ax.xaxis.set_major_locator(mdates.AutoDateLocator())
+    ax.xaxis.set_major_formatter(mdates.DateFormatter(x_time_format))
+    fig.autofmt_xdate()
+
+
+# Calculate relative available memory
+def add_percentage_columns(df, column_specs):
+    for numerator_col, denominator_col, pct_col in column_specs:
+        numerator = pandas.to_numeric(df[numerator_col], errors="coerce")
+        denominator = pandas.to_numeric(df[denominator_col], errors="coerce")
+        pct = (numerator / denominator) * 100.0
+        df[pct_col] = pct.where(denominator > 0)
+
+
+# Add indices if there are identical values
+def build_unique_labels(values):
+    counters = {}
+    labels = []
+    for value in [str(item) for item in values]:
+        counters[value] = counters.get(value, -1) + 1
+        if counters[value] > 0:
+            labels.append(f"{value}-{counters[value]}")
+        else:
+            labels.append(value)
+    return labels
+
+
+# Plot data as one-series-per-group
+def plot_grouped_metric(
+    df,
+    x_col,
+    y_col,
+    out_path,
+    title,
+    xlabel,
+    group_col="vm",
+    ylabel="%",
+    sort_col="datetime_dt",
+    x_labels=None,
+    x_time_format="%H:%M:%S",
+    y_limits=None,
+    legend_loc="upper left",
+    marker="o",
+):
+    fig, ax = plt.subplots(figsize=PLOT_FIGSIZE)
+    plt.set_loglevel("WARNING")
+
+    for group_name, group_df in df.groupby(group_col):
+        if sort_col:
+            group_df = group_df.sort_values(sort_col)
+        y_values = pandas.to_numeric(group_df[y_col], errors="coerce")
+        if y_values.isna().all():
+            continue
+        ax.plot(
+            group_df[x_col],
+            y_values,
+            marker=marker,
+            linestyle="-",
+            label=group_name,
+            linewidth=PLOT_LINEWIDTH,
+        )
+
+    ax.set_title(title, fontsize=18, fontweight="bold")
+    ax.set_xlabel(xlabel, fontsize=16)
+    ax.set_ylabel(ylabel, fontsize=16)
+    ax.grid(True)
+    if y_limits:
+        ax.set_ylim(*y_limits)
+    configure_time_axis(fig, ax, x_time_format)
+    if x_labels is not None:
+        ax.set_xticks(sorted(df[x_col].dropna().unique().tolist()))
+        ax.set_xticklabels(x_labels, rotation=90, fontsize=10)
+    ax.legend(loc=legend_loc)
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+    logging.info("Wrote plot to %s", out_path)
+
+
+# Plot data as two-series-per-group
+def plot_grouped_metric_pair(
+    df,
+    x_col,
+    value_col,
+    total_col,
+    out_path,
+    title,
+    xlabel,
+    group_col="vm",
+    ylabel="MiB",
+    value_label="value",
+    total_label="total",
+    sort_col="datetime_dt",
+    x_labels=None,
+    x_time_format="%H:%M:%S",
+    legend_loc="upper left",
+    value_marker="o",
+    total_marker="s",
+):
+    fig, ax = plt.subplots(figsize=PLOT_FIGSIZE)
+    plt.set_loglevel("WARNING")
+    color_cycle = cycle(plt.rcParams["axes.prop_cycle"].by_key()["color"])
+
+    for group_name, group_df in df.groupby(group_col):
+        if sort_col:
+            group_df = group_df.sort_values(sort_col)
+        values = pandas.to_numeric(group_df[value_col], errors="coerce")
+        totals = pandas.to_numeric(group_df[total_col], errors="coerce")
+        if values.isna().all() and totals.isna().all():
+            continue
+
+        color = next(color_cycle)
+        if not totals.isna().all():
+            ax.plot(
+                group_df[x_col],
+                totals,
+                marker=total_marker,
+                linestyle=":",
+                label=f"{group_name} ({total_label})",
+                linewidth=PLOT_LINEWIDTH,
+                color=color,
+            )
+        if not values.isna().all():
+            ax.plot(
+                group_df[x_col],
+                values,
+                marker=value_marker,
+                linestyle="-",
+                label=f"{group_name} ({value_label})",
+                linewidth=PLOT_LINEWIDTH,
+                color=color,
+            )
+
+    ax.set_title(title, fontsize=18, fontweight="bold")
+    ax.set_xlabel(xlabel, fontsize=16)
+    ax.set_ylabel(ylabel, fontsize=16)
+    ax.grid(True)
+    configure_time_axis(fig, ax, x_time_format)
+    if x_labels is not None:
+        ax.set_xticks(sorted(df[x_col].dropna().unique().tolist()))
+        ax.set_xticklabels(x_labels, rotation=90, fontsize=10)
+    ax.legend(loc=legend_loc)
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+    logging.info("Wrote plot to %s", out_path)

--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -92,10 +92,23 @@ Save Time
     Set Suite Variable    ${TIME_${label}}    ${time}
 
 Wait
-    [Arguments]     ${sec}
-    ${time}         Get Time
-    Log             ${time}: waiting for ${sec} sec  console=True
-    Sleep           ${sec}
+    [Arguments]       ${sec}  ${silently}=${True}  ${log_interval}=5
+    ${time}           Get Time
+    Log               ${time}: waiting for ${sec} sec    console=True
+    IF  ${silently}
+        Sleep         ${sec}
+    ELSE
+        ${steps}        Evaluate    int(${sec}) // ${log_interval}
+        ${remainder}    Evaluate    float(${sec}) % float(${log_interval})
+        FOR    ${i}    IN RANGE    ${steps}
+            Sleep           ${log_interval}
+            ${elapsed_s}    Evaluate    (${i} + 1) * ${log_interval}
+            Log             ${elapsed_s}    console=True
+        END
+        IF  ${remainder} > 0
+            Sleep    ${remainder}
+        END
+    END
 
 Search nix store
     [Documentation]      Search a file containing string argument in the target nix store.

--- a/Robot-Framework/resources/measurement_keywords.resource
+++ b/Robot-Framework/resources/measurement_keywords.resource
@@ -166,7 +166,7 @@ Plot parameter log
     [Arguments]                  ${vm}  ${param_label}  ${param_unit}  ${script}=log_params  ${divider}=1
     Switch to vm                 ${vm}
     Kill process by name         ${script}   True   ${False}
-    SSHLibrary.Get file          /tmp/${script}.csv   ${LOGGED_PARAMS_DIR}/${script}.csv
+    SSHLibrary.Get file          /tmp/${script}.csv   ${LOGGED_PARAMS_DIR}${script}.csv
     ${end_timestamp}             Get current timestamp
     Save measurement interval    ${script}.csv  '${${script}_log_start}'  '${end_timestamp}'  ${script}_interval.csv  ${False}  ${divider}
     IF  ${DATA_PROCESS_ERROR}

--- a/Robot-Framework/resources/mem_recording_keywords.resource
+++ b/Robot-Framework/resources/mem_recording_keywords.resource
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: 2022-2026 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Settings ***
+Library             OperatingSystem
+Library             Collections
+Library             ../lib/MemRecordingProcessing.py    ${LOGGED_PARAMS_DIR}mem_recordings/    ${PLOT_DIR}
+Resource            ../config/variables.robot
+Resource            ../resources/common_keywords.resource
+Resource            ../resources/ssh_keywords.resource
+
+
+*** Variables ***
+
+${MEMREC_SCRIPT_DIR}    /tmp/mem-recordings
+${SCRIPT_NAME}          mem_recording_loop.sh
+${SCRIPT_PATH}          ${MEMREC_SCRIPT_DIR}/${SCRIPT_NAME}
+${MEMREC_DIR}           ${EMPTY}
+
+*** Keywords ***
+
+Start memory recording in vm internals
+    [Arguments]       ${vm}    ${id}    ${memrec_sudo}    ${interval_s}=10    ${timeout_s}=60
+    Switch to vm      ${vm}
+    ${csv}            Set Variable    ${MEMREC_DIR}/memrec__${id}__${vm}.csv
+
+    Run Command    mkdir -p ${MEMREC_DIR}           sudo=${memrec_sudo}
+    Run Command    mkdir -p ${MEMREC_SCRIPT_DIR}
+    Put File       ../test-files/${SCRIPT_NAME}     ${MEMREC_SCRIPT_DIR}
+    Run Command    chmod 755 ${SCRIPT_PATH}         sudo=${memrec_sudo}
+
+    # Log the local time for debugging potential timesync problems
+    ${vm_date}     Run Command    date '+%Y-%m-%d %H:%M:%S %z %Z'
+    Log            Current date in ${vm}: ${vm_date}    console=True
+
+    Run Command    sh -c 'nohup ${SCRIPT_PATH} ${csv} ${interval_s} ${timeout_s} > /dev/null 2>&1 &'    sudo=${memrec_sudo}
+    Log    Started mem recording in ${vm}: ${csv}    console=True
+
+Start memory recording in vm
+    [Arguments]       ${vm}    ${memrec_sudo}=False    ${id}=${TEST NAME}    ${interval_s}=10    ${timeout_s}=60    ${memrec_dir}=${MEMREC_SCRIPT_DIR}
+    ${id_safe}        Replace String    ${id}    ${SPACE}    _
+    Set Suite Variable    ${MEMREC_ID}    ${id_safe}
+    Set Suite Variable    ${MEMREC_DIR}    ${memrec_dir}
+    @{single_vm}      Create List    ${vm}
+    Set Suite Variable    @{MEMREC_VMS}    @{single_vm}
+    Start memory recording in vm internals    ${vm}    ${id_safe}    ${memrec_sudo}    ${interval_s}    ${timeout_s}
+
+Start memory recording in all VMs
+    [Arguments]    ${memrec_sudo}=False    ${id}=${TEST NAME}    ${interval_s}=10    ${timeout_s}=60    ${with_host}=True    ${memrec_dir}=${MEMREC_SCRIPT_DIR}
+    Set Suite Variable    ${MEMREC_ID}    ${EMPTY}
+    Set Suite Variable    @{MEMREC_VMS}   @{EMPTY}
+    Set Suite Variable   ${MEMREC_DIR}   ${memrec_dir}
+    @{vms}    Get VM list    with_host=${with_host}
+    ${id_safe}    Replace String    ${id}    ${SPACE}    _
+    Set Suite Variable    ${MEMREC_ID}    ${id_safe}
+
+    FOR    ${vm}    IN    @{vms}
+        ${ok}    Run Keyword And Return Status    Start memory recording in vm internals    ${vm}    ${id_safe}    ${memrec_sudo}    ${interval_s}    ${timeout_s}
+        IF    ${ok}
+            Append To List    ${MEMREC_VMS}    ${vm}
+        ELSE
+            Log    Failed to start mem recording in ${vm}; skipping for stop/collect    console=True
+        END
+    END
+    IF    ${MEMREC_VMS} == []
+        Log    No VMs started mem recording    console=True
+    END
+
+Stop memory recording and collect
+    [Arguments]    ${memrec_sudo}
+    ${id}    Get Variable Value    ${MEMREC_ID}    ${EMPTY}
+    @{memrec_vms}    Get Variable Value    @{MEMREC_VMS}    @{EMPTY}
+    ${has_id}    Run Keyword And Return Status    Should Not Be Empty    ${id}
+    IF    not ${has_id}
+        Log To Console    No mem recording id set. Cannot collect results.
+        RETURN
+    END
+    IF  $MEMREC_DIR == '${EMPTY}'
+        Log To Console    No mem recording output directory set. Cannot collect results.
+        RETURN
+    END
+    IF    ${memrec_vms} == []
+        Log To Console    No mem recording VM list set. Cannot collect results.
+        RETURN
+    END
+
+    ${out_dir}    Set Variable    ${LOGGED_PARAMS_DIR}mem_recordings
+    OperatingSystem.Create Directory    ${out_dir}
+    ${local_files}    Create List
+
+    FOR    ${vm}    IN    @{memrec_vms}
+        Switch to vm    ${vm}
+        ${csv}        Set Variable    ${MEMREC_DIR}/memrec__${id}__${vm}.csv
+        ${tmp_csv}    Set Variable    /tmp/memrec__${id}__${vm}.csv
+
+        Kill process by name    ${SCRIPT_PATH}    ${memrec_sudo}    ${False}
+
+        # Copy per-VM recording to local for merging.
+        ${local_path}  Set Variable    ${out_dir}/memrec__${id}__${vm}.csv
+        Run Command    cp ${csv} ${tmp_csv}    sudo=${memrec_sudo}
+        Run Command    chmod 644 ${tmp_csv}    sudo=${memrec_sudo}
+        Run Keyword And Ignore Error    SSHLibrary.Get File    ${tmp_csv}    ${local_path}
+        Run Command    rm -f ${tmp_csv}    sudo=${memrec_sudo}
+        Run Command    rm -f ${csv}    sudo=${memrec_sudo}
+        Run Command    rm -f ${SCRIPT_PATH}
+        ${exists}    Run Keyword And Return Status    OperatingSystem.File Should Exist    ${local_path}
+        IF    ${exists}
+            Append To List    ${local_files}    ${local_path}
+        ELSE
+            Log    Mem recording missing for ${vm} (${csv})    console=True
+        END
+    END
+
+    IF    ${local_files} == []
+        Log    No mem recordings collected; skipping merge/plot    console=True
+        RETURN
+    END
+
+    ${base}    Set Variable    ${BUILD_ID}__mem_recording__${DEVICE}__${id}
+    ${csv_out}    Merge Mem Recordings And Plot    ${local_files}    ${base}
+    Log    <img src="${REL_PLOT_DIR}${base}__mem_avail.png" alt="MemAvailable Plot" width="1200">    HTML
+    Log    <img src="${REL_PLOT_DIR}${base}__swap_free.png" alt="SwapFree Plot" width="1200">    HTML
+    Log    <img src="${REL_PLOT_DIR}${base}__mem_avail_pct.png" alt="Mem Available (%) Plot" width="1200">    HTML
+    Log    <img src="${REL_PLOT_DIR}${base}__swap_free_pct.png" alt="Swap Free (%) Plot" width="1200">    HTML
+    Log    Merged mem recording saved: ${csv_out}    console=True

--- a/Robot-Framework/test-files/mem_recording_loop.sh
+++ b/Robot-Framework/test-files/mem_recording_loop.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2022-2026 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+# Record memory and swap snapshots to a CSV file at given interval.
+#
+# Arguments:
+#   $1: output CSV path
+#   $2: sampling interval in seconds
+#   $3: timeout in seconds
+
+set -eu
+
+csv_path="$1"
+interval_s="$2"
+timeout_s="$3"
+start_epoch_s="$(date +%s)"
+
+printf "%s\n" "datetime,mem_total_kb,mem_avail_kb,swap_total_kb,swap_free_kb" > "$csv_path"
+
+while true; do
+    current_epoch_s="$(date +%s)"
+    elapsed_s=$((current_epoch_s - start_epoch_s))
+    if [ "$elapsed_s" -gt "$timeout_s" ]; then
+        break
+    fi
+
+    timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+    awk -v ts="$timestamp" '
+        /MemTotal:/     { mem_total_kb = $2 }
+        /MemAvailable:/ { mem_avail_kb = $2 }
+        /SwapTotal:/    { swap_total_kb = $2 }
+        /SwapFree:/     { swap_free_kb = $2 }
+        END {
+            printf "%s,%s,%s,%s,%s\n",
+                ts, mem_total_kb, mem_avail_kb, swap_total_kb, swap_free_kb
+        }
+    ' /proc/meminfo >> "$csv_path"
+    sleep "$interval_s"
+done

--- a/Robot-Framework/test-suites/functional-tests/vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/vm.robot
@@ -96,7 +96,6 @@ Check Device ID in every VM
     END
     IF  ${failed_vms} != []    FAIL    VMs with different Device IDs: ${failed_vms}
 
-
 *** Keywords ***
 
 Check systemctl status Template

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -15,6 +15,7 @@ Resource            ../../resources/serial_keywords.resource
 Resource            ../../resources/setup_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/measurement_keywords.resource
+Resource            ../../resources/mem_recording_keywords.resource
 
 Suite Setup         Switch to vm   ${HOST}
 
@@ -25,6 +26,57 @@ Suite Setup         Switch to vm   ${HOST}
 
 
 *** Test Cases ***
+
+Record memory usage test
+    [Documentation]      This test demonstrates usage of the memory recording keywords.
+    ...                  Records memory usage across all vms over wait_time_s.
+    [Tags]               log_mem
+    ${wait_time_s}             Set Variable    120
+    ${recording_interval_s}    Set Variable    5
+    ${recording_timeout_s}     Evaluate        ${wait_time_s} + 120
+    Start memory recording in all VMs    memrec_sudo=False    interval_s=${recording_interval_s}    timeout_s=${recording_timeout_s}    memrec_dir=/tmp/mem-recordings
+    Wait          ${wait_time_s}  silently=${False}
+    [Teardown]    Stop memory recording and collect    memrec_sudo=False
+
+VM memory usage snapshot
+    [Documentation]    Log current memory usage (available/total) and swap usage (free/total) in every VM and ghaf-host and plot it across builds.
+    [Tags]             SP-T360  memory_usage  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  orin-nx
+    ${low_mem_limit}  Set Variable    5.0
+    @{vms}         Get VM list    with_host=True
+    &{mem_data}    Create Dictionary
+    ${failed_mem_vms}    Create List
+    FOR    ${vm}    IN    @{vms}
+        Switch to vm    ${vm}
+        ${out}    Run Command
+        ...    awk '/MemTotal:/ {mt=$2} /MemAvailable:/ {ma=$2} /SwapTotal:/ {st=$2} /SwapFree:/ {sf=$2} END {if (mt>0 && ma>=0) printf("%d %d ", int(ma/1024), int(mt/1024)); else printf("0 0 "); if (st>0 && sf>=0) printf("%d %d", int(sf/1024), int(st/1024)); else print "0 0"}' /proc/meminfo
+        @{vals}    Split String    ${out}
+        ${mem_avail_mib}     Set Variable    ${vals}[0]
+        ${mem_total_mib}     Set Variable    ${vals}[1]
+        ${swap_free_mib}     Set Variable    ${vals}[2]
+        ${swap_total_mib}    Set Variable    ${vals}[3]
+        ${mem_avail_pct}     Evaluate    (float($mem_avail_mib) / float($mem_total_mib)) * 100 if float($mem_total_mib) > 0 else 0
+        ${pct_str}           Evaluate    f"{float($mem_avail_pct):.2f}%"
+        IF    ${mem_avail_pct} < ${low_mem_limit}
+            Append To List   ${failed_mem_vms}    ${vm}: ${pct_str}
+            ${red_msg}       Evaluate  "\\033[31m${vm} available memory is below 5% of the total memory\\033[0m"
+            Log              ${red_msg}    console=True
+        END
+        Log    Memory in ${vm}: avail ${mem_avail_mib}/${mem_total_mib} MiB, swap free ${swap_free_mib}/${swap_total_mib} MiB    console=True
+        Set To Dictionary    ${mem_data}    mem_avail_mib__${vm}=${mem_avail_mib}
+        Set To Dictionary    ${mem_data}    mem_total_mib__${vm}=${mem_total_mib}
+        Set To Dictionary    ${mem_data}    swap_free_mib__${vm}=${swap_free_mib}
+        Set To Dictionary    ${mem_data}    swap_total_mib__${vm}=${swap_total_mib}
+    END
+
+    Save VM Memory Snapshot Data    ${TEST NAME}    ${mem_data}
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}__mem_avail.png" alt="VM Mem Available (MiB) Plot" width="1200">    HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}__swap_free.png" alt="VM Swap Free (MiB) Plot" width="1200">    HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}__mem_avail_pct.png" alt="VM Mem Available (%) Plot" width="1200">    HTML
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}__swap_free_pct.png" alt="VM Swap Free (%) Plot" width="1200">    HTML
+    ${failed_count}    Get Length    ${failed_mem_vms}
+    IF    ${failed_count} > 0
+        FAIL    VMs with available memory < ${low_mem_limit}%: ${failed_mem_vms}
+    END
 
 nvpmodel check test
     [Documentation]     If power mode changed it would probably have an effect on performance test results.


### PR DESCRIPTION
**Add test case for checking memory usage status of all vms and ghaf-host**
- For now I just set universal 5% pass limit for available memory for all vms. This should allow all vms to pass on all targets. (Well Dell ghaf-host barely passes.) After we have gathered some data I will make another PR for adding customized vm/target specific pass limits for this test.

**Add tooling for recording and plotting memory usage status from all vms and ghaf-host**
Keywords of Robot-Framework/resources/mem_recording_keywords.resource can be used for debugging memory over any test case:
```
Start memory recording in all VMs
Start memory recording in vm
Stop memory recording and collect
```
To demonstrate these created a demo test case `Record memory usage test` into performance.robot without adding it to any target. 

Note: Memory recording keywords have also ability to write memory records with sudo. This can enable recording memory status just before shutdown (e.g. writing to /guestStore) and reading the results after boot.

**Test runs:**

Orin AGX
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5546/

Orin NX
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5561/

Dell
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5549/

Darter-Pro
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5557/

Lenovo-X1
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5558/