### PR TITLE
Recover after logging failure

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -309,13 +309,14 @@ Transfer Shell Script To VM
     Transfer Shell Script To DUT    performance-tests   ${script_name}   /tmp
 
 Elevate to superuser
+    [Arguments]    ${sleep}=0.5
     SSHLibrary.Read
     Write                 sudo su
-    Sleep                 0.5
+    Sleep                 ${sleep}
     ${out}                SSHLibrary.Read
     IF  'password for ${LOGIN}' in $out
         ${out}            Write        ${PASSWORD}
-        Sleep             0.5
+        Sleep             ${sleep}
         ${out}            SSHLibrary.Read
     END
     IF  'root@' in $out

--- a/Robot-Framework/test-suites/update-tests/__init__.robot
+++ b/Robot-Framework/test-suites/update-tests/__init__.robot
@@ -5,14 +5,18 @@
 Documentation       Update tests
 Test Tags           regression  update  lenovo-x1  darter-pro  excl-storeDisk  excl-secboot
 
-Library             SSHLibrary
-Resource            ../../config/variables.robot
+Resource            ../../resources/setup_keywords.resource
 
 Suite Setup         Update tests setup
-Suite Teardown      Close All Connections
+Suite Teardown      Update tests teardown
 
 
 *** Keywords ***
 
 Update tests setup
-    Set Variables   ${DEVICE}
+    [Timeout]    5 minutes
+    Prepare Test Environment
+
+Update tests teardown
+    [Timeout]    5 minutes
+    Clean Up Test Environment

--- a/Robot-Framework/test-suites/update-tests/update-tests.robot
+++ b/Robot-Framework/test-suites/update-tests/update-tests.robot
@@ -12,6 +12,7 @@ Resource            ../../resources/setup_keywords.resource
 Resource            ../../resources/update_keywords.resource
 
 Test Teardown       Roll back to original generation
+Suite Teardown      Update Teardown
 Test Timeout        15 minutes
 
 
@@ -31,6 +32,27 @@ Update via givc-cli
 
 
 *** Keywords ***
+
+Update Teardown
+    # The update can leave log forwarding stuck, verify that logging to Grafana is still working
+    Switch to vm   ${ADMIN_VM}
+    ${id}          Get Actual Device ID
+    ${status}      Check VM Log on Grafana   ${id}   ${HOST}   15s
+    IF    not ${status}
+        Log    No recent logs found, recovering the logging service (Known issue: SSRCSP-8302)  console=True
+        # If no recent logs found in Grafana, restart alloy and clear its WAL
+        # The removed logs won't get forwarded to Grafana but are available on the device
+        Run Command    df -h   # For debugging
+        Run Command    systemctl stop alloy.service   sudo=True
+        Elevate to superuser   sleep=5
+        Write    rm -rf /var/lib/private/alloy/data-alloy/loki.write.remote/wal/*
+        Sleep    1
+        Run Command    systemctl start alloy.service   sudo=True
+        Run Command    df -h   # For debugging
+        # Check that logs are available
+        Log    Logging service restarted, checking for new logs   console=True
+        Wait Until Keyword Succeeds     15s   2s    Check VM Log on Grafana   ${id}   ${HOST}   15s   ${True}
+    END
 
 Update with
     [Arguments]           ${update_method}

--- a/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
+++ b/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
@@ -14,7 +14,7 @@ Resource            ../../resources/update_keywords.resource
 Resource            ../../resources/service_keywords.resource
 
 Suite Setup          Rebuild Setup
-Suite Teardown       Teardown Audit Update Logging
+Suite Teardown       Rebuild Teardown
 
 *** Variables ***
 ${repository_path}      /persist/ghaf
@@ -44,8 +44,10 @@ Check net-vm hostname persistence over nixos-rebuild
 Check file system changes are logged
     [Documentation]         Create file and verify that the operation was logged
     [Tags]                  SP-T280
+    [Setup]                 Check That Logging Is Working in VM   ${CHROME_VM}
     ${file_path}              Set Variable    /tmp/test_text.txt
 
+    Switch to vm              ${HOST}
     ${state}  ${substate}     Verify service status  range=60  service=microvm@${CHROME_VM}.service  expected_state=active  expected_substate=running
     Switch to vm              ${CHROME_VM}
     Create text file          test    ${file_path}
@@ -59,6 +61,7 @@ Check file system changes are logged
 Check that system logs privilege uses and key events
     [Documentation]         Execute check of ipset list and verify that the command was logged
     [Tags]                  SP-T281
+    [Setup]                 Check That Logging Is Working in VM   ${NET_VM}   ${NETVM_NAME}
     Switch to vm              ${NET_VM}
     Run Command               ipset list   sudo=True
     Sleep                     3
@@ -195,6 +198,7 @@ Run Nixos Rebuild
         FAIL  nixos-rebuild didn't finish successfully withing the given time
     END
     Soft Reboot Device And Connect
+    Login to laptop   enable_dnd=True
 
 Clone Ghaf Repository
     [Arguments]               ${repository_path}    ${commit}=${EMPTY}
@@ -215,15 +219,28 @@ Clone Ghaf Repository
 Remove Ghaf Repository
     Run Command     rm -r ${repository_path}   sudo=True
 
-Teardown Audit Update Logging
+Rebuild Teardown
     Set Client Configuration      timeout=10
     IF  ${setup_skipped} or '${PREV_TEST_STATUS}'=='FAIL'
         Reboot Laptop
         Close All Connections
         Connect After Reboot
+        Login to laptop   enable_dnd=True
     END
     Switch to vm    ${HOST}
     Remove Ghaf Repository
     Roll back to original generation
     Soft Reboot Device And Connect
-    Close All Connections
+    Login to laptop   enable_dnd=True
+
+Check That Logging Is Working in VM
+    [Documentation]  Check that the test log is sent to Grafana
+    [Arguments]      ${vm}   ${log_vm}=${vm}   ${since}=1m
+    Switch to vm   ${vm}
+    Run Command  logger --priority=user.info "Rebuild_test_log"
+    ${id}   Get Actual Device ID
+    ${status}  Run Keyword And Return Status  Wait Until Keyword Succeeds  15s  2s
+    ...  Check VM Log on Grafana  ${id}  ${log_vm}  ${since}  ${True}  Rebuild_test_log
+    IF  not ${status}
+        FAIL    Log sent from ${vm} was not found in Grafana.\nCheck if log forwarding is broken.
+    END


### PR DESCRIPTION
- Execute update tests in a logged in state. This makes connecting to app VMs more reliable and aligns with other tests.
- Add a suite teardown for update tests. Updating is currently producing too much logs for the admin-vm to handle and causes the logging to Grafana stop.
  - `Update Teardown` stops the logging service, deletes extra logs and then restarts the service.
  - `Elevate to superuser` needs an extended timeout because admin-vm is working very slowly due to running out of space. 
- Confirm that logging is working before running `Check file system changes are logged` and `Check that system logs privilege uses and key events`. This will help with debugging.

Testrun https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5432/