### PR TITLE
Remove old GUI workarounds

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -33,23 +33,15 @@ Log in, unlock and verify
     ${logout_status}    Check if logged out   1
     IF  ${logout_status}
         Log in via GUI
+        Wait Until Keyword Succeeds    60s    1s    Verify user login session
     ELSE
         ${lock}       Check if locked
         IF  ${lock}   Unlock
     END
 
-    # This is a workaround for a cosmic-greeter bug https://github.com/pop-os/cosmic-greeter/issues/135.
-    # If the laptop did not login on the first attempt tries to press Tab to select the password field
-    # and then attempts to log in again.
-    ${status}   ${output}   Run Keyword And Ignore Error   Verify desktop availability   logging_in=True
-    IF   $status == 'FAIL'
-        Log To Console    There was maybe a bug with the cosmic-greeter, let's try logging in again
-        Log To Console    Pressing Tab to activate the password field
-        Press Key(s)      TAB
-        Log in via GUI
-        Verify desktop availability   logging_in=True
-    END
+    Verify desktop availability   iterations=100
 
+    Kill Initial Setup
     Disable automatic suspension
     IF  ${enable_dnd}      Set do not disturb state   true
 
@@ -184,34 +176,27 @@ Wiggle cursor
     Run ydotool command   mousemove -- -1 -1
 
 Verify desktop availability
-    [Documentation]    Wait for the login and check that launcher icon is available on desktop
-    [Arguments]        ${logging_in}=False
+    [Documentation]   Check that launcher icon is available on desktop
+    [Arguments]       ${iterations}=30
+    Log To Console    Verifying login by trying to detect the launcher icon
+    Locate on screen  image  ${APP_MENU_LAUNCHER}  0.95  ${iterations}
 
-    FOR   ${i}   IN RANGE  60
-        ${logout_status}   Check if logged out   1
-        IF  not ${logout_status}    BREAK
+Verify user login session
+    [Documentation]   Confirm that the user has an active login session on a seat
+    ${sessions}       Run Command   loginctl list-sessions | grep seat   rc_match=skip
+    IF    $USER_LOGIN in $sessions
+        Log   Found active GUI session for ${USER_LOGIN}   console=True
+        RETURN
     END
-    IF  ${logout_status}    FAIL    User session did not activate, user is still logged out
-    IF  "${DEVICE_TYPE}" == "dell-7330"    Sleep   10
-
-    IF  ${logging_in}   Kill Initial Setup
-
-    Log To Console         Verifying login by trying to detect the launcher icon
-    # This is a workaround for launcher icon missing sometimes. If launcher icon can't be found tries to search
-    # for the power menu icon. Gui-vm user log is saved to help debugging.
-    ${status}   ${output}   Run Keyword And Ignore Error   Locate on screen  image  ${APP_MENU_LAUNCHER}  0.95  100
-    IF   $status == 'FAIL'
-        Get gui-vm user journalctl log
-        Log To Console    Could not find launcher icon, checking for power menu icon
-        Locate on screen  image  power.png  0.95  10
-    END
+    Log     No active GUI session found for ${USER_LOGIN}   console=True
+    FAIL    User is logged out
 
 Check if logged out
     [Documentation]    Check if system is in logged out state
     [Arguments]        ${iterations}=10
     FOR   ${i}   IN RANGE  ${iterations}
-        ${sessions}       Run Command   loginctl list-sessions | grep seat   rc_match=skip
-        IF    $USER_LOGIN in $sessions
+        ${status}    ${output}    Run Keyword And Ignore Error    Verify user login session
+        IF    '${status}' == 'PASS'
             Log      Found active GUI session for ${USER_LOGIN}, user is logged in  console=True
         ELSE
             Log      No active GUI session found for ${USER_LOGIN}, user is logged out  console=True
@@ -229,13 +214,10 @@ Get icon
 
 Check if locked
     [Documentation]    Check if the screen lock is active
-    ${logout_status}   Check if logged out   1
-    IF  not ${logout_status}
-        ${status}   ${output}      Run Keyword And Ignore Error   Locate on screen  image  ${LOCK_ICON}  0.95  1  debug_screenshot=False
-        IF  '${status}' == 'PASS'
-            Log To Console    Screen is locked
-            RETURN    ${True}
-        END
+    ${status}   ${output}      Run Keyword And Ignore Error   Locate on screen  image  ${LOCK_ICON}  0.95  1  debug_screenshot=False
+    IF  '${status}' == 'PASS'
+        Log To Console    Screen is locked
+        RETURN    ${True}
     END
     Log To Console    Screen lock is not active
     RETURN    ${False}
@@ -274,12 +256,6 @@ Set do not disturb state
     ELSE
         Run Command   echo 3 > ~/.config/cosmic/com.system76.CosmicNotifications/v1/max_notifications
     END
-
-Get gui-vm user journalctl log
-    [Arguments]       ${filename}=gui-vm-user.txt
-    Run Command   journalctl --user > /tmp/${filename}
-    SSHLibrary.Get file   /tmp/${filename}   ${OUTPUT_DIR}/${filename}
-    OperatingSystem.File Should Exist   ${OUTPUT_DIR}/${filename}
 
 Timestamp last screenshot
     ${current_time}  DateTime.Get Current Date  result_format=%Y%m%d_%H%M%S
@@ -326,15 +302,6 @@ Run ydotool command
         Run Command    YDOTOOL_SOCKET=${YDOTOOL_SOCKET} ydotool ${command}
     END
     Sleep   0.2
-
-Change to gray wallpaper
-    Log To Console    Changing to gray wallpaper
-    Put File          ../test-files/background.config   .
-    Run Command   mv background.config .config/cosmic/com.system76.CosmicBackground/v1/all
-
-Restore default wallpaper
-    Log To Console    Changing back to default wallpaper
-    Remove file       ~/.config/cosmic/com.system76.CosmicBackground/v1/all
 
 Start screen recording
     [Setup]          Kill App By Name   gpu-screen-recorder

--- a/Robot-Framework/test-files/background.config
+++ b/Robot-Framework/test-files/background.config
@@ -1,9 +1,0 @@
-(
-    output: "all",
-    source: Color(Single((0.32, 0.32, 0.32))),
-    filter_by_theme: false,
-    rotation_frequency: 0,
-    filter_method: Lanczos,
-    scaling_mode: Zoom,
-    sampling_method: Alphanumeric,
-)

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -104,8 +104,7 @@ Test setup
 
 Test teardown
     IF  $TEST_STATUS=='PASS'
-        Switch to vm   ${GUI_VM}   user=${USER_LOGIN}
-        Log out and verify
+        Log out from laptop
     ELSE
         Reboot Laptop
         Connect After Reboot


### PR DESCRIPTION
- Remove the second GUI login attempt, this workaround should not be needed anymore
- Remove the workaround for launcher icon missing sometimes
- Remove the keywords related to changing the wallpaper, they are not used

Testrun https://ci-dev.vedenemo.dev/job/ghaf-nightly/323/ (This was not rebased to the logging changes I did yesterday)