### PR TITLE
Verify hard shutdown via network

### DIFF
--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -44,21 +44,22 @@ Turn Off Power
     END
 
 Reboot Laptop
-    [Arguments]       ${delay}=15    ${verify_shutdown}=True
+    [Arguments]       ${delay}=20    ${verify_shutdown}=True
     [Documentation]   Turn off the laptop by pressing power button for 10 sec turn on by short pressing power button
-    IF  "${DEVICE_TYPE}" == "lenovo-x1" or "${DEVICE_TYPE}" == "darter-pro" or "${DEVICE_TYPE}" == "x1-sec-boot"
-        ${delay}      Set variable    20
-    END
-    Log To Console    ${\n}Turning device off...
+    Log To Console    ${\n}Shutting down by pressing the power button
+    ${start_time}     Get Time    epoch
     Press Button      ${SWITCH_BOT}-OFF
-    Sleep             ${delay}    # needed because Pressing OFF button takes up to 15 sec
     IF  ${verify_shutdown}
-        Verify shutdown via network
+        ${stop_time}  Verify shutdown via network
+        ${wait_time}  Evaluate    int(${delay}) - int(${stop_time}) + int(${start_time})
+        Wait          ${wait_time}
+    ELSE
+        Sleep         ${delay}    # needed because Pressing OFF button takes up to 15 sec
     END
     Turn Laptop On
 
 Turn Laptop On
-    Log To Console    ${\n}Turning device on...
+    Log To Console    ${\n}Booting the device by pressing the power button
     Press Button      ${SWITCH_BOT}-ON
     IF    "${DEVICE_TYPE}" == "darter-pro"
         Wait    15
@@ -67,7 +68,7 @@ Turn Laptop On
     END
 
 Turn Laptop On and Connect
-    Log To Console    ${\n}Turning device on...
+    Log To Console    ${\n}Booting the device by pressing the power button
     Turn Laptop On
     Check If Device Is Up
     IF    ${IS_AVAILABLE} == False

--- a/Robot-Framework/test-suites/performance-tests/boot_time.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time.robot
@@ -36,15 +36,7 @@ Measure Soft Boot Time
 Measure Hard Boot Time
     [Documentation]  Measure how long it takes to device to boot up with hard reboot
     [Tags]           SP-T182  SP-T182-1  lenovo-x1  darter-pro  dell-7330  lab-only
-    Log To Console                Shutting down by pressing the power button
-    Press Button                  ${SWITCH_BOT}-OFF
-    Wait Until Device Is Down
-    Close All Connections
-    Log To Console                The device has shut down
-    Log To Console                Waiting for the robot finger to return
-    Sleep  20
-    Log To Console                Booting the device by pressing the power button
-    Turn Laptop On
+    Reboot Laptop
     Get Boot times                plot_name=Hard Boot Times
     [Teardown]                    Boot Time Test Teardown
 


### PR DESCRIPTION
Verifying shudown via serial on laptops does not work in case of hard shutdown, so lately after 1 minute of waiting it was anyway going to verify via network,so I would consider this a waste of time
Example how it works in main on [Darter](https://ci-prod.vedenemo.dev/job/ghaf-hw-test/22288/artifact/Robot-Framework/test-suites/performance/log.html#s1-s1-s1-t1-k3-k2-k1-k3-k4-k2)
On [Lenovo X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5456/artifact/Robot-Framework/test-suites/SP-T182-1/log.html#s1-s1-s1-t1-k3-k3-k4-k2)
And 1 minute faster `[With this changes on X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5457/artifact/Robot-Framework/test-suites/SP-T182-1/log.html#s1-s1-s1-t1-k3)