### PR TITLE
Check boot device before running tests

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -126,12 +126,13 @@ Set Variables
 
     Set Log Level       INFO
 
-    IF  $BUILD_ID != '${EMPTY}'
-        ${config}=     Read Config  ${CONFIG_PATH}/${BUILD_ID}.json
+    ${job_json_available}    Run Keyword And Return Status    OperatingSystem.File Should Exist    ${CONFIG_PATH}/${BUILD_ID}.json
+    IF  $BUILD_ID != '${EMPTY}' and ${job_json_available}
+        ${config}    Read Config  ${CONFIG_PATH}/${BUILD_ID}.json
         Set Global Variable    ${JOB}    ${config['Job']}
     ELSE
         IF  $JOB == '${EMPTY}'
-            Set Global Variable    ${JOB}    dummy_job
+            Set Global Variable    ${JOB}    ${DEVICE_TYPE}
         END
     END
 

--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -223,3 +223,12 @@ Get Time Since Last Boot
     Switch to vm        ${HOST}
     ${output}           Run Command    cat /proc/uptime | cut -d. -f1
     RETURN              ${output}
+
+Get Backing Disk For Mountpoint
+    [Documentation]    Resolve the physical disk backing the given mountpoint.
+    [Arguments]        ${mountpoint}
+    Run Command        lsblk    # For debugging
+    ${device}          Run Command    findmnt -no SOURCE ${mountpoint}
+    ${disk_info}       Run Command    lsblk --json -s -o NAME,TYPE ${device}
+    ${disk}            Get Backing Disk From Lsblk    ${disk_info}
+    RETURN             ${disk}

--- a/Robot-Framework/resources/setup_keywords.resource
+++ b/Robot-Framework/resources/setup_keywords.resource
@@ -5,6 +5,7 @@
 Resource            ../config/variables.robot
 Resource            ../resources/gui_keywords.resource
 Resource            ../resources/ssh_keywords.resource
+Resource            ../resources/common_keywords.resource
 
 
 *** Variables ***
@@ -23,12 +24,36 @@ Prepare Test Environment
     END
     Close All Connections
     Switch to vm    ${HOST}
+
     Log versions and device unique data
     IF  ${IS_LAPTOP}
+        Verify boot from expected device
         Create test user
         Save gui icons and icon path
         Login to laptop   ${enable_dnd}
     END
+
+Verify boot from expected device
+    IF  '${JOB}' == '${DEVICE_TYPE}'
+        # Avoid blocking custom local test runs
+        RETURN
+    END
+    Log To Console    Verifying boot from expected device...
+    ${expect_internal_boot}    Run Keyword And Return Status    Should Contain    ${JOB}    installer
+    IF  ${expect_internal_boot}
+        Check that System And Boot Disk Match    nvme0n1
+    ELSE
+        Check that System And Boot Disk Match    sda
+    END
+
+Check that System And Boot Disk Match
+    [Documentation]    Check that /boot and / are backed by the same physical disk and match the expected disk.
+    [Arguments]        ${expected_disk}
+    ${boot_disk}       Get Backing Disk For Mountpoint    /boot
+    ${root_disk}       Get Backing Disk For Mountpoint    /
+    Should Be Equal    ${boot_disk}       ${expected_disk}    Laptop booted from ${boot_disk}, expected ${expected_disk}
+    Should Be Equal    ${root_disk}       ${boot_disk}        / is mounted from ${root_disk}, expected ${boot_disk}
+    Log                Correct boot device verified: ${expected_disk}    console=True
 
 Clean Up Test Environment
     [Timeout]     5 minutes

--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -101,15 +101,6 @@ Check Secure Boot is enabled
     ${sb_status}      Get Secure Boot Status
     Should Be Equal   ${sb_status}   Enabled   Secure Boot is not enabled
 
-Check that laptop booted from Internal Memory
-    [Documentation]  Check that laptop booted and is running from the internal memory when running tests with installer
-    [Tags]           SP-T130  SP-T130-1  lenovo-x1  darter-pro  installer-only
-    Check that System And Boot Disk Match    nvme0n1
-
-Check that laptop booted from SSD
-    [Documentation]  Check that laptop booted and is running from the SSD when running tests without installer
-    [Tags]           SP-T130  SP-T130-2  pre-merge  bat  lenovo-x1  darter-pro  excl-installer
-    Check that System And Boot Disk Match    sda
 
 *** Keywords ***
 
@@ -157,23 +148,6 @@ Check QSPI Version is up to date
     ${output}      Run Command     ota-check-firmware  rc_match=skip
     ${fw_version}  ${sw_version}   Get qspi versions   ${output}
     Should Be True	'${fw_version}' == '${sw_version}'	  Update QSPI version! Test results can be wrong!
-
-Check that System And Boot Disk Match
-    [Documentation]    Check that /boot and / are backed by the same physical disk and match the expected disk.
-    [Arguments]        ${expected_disk}
-    ${boot_disk}       Get Backing Disk For Mountpoint    /boot
-    ${root_disk}       Get Backing Disk For Mountpoint    /
-    Should Be Equal    ${boot_disk}       ${expected_disk}    Laptop booted from ${boot_disk}, expected ${expected_disk}
-    Should Be Equal    ${root_disk}       ${boot_disk}        / is mounted from ${root_disk}, expected ${boot_disk}
-
-Get Backing Disk For Mountpoint
-    [Documentation]    Resolve the physical disk backing the given mountpoint.
-    [Arguments]        ${mountpoint}
-    Run Command        lsblk    # For debugging
-    ${device}          Run Command    findmnt -no SOURCE ${mountpoint}
-    ${disk_info}       Run Command    lsblk --json -s -o NAME,TYPE ${device}
-    ${disk}            Get Backing Disk From Lsblk    ${disk_info}
-    RETURN             ${disk}
 
 Check Boot Disk Size
     [Documentation]  Check the size of the disk the system booted from.

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -54,7 +54,7 @@ CPU multiple threads test
     ...                     The benchmark records to csv CPU events per second, events per thread, and latency data.
     ...                     Create visual plots to represent these metrics comparing to previous tests.
     [Tags]                  SP-T61  SP-T61-2  cpu  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  orin-nx
-    ${output}               Run Command    sysbench cpu --time=10 --threads=${threads_number} --cpu-max-prime=20000 run
+    ${output}               Run Command    sysbench cpu --time=10 --threads=${THREADS_NUMBER} --cpu-max-prime=20000 run
     &{cpu_data}             Parse Cpu Results   ${output}
     &{statistics}           Save Cpu Data       ${TEST NAME}  ${cpu_data}
     Log                     <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="CPU Plot" width="1200">    HTML
@@ -101,7 +101,7 @@ Memory Read multiple threads test
     ...                     and Latency for READ operations.
     ...                     Create visual plots to represent these metrics comparing to previous tests.
     [Tags]                  SP-T61  SP-T61-5  memory  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  orin-nx
-    ${output}               Run Command    sysbench memory --time=60 --memory-oper=read --threads=${threads_number} run
+    ${output}               Run Command    sysbench memory --time=60 --memory-oper=read --threads=${THREADS_NUMBER} run
     &{mem_data}             Parse Memory Results   ${output}
     ${statistics}           Save Memory Data       ${TEST NAME}  ${mem_data}
     Log                     <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
@@ -113,7 +113,7 @@ Memory Write multiple threads test
     ...                     and Latency for WRITE operations.
     ...                     Create visual plots to represent these metrics comparing to previous tests.
     [Tags]                  SP-T61  SP-T61-6  memory  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  orin-nx
-    ${output}               Run Command    sysbench memory --time=60 --memory-oper=write --threads=${threads_number} run
+    ${output}               Run Command    sysbench memory --time=60 --memory-oper=write --threads=${THREADS_NUMBER} run
     &{mem_data}             Parse Memory Results   ${output}
     &{statistics}           Save Memory Data       ${TEST NAME}  ${mem_data}
     Log                     <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}.png" alt="Mem Plot" width="1200">    HTML
@@ -136,14 +136,14 @@ FileIO test
         Elevate to superuser
         Write                 cd /persist
         Log To Console        Starting fileio test
-        Write                 /persist/fileio_test ${threads_number} /persist
+        Write                 /persist/fileio_test ${THREADS_NUMBER} /persist
         Set Client Configuration	  timeout=900
         ${out}                SSHLibrary.Read Until   Test finished.
         Set Client Configuration	  timeout=30
         Log                   ${out}
     ELSE
         Log To Console        Starting fileio test
-        Run Command           /tmp/fileio_test ${threads_number}  sudo=True   timeout=300
+        Run Command           /tmp/fileio_test ${THREADS_NUMBER}  sudo=True   timeout=300
     END
 
     ${test_info}  Run Command    cat /tmp/sysbench_results/test_info

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -83,7 +83,7 @@ Automatic suspension
         ${max_suspended_power}   Check max power during suspension   ${BUILD_ID}
         ${power_changed}         Measure power level change  ${BUILD_ID}  ${rel_power_change_limit}  ${before_suspend_start}  ${before_suspend_end}  ${after_suspend_start}  ${after_suspend_end}
 
-        IF  ${suspended_power} > ${suspended_power_limit}
+        IF  ${max_suspended_power} > ${suspended_power_limit}
             FAIL    Power consumption exceptionally high during suspension\nMax suspended power: ${max_suspended_power}mW\nTest limit: ${suspended_power_limit}mW
         END
 


### PR DESCRIPTION
Verify that the target machine has booted from correct device as a prerequisite for running any tests. There is no point in running tests with wrong image / boot. Consequently it is justified to fail all tests if that check fails.

Just need to remember to add "installer" to the job name if running tests manually on target device with ghaf pre-installed on internal ssd.

Also fix incorrect variable name: ${suspended_power} --> ${max_suspended_power}

Lenovo-X1
Test run without flash, JOB defaulting to DEVICE_TYPE
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5481/

Test run with flash, ghaf image boot from USB ssd, JOB extracted from url
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5482/

Test run with installer image, flash, ghaf image boot form internal ssd, JOB extracted from url
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5483/

Darter-Pro
Test run with flash, ghaf image boot from USB ssd, JOB extracted from url
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5485/

Tested with X1 that local run works if BUILD_ID.json job matches (contains installer / no installer) with the state of the target (ghaf booted from internal/external ssd). If running a local test (not performance test) without BUILD_ID the boot device check will be also skipped.

Tested that nix develop .#smoke-test of the ghaf repo works. Boot device check is skipped always in smoke-test.