### PR TITLE
Temporarily skip failing update tests

### DIFF
--- a/Robot-Framework/test-suites/update-tests/update-tests.robot
+++ b/Robot-Framework/test-suites/update-tests/update-tests.robot
@@ -51,7 +51,7 @@ Update Teardown
         Run Command    df -h   # For debugging
         # Check that logs are available
         Log    Logging service restarted, checking for new logs   console=True
-        Wait Until Keyword Succeeds     15s   2s    Check VM Log on Grafana   ${id}   ${HOST}   15s   ${True}
+        Run Keyword And Ignore Error   Wait Until Keyword Succeeds     15s   2s    Check VM Log on Grafana   ${id}   ${HOST}   15s   ${True}
     END
 
 Update with

--- a/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
+++ b/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
@@ -15,6 +15,7 @@ Resource            ../../resources/service_keywords.resource
 
 Suite Setup          Rebuild Setup
 Suite Teardown       Rebuild Teardown
+Test Teardown        Run Keyword If Test Failed   SKIP   Known issue: SSRCSP-8302
 
 *** Variables ***
 ${repository_path}      /persist/ghaf

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -4,6 +4,7 @@
 
 | DATE SET   | TEST CASE                                               | TICKET / Additional Data.                                                                     |
 | ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| 17.04.2026 | Rebuild tests skipped if they fail                      | SSRCSP-8302                                                                                   |
 | 08.04.2026 | Automatic suspension                                    | SSRCSP-8288                                                                                   |
 | 30.03.2026 | Check Camera in VMs (Dell)                              | SSRCSP-8266                                                                                   |
 | 30.03.2026 | Check Camera Application (Dell checked in chrome-vm)    | SSRCSP-8266                                                                                   |


### PR DESCRIPTION
This is to prevent unnecessary failures in the pipelines. We might have to wait for fixes in Ghaf before these skips can be removed.

Testrun https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5502/ (of course nothing failed now that I wanted it to)