### PR TITLE
Verify blacklisting by second flood burst

### DIFF
--- a/Robot-Framework/test-suites/security-tests/firewall.robot
+++ b/Robot-Framework/test-suites/security-tests/firewall.robot
@@ -247,14 +247,10 @@ Tcp Syn Flood
         ${rc}   ${output}  Run And Return Rc And Output    ${flood_cmd}
         Should Be Equal As Integers    ${output}    1    Blacklisting not detected
     ELSE
-        ${rc}    Run Command    ${flood_cmd}
+        ${rc}              Run Command    ${flood_cmd}
         Run Keyword If     ${rc}!=0       FAIL       No responses to first ping flood, expected at least 1
-        # Skipping ghaf-host for now, it behaves differently.
-        # ghaf-host replies to some packets even after blacklisting has been triggered.
-        IF  $target_ip!="ghaf-host"
-            ${rc}    Run Command    ${flood_cmd}
-            Run Keyword If    ${rc}!=1       FAIL       Blacklisting not detected
-        END
+        ${rc}              Run Command    ${flood_cmd}
+        Run Keyword If     ${rc}!=1       FAIL       Blacklisting not detected
     END
 
 Blacklist Teardown


### PR DESCRIPTION
After this bug fix went in https://github.com/tiiuae/ghaf/pull/1885 we can verify also ghaf-host blacklisting by sending
second tcp syn burst.

https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5575/