### PR TITLE
Add fail condition to shutdown & reboot tests

### DIFF
--- a/Robot-Framework/test-suites/gui-tests/gui_power_menu.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power_menu.robot
@@ -73,9 +73,13 @@ GUI Reboot
     ...               Check that it shuts down. Check that it turns on and boots to login screen.
     [Tags]            SP-T75  SP-T75-4  lenovo-x1  darter-pro
     Select power menu option   x=870   y=120   confirmation=True
+    ${start_time}     Get Time    epoch
     Verify shutdown via network
     Connect After Reboot   soft_reboot=True
+    ${end_time}       Get Time    epoch
     Login to laptop   enable_dnd=True
+    ${elapsed}        Evaluate    ${end_time} - ${start_time}
+    IF   ${elapsed} > 90    FAIL   Reboot took too long: ${elapsed} seconds (expected < 90)
 
 GUI Shutdown
     [Documentation]   Shutdown the device via GUI power menu shutdown icon.
@@ -94,6 +98,7 @@ GUI Shutdown
     END
     Turn Laptop On and Connect
     Login to laptop   enable_dnd=True
+    IF   ${elapsed} > 20    FAIL   Shutdown took too long: ${elapsed} seconds (expected < 20)
 
 GUI Log out and log in
     [Documentation]   Logout via GUI power menu icon and verify logged out state.


### PR DESCRIPTION
I accidentally removed the fail condition when removing the skip from shutdown test (https://github.com/tiiuae/ci-test-automation/pull/756)

This PR brings the fail requirement back and adds it also for reboot. I am pretty sure it used to have one, no idea what happened to it.

I checked the reboot/shutdown times from the last 2 nights, there would have been no failures with these limits. 

X1 testrun https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5576/