### PR TITLE
Save build commit on target

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -26,6 +26,7 @@ ${LOGGED_PARAMS_DIR}      ../../../logged_parameters/
 ${PERF_DATA_DIR}          ../../../Performance_test_results/
 ${PLOT_DIR}               ./
 ${REL_PLOT_DIR}           ./
+${FLASHED}                false
 
 
 *** Keywords ***

--- a/Robot-Framework/resources/file_keywords.resource
+++ b/Robot-Framework/resources/file_keywords.resource
@@ -6,14 +6,14 @@
 Create file
     [Documentation]    Create file with given path & name, requires existing ssh connection
     [Arguments]        ${file_name}   ${sudo}=False
-    Log To Console     Creating file ${file_name}
+    Log                Creating file ${file_name}    console=True
     Run Command        touch ${file_name}  sudo=${sudo}
 
 Create text file
     [Documentation]    Create text file with given text and name, requires existing ssh connection
-    [Arguments]        ${text}    ${file_name}
-    Log To Console     Writing to file ${file_name}
-    Run Command        echo '${text}' > ${file_name}
+    [Arguments]        ${text}    ${file_name}    ${sudo}=False
+    Log                Writing to file ${file_name}    console=True
+    Run Command        sh -c 'echo "${text}" > ${file_name}'    sudo=${sudo}
 
 Get file owner id
     [Arguments]        ${file_name}
@@ -24,25 +24,25 @@ Get file owner id
 Remove file
     [Documentation]    Remove file with given path & name, requires existing ssh connection
     [Arguments]        ${file_name}   ${sudo}=False   ${rc_match}=equal
-    Log To Console     Removing file ${file_name}
+    Log                Removing file ${file_name}    console=True
     Run Command        rm ${file_name}  sudo=${sudo}  rc_match=${rc_match}
 
 Copy file
     [Documentation]    Copy file, requires existing ssh connection
     [Arguments]        ${file_1}    ${file_2}
-    Log To Console     Copying file ${file_1} to ${file_2}
+    Log                Copying file ${file_1} to ${file_2}    console=True
     Run Command        cp ${file_1} ${file_2}
 
 Check file exists
     [Documentation]    Check file exists, requires existing ssh connection
     [Arguments]        ${file_name}   ${sudo}=False
-    Log To Console     Checking that file ${file_name} exists
+    Log                Checking that file ${file_name} exists    console=True
     Run Command        ls ${file_name}  sudo=${sudo}
 
 Check file doesn't exist
     [Documentation]    Check file doesn't exist, requires existing ssh connection
     [Arguments]        ${file_name}  ${sudo}=False
-    Log To Console     Checking that file ${file_name} does not exist
+    Log                Checking that file ${file_name} does not exist    console=True
     Run Command        ls ${file_name}  sudo=${sudo}  rc_match=not_equal  compare_rc=0
 
 Edit File
@@ -58,3 +58,12 @@ Edit File
     END
     ${out}             Run Command    cat ${file_path}
     Log                ${out}
+
+Get File Content Or Default
+    [Arguments]    ${path}    ${default}=not found
+    ${out}    ${rc}=    Run Command    cat ${path}    return=out,rc    rc_match=skip
+    IF    ${rc} == 0
+        RETURN    ${out}
+    ELSE
+        RETURN    ${default}
+    END

--- a/Robot-Framework/resources/setup_keywords.resource
+++ b/Robot-Framework/resources/setup_keywords.resource
@@ -78,20 +78,26 @@ Save host journalctl
     OperatingSystem.File Should Exist    ${OUTPUT_DIR}/jrnl.txt
 
 Log versions and device unique data
-    Log                 ---- Versions ----                console=True
+    ${ghaf_commit}      Get File Content Or Default        /persist/build_commit
+    ${build_job}        Get File Content Or Default        /persist/job
+
+    Log                 ---- Versions ----                 console=True
+    Log                 Ghaf build commit file on the device: ${ghaf_commit}  console=True
+    Log                 Test run commit variable: ${COMMIT_HASH}  console=True
     ${ghaf_version}     Run Command   ghaf-version
-    Log                 Ghaf version: ${ghaf_version}     console=True
+    Log                 Ghaf version: ${ghaf_version}      console=True
     ${nixos_version}    Run Command   nixos-version
-    Log                 Nixos version: ${nixos_version}   console=True
-    Log                 NetVM hostname: ${NETVM_NAME}     console=True
+    Log                 Nixos version: ${nixos_version}    console=True
+    Log                 NetVM hostname: ${NETVM_NAME}      console=True
     Get Actual Device ID
     #Save the Robot Framework version
     ${robot_version}    Run   robot --version
     Log                 Robot version of the tests: ${robot_version}   console=True
-    Log                 Device: ${DEVICE}                 console=True
-    Log                 Device type: ${DEVICE_TYPE}       console=True
-    Log                 Job: ${JOB}                       console=True
-    Log                 --------                          console=True
+    Log                 Device: ${DEVICE}                  console=True
+    Log                 Device type: ${DEVICE_TYPE}        console=True
+    Log                 Job file on device: ${build_job}   console=True
+    Log                 Test run job variable: ${JOB}      console=True
+    Log                 --------                           console=True
 
 Create test user
     [Setup]          Switch to vm    ${GUI_VM}
@@ -163,3 +169,12 @@ Is first graphical login
     ${lines}    Count lines    ${result}
     IF  ${lines} <= 1   RETURN   True
     RETURN      False
+
+Get File Content Or Default
+    [Arguments]    ${path}    ${default}=not found
+    ${out}    ${rc}=    Run Command    cat ${path}    return=out,rc    rc_match=skip
+    IF    ${rc} == 0
+        RETURN    ${out}
+    ELSE
+        RETURN    ${default}
+    END

--- a/Robot-Framework/resources/setup_keywords.resource
+++ b/Robot-Framework/resources/setup_keywords.resource
@@ -6,6 +6,7 @@ Resource            ../config/variables.robot
 Resource            ../resources/gui_keywords.resource
 Resource            ../resources/ssh_keywords.resource
 Resource            ../resources/common_keywords.resource
+Resource            ../resources/file_keywords.resource
 
 
 *** Variables ***
@@ -78,20 +79,26 @@ Save host journalctl
     OperatingSystem.File Should Exist    ${OUTPUT_DIR}/jrnl.txt
 
 Log versions and device unique data
-    Log                 ---- Versions ----                console=True
+    ${ghaf_commit}      Get File Content Or Default        /persist/build_commit
+    ${build_job}        Get File Content Or Default        /persist/job
+
+    Log                 ---- Versions ----                 console=True
+    Log                 Ghaf build commit file on the device: ${ghaf_commit}  console=True
+    Log                 Test run commit variable: ${COMMIT_HASH}  console=True
     ${ghaf_version}     Run Command   ghaf-version
-    Log                 Ghaf version: ${ghaf_version}     console=True
+    Log                 Ghaf version: ${ghaf_version}      console=True
     ${nixos_version}    Run Command   nixos-version
-    Log                 Nixos version: ${nixos_version}   console=True
-    Log                 NetVM hostname: ${NETVM_NAME}     console=True
+    Log                 Nixos version: ${nixos_version}    console=True
+    Log                 NetVM hostname: ${NETVM_NAME}      console=True
     Get Actual Device ID
     #Save the Robot Framework version
     ${robot_version}    Run   robot --version
     Log                 Robot version of the tests: ${robot_version}   console=True
-    Log                 Device: ${DEVICE}                 console=True
-    Log                 Device type: ${DEVICE_TYPE}       console=True
-    Log                 Job: ${JOB}                       console=True
-    Log                 --------                          console=True
+    Log                 Device: ${DEVICE}                  console=True
+    Log                 Device type: ${DEVICE_TYPE}        console=True
+    Log                 Job file on device: ${build_job}   console=True
+    Log                 Test run job variable: ${JOB}      console=True
+    Log                 --------                           console=True
 
 Create test user
     [Setup]          Switch to vm    ${GUI_VM}

--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -11,6 +11,7 @@ Resource            ../../resources/device_control.resource
 Resource            ../../resources/serial_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/service_keywords.resource
+Resource            ../../resources/file_keywords.resource
 
 Suite Teardown      Teardown
 
@@ -40,11 +41,12 @@ Verify booting after restart by power
     ELSE
         Log To Console  The device started
     END
-    IF  not ${IS_LAPTOP}
-        Sleep  30
-    END
+
+    Sleep  30
+
     IF  "${CONNECTION_TYPE}" == "ssh"
         Switch to vm    ${HOST}
+        Save commit hash on target device
         Verify service status   service=init.scope
     ELSE IF  "${CONNECTION_TYPE}" == "serial"
         Verify init.scope status via serial
@@ -72,6 +74,7 @@ Verify booting laptop
     END
     IF  "${CONNECTION_TYPE}" == "ssh"
         Switch to vm    ${HOST}
+        Save commit hash on target device
         Verify service status   service=init.scope
     ELSE IF  "${CONNECTION_TYPE}" == "serial"
         Verify init.scope status via serial
@@ -225,3 +228,23 @@ Wipe system with ghaf-installer
     ${raw}            Read Until Prompt
     ${rc}             Evaluate    [s for s in """${raw}""".splitlines() if s.strip().isdigit()][-1]
     Should Be Equal As Integers    ${rc}   0    Wiping was not successful
+
+Save commit hash on target device
+    ${commit_path}    Set Variable    /persist/build_commit
+    ${job_path}       Set Variable    /persist/job
+    ${file_found}     Run Keyword And Return Status    Check file exists    ${commit_path}    sudo=True
+    ${flashed_bool}   Convert To Boolean    ${FLASHED}
+    IF  ${file_found}
+        IF  ${flashed_bool}
+            FAIL    Expected fresh installation but found existing ${commit_path}\nProbably something has gone wrong in flashing or installing.
+        END
+        ${saved_commit}    Get File Content Or Default        /persist/build_commit
+        ${saved_job}       Get File Content Or Default        /persist/job
+        Log    Ghaf commit hash entry found on the target device: ${saved_commit}    console=True
+        Log    Job entry found on the target device: ${saved_job}                    console=True
+        RETURN
+    END
+    IF  ${flashed_bool}
+        Create text file    ${COMMIT_HASH}    ${commit_path}    sudo=True
+        Create text file    ${JOB}    ${job_path}    sudo=True
+    END

--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -40,11 +40,12 @@ Verify booting after restart by power
     ELSE
         Log To Console  The device started
     END
-    IF  not ${IS_LAPTOP}
-        Sleep  30
-    END
+
+    Sleep  30
+
     IF  "${CONNECTION_TYPE}" == "ssh"
         Switch to vm    ${HOST}
+        Save commit hash on target device
         Verify service status   service=init.scope
     ELSE IF  "${CONNECTION_TYPE}" == "serial"
         Verify init.scope status via serial
@@ -72,6 +73,7 @@ Verify booting laptop
     END
     IF  "${CONNECTION_TYPE}" == "ssh"
         Switch to vm    ${HOST}
+        Save commit hash on target device
         Verify service status   service=init.scope
     ELSE IF  "${CONNECTION_TYPE}" == "serial"
         Verify init.scope status via serial
@@ -225,3 +227,20 @@ Wipe system with ghaf-installer
     ${raw}            Read Until Prompt
     ${rc}             Evaluate    [s for s in """${raw}""".splitlines() if s.strip().isdigit()][-1]
     Should Be Equal As Integers    ${rc}   0    Wiping was not successful
+
+Save commit hash on target device
+    ${commit_path}    Set Variable    /persist/build_commit
+    ${job_path}       Set Variable    /persist/job
+    ${out}  ${rc}     Run Command     test -f ${commit_path}    return=out,rc    rc_match=skip
+    ${flashed_bool}    Convert To Boolean    ${FLASHED}
+    IF  ${rc} == 0
+        IF  ${flashed_bool}
+            FAIL    Expected fresh installation but found existing ${commit_path}\nProbably something has gone wrong in flashing or installing.
+        END
+        Log    Ghaf commit hash entry found on the target device: ${out}    console=True
+        RETURN
+    END
+    IF  ${flashed_bool}
+        Run Command       sh -c 'echo ${COMMIT_HASH} > ${commit_path}'    sudo=True
+        Run Command       sh -c 'echo ${JOB} > ${job_path}'               sudo=True
+    END


### PR DESCRIPTION
This is to help us verify which build / image / job variant we are acutally testing. Can be especially useful in ghaf-hw-test-manual when running tests on pre-existing images.

- Fail boot test if ${FLASHED} is set true but target device has already commit hash entry.
- Otherwise save commit hash into persistent directory if ${FLASHED} is set true.
- By default ${FLASHED} is 'false' and this PR will not affect local test runs (unless setting -v FLASHED:true). In the pipelines ${FLASHED} value is provided by jenkins (https://github.com/tiiuae/ghaf-infra/pull/1025, already merged)

Test runs after manually changed dev ghaf-hw-test-manual script to match https://github.com/tiiuae/ghaf-infra/pull/1025

- Orin AGX without flash NOT having commit hash saved on the target
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5659/

- Orin AGX with flashing an image to USB SSD
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5661/

- Test run without flash having commit hash already saved on the target
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5662/

- Lenovo-X1 with flash and installer image
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5660/