### PR TITLE
Remove rebuild tests from regression

### DIFF
--- a/Robot-Framework/resources/update_keywords.resource
+++ b/Robot-Framework/resources/update_keywords.resource
@@ -16,17 +16,15 @@ Get current generation
     RETURN                 ${current_generation}
 
 Roll back to original generation
-    IF   "${DEVICE_TYPE}" != "x1-sec-boot"
-        ${gen_at_teardown}    Get current generation
-        IF  ${gen_at_teardown}!=${gen_before}
-            Log To Console    Rolling back to original generation and removing the new generation
-            Run Command   bootctl unlink nixos-generation-${gen_at_teardown}.conf  sudo=True
-            Run Command   nix-env -p /nix/var/nix/profiles/system --switch-generation ${gen_before}  sudo=True
-            Run Command   nix-env -p /nix/var/nix/profiles/system --delete-generations ${gen_at_teardown}  sudo=True
-        ELSE
-            Log To Console    New generation not found. Skipping roll back.
-        END
-        Log To Console        Running garbage collect
-        Run Command           nix-collect-garbage  sudo=True  timeout=180
-        Close All Connections
+    ${gen_at_teardown}    Get current generation
+    IF  ${gen_at_teardown}!=${gen_before}
+        Log To Console    Rolling back to original generation and removing the new generation
+        Run Command   bootctl unlink nixos-generation-${gen_at_teardown}.conf  sudo=True
+        Run Command   nix-env -p /nix/var/nix/profiles/system --switch-generation ${gen_before}  sudo=True
+        Run Command   nix-env -p /nix/var/nix/profiles/system --delete-generations ${gen_at_teardown}  sudo=True
+    ELSE
+        Log To Console    New generation not found. Skipping roll back.
     END
+    Log To Console        Running garbage collect
+    Run Command           nix-collect-garbage  sudo=True  timeout=180
+    Close All Connections

--- a/Robot-Framework/test-suites/functional-tests/logging.robot
+++ b/Robot-Framework/test-suites/functional-tests/logging.robot
@@ -66,6 +66,49 @@ Check Grafana logs
     END
     [Teardown]   Run Keyword If Test Failed   Run Keyword If   "storeDisk" in "${JOB}"   SKIP   Known issue: SSRCSP-8326
 
+Check logging rate
+    [Documentation]    Check that host or vms are not creating too much logs
+    [Tags]             SP-T359  log_rate  pre-merge  orin-agx  orin-agx-64  orin-nx
+    ${check_interval}  Set Variable   100
+    ${saved_entries}   Set Variable   100
+    ${entry_limit}     Set Variable   2000
+    ${byte_limit}      Set Variable   400000
+    ${gui_vm_entry_limit}   Set Variable   10000
+    ${gui_vm_byte_limit}    Set Variable   2000000
+    &{spam_metrics}    Create Dictionary
+    &{ok_metrics}      Create Dictionary
+    &{spam_logs}       Create Dictionary
+    FOR  ${vm}  IN  @{VM_LIST}
+        Switch to vm   ${vm}
+        IF  '${vm}' == 'gui-vm'
+            ${vm_entry_limit}   Set Variable   ${gui_vm_entry_limit}
+            ${vm_byte_limit}    Set Variable   ${gui_vm_byte_limit}
+        ELSE
+            ${vm_entry_limit}   Set Variable   ${entry_limit}
+            ${vm_byte_limit}    Set Variable   ${byte_limit}
+        END
+        ${byte_rate}   Run Command    journalctl --since "$(date -d '${check_interval} seconds ago' '+%Y-%m-%d %H:%M:%S')" | wc -c | awk '{print $1}'
+        ${entries}     Run Command    journalctl --since "${check_interval} seconds ago" | wc -l
+        IF  ${entries} > ${vm_entry_limit} or ${byte_rate} > ${vm_byte_limit}
+            ${recent_logs}       Run Command        journalctl -n ${saved_entries}
+            Set To Dictionary    ${spam_logs}       ${vm}=${recent_logs}
+            Set To Dictionary    ${spam_metrics}    ${vm}=entries:${entries}_byterate:${byte_rate}_limits:${vm_entry_limit}/${vm_byte_limit}
+        ELSE
+            Set To Dictionary    ${ok_metrics}      ${vm}=entries:${entries}_byterate:${byte_rate}_limits:${vm_entry_limit}/${vm_byte_limit}
+        END
+    END
+    Log                VMs with acceptable logging rates:\n${ok_metrics}       console=True
+    Log                Log spamming detected in these VMs:\n${spam_metrics}    console=True
+    ${status}          Run Keyword And Return Status    Should Be Empty  ${spam_metrics}
+    IF  not ${status}
+        Log            Sample of ${saved_entries} log entries from VMs demonstrating too high logging rates
+        FOR  ${vm}  ${logs}  IN  &{spam_logs}
+            Log        ${vm}
+            Log        ${logs}
+        END
+        FAIL           meas interval: ${check_interval}s\ndefault entry limit: ${entry_limit}\ndefault byte limit: ${byte_limit}\ngui-vm entry limit: ${gui_vm_entry_limit}\ngui-vm byte limit: ${gui_vm_byte_limit}\n${spam_metrics}
+    END
+
 Validate Forward Secure Sealing
     [Documentation]   Run Forward Secure Sealing tests in all VMs
     [Tags]            SP-T353
@@ -82,40 +125,6 @@ Validate Forward Secure Sealing
         END
     END
     [Teardown]  Run Keyword If Test Failed   SKIP   Known issue: SSRCSP-7973
-
-Check logging rate
-    [Documentation]    Check that host or vms are not creating too much logs
-    [Tags]             SP-T359  log_rate  pre-merge  orin-agx  orin-agx-64  orin-nx
-    ${check_interval}  Set Variable   100
-    ${saved_entries}   Set Variable   100
-    ${entry_limit}     Set Variable   10000
-    ${byte_limit}      Set Variable   2000000
-    &{spam_metrics}    Create Dictionary
-    &{ok_metrics}      Create Dictionary
-    &{spam_logs}       Create Dictionary
-    FOR  ${vm}  IN  @{VM_LIST}
-        Switch to vm   ${vm}
-        ${byte_rate}   Run Command    journalctl --since "$(date -d '${check_interval} seconds ago' '+%Y-%m-%d %H:%M:%S')" | wc -c | awk '{print $1}'
-        ${entries}     Run Command    journalctl --since "${check_interval} seconds ago" | wc -l
-        IF  ${entries} > ${entry_limit} or ${byte_rate} > ${byte_limit}
-            ${recent_logs}       Run Command        journalctl -n ${saved_entries}
-            Set To Dictionary    ${spam_logs}       ${vm}=${recent_logs}
-            Set To Dictionary    ${spam_metrics}    ${vm}=entries:${entries}_byterate:${byte_rate}
-        ELSE
-            Set To Dictionary    ${ok_metrics}      ${vm}=entries:${entries}_byterate:${byte_rate}
-        END
-    END
-    Log                VMs with acceptable logging rates:\n${ok_metrics}       console=True
-    Log                Log spamming detected in these VMs:\n${spam_metrics}    console=True
-    ${status}          Run Keyword And Return Status    Should Be Empty  ${spam_metrics}
-    IF  not ${status}
-        Log            Sample of ${saved_entries} log entries from VMs demonstrating too high logging rates
-        FOR  ${vm}  ${logs}  IN  &{spam_logs}
-            Log        ${vm}
-            Log        ${logs}
-        END
-        FAIL           meas interval: ${check_interval}s\nentry limit: ${entry_limit}\nbyte limit: ${byte_limit}\n${spam_metrics}
-    END
 
 
 *** Keywords ***
@@ -140,15 +149,7 @@ Check Logs Are Available
             ${status}  Check VM Log on Grafana   ${id}   ${vm}   ${since}   log_entry=${word}
         END
 
-        # Logging from one VM sometimes stops during the run (SSRCSP-7612).
-        # To avoid failures in the pipelines the test checks for any logs during the last 10 minutes.
-        # 10 minutes should be enough to make sure that logs from previous run are not detected.
-        # When the bug is fixed the old version should be taken back into use.
         IF  $status == ${False}
-            IF  '${vm}' == '${NETVM_NAME}'
-                # Special case for net-vm SSRCSP-7542
-                Save net-vm log
-            END
             Append To List    ${failed_vms}    ${vm}
         END
     END
@@ -163,8 +164,3 @@ Create logs in all VMs
         ${out}   Run Command    journalctl --since "1 minute ago" | grep "${TEST_LOG}"
         Run Keyword And Continue On Failure   Should Contain  ${out}   ${TEST_LOG}   Log was not created in ${vm}
     END
-
-Save net-vm log
-    Switch to vm   ${NET_VM}
-    Run Command   journalctl -b
-    [Teardown]     Switch to vm   ${ADMIN_VM}

--- a/Robot-Framework/test-suites/update-tests/__init__.robot
+++ b/Robot-Framework/test-suites/update-tests/__init__.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       Update tests
-Test Tags           regression  update  lenovo-x1  darter-pro  excl-storeDisk  excl-secboot
+Test Tags           update  lenovo-x1  darter-pro  excl-storeDisk  excl-secboot
 
 Resource            ../../resources/setup_keywords.resource
 

--- a/Robot-Framework/test-suites/update-tests/update-tests.robot
+++ b/Robot-Framework/test-suites/update-tests/update-tests.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       Tests for update tooling
-
+Test Tags           cachix-update  regression
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/device_control.resource
 Resource            ../../resources/common_keywords.resource
@@ -12,7 +12,6 @@ Resource            ../../resources/setup_keywords.resource
 Resource            ../../resources/update_keywords.resource
 
 Test Teardown       Roll back to original generation
-Suite Teardown      Update Teardown
 Test Timeout        15 minutes
 
 
@@ -32,27 +31,6 @@ Update via givc-cli
 
 
 *** Keywords ***
-
-Update Teardown
-    # The update can leave log forwarding stuck, verify that logging to Grafana is still working
-    Switch to vm   ${ADMIN_VM}
-    ${id}          Get Actual Device ID
-    ${status}      Check VM Log on Grafana   ${id}   ${HOST}   15s
-    IF    not ${status}
-        Log    No recent logs found, recovering the logging service (Known issue: SSRCSP-8302)  console=True
-        # If no recent logs found in Grafana, restart alloy and clear its WAL
-        # The removed logs won't get forwarded to Grafana but are available on the device
-        Run Command    df -h   # For debugging
-        Run Command    systemctl stop alloy.service   sudo=True
-        Elevate to superuser   sleep=5
-        Write    rm -rf /var/lib/private/alloy/data-alloy/loki.write.remote/wal/*
-        Sleep    1
-        Run Command    systemctl start alloy.service   sudo=True
-        Run Command    df -h   # For debugging
-        # Check that logs are available
-        Log    Logging service restarted, checking for new logs   console=True
-        Run Keyword And Ignore Error   Wait Until Keyword Succeeds     15s   2s    Check VM Log on Grafana   ${id}   ${HOST}   15s   ${True}
-    END
 
 Update with
     [Arguments]           ${update_method}

--- a/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
+++ b/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
@@ -15,7 +15,6 @@ Resource            ../../resources/service_keywords.resource
 
 Suite Setup          Rebuild Setup
 Suite Teardown       Rebuild Teardown
-Test Teardown        Run Keyword If Test Failed   SKIP   Known issue: SSRCSP-8302
 
 *** Variables ***
 ${repository_path}      /persist/ghaf
@@ -76,6 +75,7 @@ Check audit update logging
     [Tags]                  SP-T276
     [Timeout]               10 minutes
     Switch to vm              ${HOST}
+    Run Keyword And Continue On Failure    Verify service status  range=10  service=nixos-rebuild-watch.service
     Elevate to superuser
     Run Nix Shell             git
     Log To Console            Modifying modules/development/debug-tools.nix
@@ -93,7 +93,6 @@ Check audit update logging
     ${found}  ${logs}         Get logs by key words   nixos_rebuild_store   ${log_search_window}s   ${False}
     Should Be True            ${found}    No 'nixos_rebuild_store' keywords found in Grafana from the time of nixos-rebuild.
     Log                       ${logs}
-    [Teardown]    Run Keyword If  '${watch_service_status}' != 'True'  Run Keyword If Test Failed  Skip  "Known issue: SSRCSP-8199"
 
 
 *** Keywords ***
@@ -135,8 +134,6 @@ Enable audit logging and nix-store-watch
     Run Nixos Rebuild         ${repository_path}  ${target_name}
 
     Switch to vm              ${HOST}
-    ${watch_service_status}   Run Keyword And Return Status    Verify service status  range=10  service=nixos-rebuild-watch.service
-    Set Suite variable        ${watch_service_status}
 
 Run Nixos Rebuild
     [Arguments]      ${repository_path}  ${target_name}  ${interrupt}=${EMPTY}

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -5,12 +5,10 @@
 | DATE SET   | TEST CASE                                               | TICKET / Additional Data.                                                                     |
 | ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | 21.04.2026 | Check Grafana logs, logging tests in security tests     | SSRCSP-8326                                                                                   |
-| 17.04.2026 | Rebuild tests skipped if they fail                      | SSRCSP-8302                                                                                   |
-| 08.04.2026 | Automatic suspension                                    | SSRCSP-8288                                                                                   |
+| 08.04.2026 | Automatic suspension (high power after suspension)      | SSRCSP-8288                                                                                   |
 | 30.03.2026 | Check Camera in VMs (Dell)                              | SSRCSP-8266                                                                                   |
 | 30.03.2026 | Check Camera Application (Dell checked in chrome-vm)    | SSRCSP-8266                                                                                   |
 | 23.03.2026 | Verify camera block persisted (Lenovo X1)               | SSRCSP-8224                                                                                   |
-| 18.03.2026 | Check audit update logging                              | SSRCSP-8199                                                                                   |
 | 26.02.2026 | Check systemctl status in every VM (retry added for NX) | Timeout of Executing command 'systemctl list-units --plain --no-legend --no-pager '.          |
 | 12.02.2026 | Account lockout after failed login                      | SSRCSP-8006                                                                                   |
 | 05.02.2026 | Validate Forward Secure Sealing                         | SSRCSP-7973                                                                                   |
@@ -30,6 +28,7 @@
 
 | DATE SET   | TEST CASE                                         | TICKET / Additional Data.                                                              |
 | ---------- | ------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| 24.04.2026 | Rebuild tests removed from regression             | Rebuild tests do not work properly with signed images                                  |
 | 27.02.2026 | Measure Soft Boot Time (Darter Pro)               | Test removed because the Enter finger causes inaccuracy to the result                  |
 | 20.02.2026 | Test ballooning in chrome-vm / business-vm        | Ballooning feature was turned off in ghaf by PR#1770                                   |
 | 04.12.2025 | Start Falcon AI and verify process started (Dell) | Test stucks with circle running on screen. Not relevant case for this HW target.       |


### PR DESCRIPTION
- Remove `regression` tag from rebuild tests, they don't work properly with the signed images.
- Remove logging skips from the update tests.
- Remove some stale code from logging tests related to old already removed skips.
- Add a new lower log limit for `Check logging rate`. Gui-vm is still sending a lot of logs, but other VMs are much more reasonable. With the old limit, this test would only fail if there were suddenly 90 extra logs per second in some VM. (We can raise the limits if they start failing unnecessarily, but it is good to notice and to be able to investigate)
- Reorder `Validate Forward Secure Sealing` to run after `Check logging rate`. The logging rate is based on the tests that run before it. `Validate Forward Secure Sealing` is not part of pre-merge tests, so the results differed between pre-merge and bat/regression.

Testruns
- Pre-merge and update tests with a signed image https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5623/
- Rebuild tests with non-signed image https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5624/