### PR TITLE
Verify power menu is opened

### DIFF
--- a/Robot-Framework/test-suites/gui-tests/gui_power_menu.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power_menu.robot
@@ -149,6 +149,11 @@ Select power menu option
     [Arguments]        ${text}=${EMPTY}   ${x}=0   ${y}=0   ${confirmation}=False   ${tabs}=1
     Log To Console     Opening power menu
     Locate and click   image  power.png  0.95  10
+    # Wait for menu to open and stop retrying when successful
+    ${menu_opened}     Run Keyword And Return Status   Locate on screen   text   Settings   iterations=3
+    IF  not ${menu_opened}
+        FAIL   Failed to open power menu: 'Settings' not visible.
+    END
     IF  '${text}'
         Locate and click   text   ${text}
     ELSE IF  ${x} != 0 and ${y} != 0


### PR DESCRIPTION
I did not manage to reproduce failed to open menu, but at least it works as expected with these changes:
[Lenovo X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5694/artifact/Robot-Framework/test-suites/SP-T75/log.html#s1-s1-s1-t4-k2-k4)
