### PR TITLE
Improve Verify shutdown via network

### DIFF
--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -136,18 +136,14 @@ Wake up device
         Log To Console   Device successfully woke up after suspend
     END
 
-Verify Laptop Shutdown
-    [Arguments]      ${timeout}=30
-    ${device_not_available}    Run Keyword And Return Status  Wait Until Keyword Succeeds  ${timeout}s  2s  Check If Ping Fails
-    IF  ${device_not_available} == True
-        Log To Console            Device is down
-    ELSE
-        FAIL                      Device didn't shut down
-    END
-
 Wait Until Device Is Down
+    [Arguments]    ${power_off}=${False}
     IF  not ${IS_LAPTOP} or "${SERIAL_PORT}" == "NONE"
-        ${time}   Verify shutdown via network
+        IF  ${power_off}
+            ${time}   Verify shutdown via network    required_down_count=1
+        ELSE
+            ${time}   Verify shutdown via network
+        END
     ELSE
         ${time}   Verify shutdown via serial
     END
@@ -156,21 +152,31 @@ Wait Until Device Is Down
 Verify shutdown via network
     [Documentation]    Check ping and port 22 until device stops responding both.
     ...                "Connection refused" is NOT considered as powered off.
-    [Arguments]        ${timeout}=60
-    ${start_time}      Get Time    epoch
-    FOR    ${i}    IN RANGE    ${timeout}
-        ${nc}     Run Process    nc    -zvw1    ${DEVICE_IP_ADDRESS}    22    stderr=STDOUT    shell=False
-        Log       rc ${nc.rc} \n${nc.stdout}
-        ${ping}   Run Process  ping  ${DEVICE_IP_ADDRESS}  -c1  -W  1  timeout=3s
-        Log       rc ${ping.rc} \n${ping.stdout}
-
-        IF    ${ping.rc} == 1 and 'Connection timed out' in '''${nc.stdout}'''
-            ${diff}   Evaluate    int(time.time()) - int(${start_time})
-            Log       Device at ${DEVICE_IP_ADDRESS} stopped responding ping in ${diff} seconds.    console=True
-            ${time}   BuiltIn.Get Time   epoch
+    [Arguments]        ${iterations}=60    ${required_down_count}=3
+    ${start_time}      Get Time        epoch
+    ${down_count}    Set Variable    0
+    FOR    ${i}    IN RANGE    ${iterations}
+        ${ping}    Run Process    ping    ${DEVICE_IP_ADDRESS}    -c1    -W    1    timeout=3s
+        Log        rc ${ping.rc} \n${ping.stdout}
+        IF    ${ping.rc} == 1
+            Sleep    ${PING_SPACING}
+            ${nc}    Run Process    nc    -zvw1    ${DEVICE_IP_ADDRESS}    22    stderr=STDOUT    shell=False
+            Log      rc ${nc.rc} \n${nc.stdout}
+            IF    'Connection timed out' in '''${nc.stdout}'''
+                ${down_count}    Evaluate    int(${down_count}) + 1
+                Log    Down count: ${down_count}    console=True
+            ELSE
+                ${down_count}    Set Variable    0
+            END
+        ELSE
+            ${down_count}    Set Variable    0
+        END
+        IF    ${down_count} >= ${required_down_count}
+            Log       Device at ${DEVICE_IP_ADDRESS} didn't respond to ${required_down_count} consecutive ping/nc cycles.    console=True
+            ${time}   BuiltIn.Get Time    epoch
             RETURN    ${time}
         END
-        Sleep    1s
+        Sleep    ${PING_SPACING}
     END
     ${diff}    Evaluate    int(time.time()) - int(${start_time})
     Fail       Device at ${DEVICE_IP_ADDRESS} still responds after ${diff} seconds.

--- a/Robot-Framework/test-suites/performance-tests/boot_time.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time.robot
@@ -52,7 +52,7 @@ Measure Orin Hard Boot Time
     [Tags]           SP-T182  SP-T182-2  orin-agx  orin-agx-64  orin-nx  lab-only
     Log To Console                Shutting down by switching the power off
     Turn Off Power
-    Wait Until Device Is Down
+    Wait Until Device Is Down     power_off=${True}
     Close All Connections
     Log To Console                The device has shut down
     Log To Console                Booting the device by switching the power on


### PR DESCRIPTION
Change the logic in `Verify shutdown via network`. Iterate only ping and only if response to ping stops check also that nc does not get reply. Require 3 consecutive ping + nc cycles to fail. (Note: This can cause some more inaccuracy for boot time tests on laptops, reboot appearing to be 0 - 3 sec faster.)

Remove unused `Verify Laptop Shutdown`


Test runs:

**Darter-Pro**
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5742/
Measure Soft Boot Time - Soft Reboot Device - Verify shutdown via network
This is interesting: There are 2 consecutive iterations (6, 7) where both ping and nc get no reply but then on the 8th iteration nc gets "Connection refused" and from then on ping is again alive more than 10 iterations. At last there are 3 consecutive iterations where both ping and nc get no reply and the keyword exits.

https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5748/
Persistence Suite Setup - Verify shutdown via network 
Here the shutdown is straightforward and faster. No intermediate pings which would go without reply.

**Lenovo-X1**
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5751/
Persistence Suite Setup - Verify shutdown via network 
Also here we see that both ping and nc didn't get response at 7th iteration but after that ping again works for a good while.

**Orin-NX**
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5757/

**Dell**
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5758/
(After adding logging for "down count")
`Measure Soft Boot Time` test failed here but `Verify shutdown via network` worked as it should. The keyword detected some non-resonded ping / nc iterations in between but ping reply didn't stop permanently. See: 
```
10:32:09  Measure Soft Boot Time :: Measure how long it takes to device to b... Switched to ghaf-host as ghaf
10:32:14  Rebooting device from command line
10:32:26  Down count: 1
10:32:49  Down count: 1
10:32:52  Down count: 2
10:33:39  Down count: 1
10:34:12  
10:34:12  Shutting down by pressing the power button
10:34:27  Down count: 1
10:34:30  Down count: 2
10:34:34  Down count: 3
```