### PR TITLE
Add new test for access list

### DIFF
--- a/Robot-Framework/lib/GuiTesting.py
+++ b/Robot-Framework/lib/GuiTesting.py
@@ -18,12 +18,44 @@ def locate_image(screenshot, image, confidence):
     logging.info(image_center_in_mouse_coordinates)
     return image_center_in_mouse_coordinates
 
-def locate_text(screenshot, text, scale=1):
-    logging.info("Searching " + text)
-    image = Image.open(screenshot)
+def get_data_from_image(image, scale=1):
+    image = Image.open(image)
     image = image.resize((image.width * scale, image.height * scale), Image.BICUBIC)
     data = pytesseract.image_to_data(image, output_type=pytesseract.Output.DICT)
     logging.info(data)
+    return data
+
+def get_text(data: pytesseract.Output.DICT):
+    text_list = []
+    sentence = []
+
+    for word in data['text']:
+        if word == "":
+            if sentence:
+                text_list.append(' '.join(sentence))
+                sentence.clear()
+        else:
+            sentence.append(word)
+
+    if sentence:
+        text_list.append(' '.join(sentence))
+
+    logging.info(text_list)
+    return text_list
+
+def is_text_on_the_screen(screenshot, text, scale=1):
+    logging.info("Searching " + text)
+    data = get_data_from_image(screenshot, scale)
+
+    for sentence in get_text(data):
+        if text in sentence:
+            return True
+
+    return False
+
+def locate_text(screenshot, text, scale=1):
+    logging.info("Searching " + text)
+    data = get_data_from_image(screenshot, scale)
 
     # Loop through results to find matching text
     for i, word in enumerate(data['text']):

--- a/Robot-Framework/resources/app_keywords.resource
+++ b/Robot-Framework/resources/app_keywords.resource
@@ -20,7 +20,7 @@ ${APP_OUTPUT_FILE}   /home/${USER_LOGIN}/output.log
 Start application in VM
     [Documentation]    Use always_check_vm=True if calling from tests other than functional
     ...                After calling for this keyword use "Kill App in VM" in the test teardown
-    [Arguments]    ${app_name}   ${app-vm}   ${process_name}   ${always_check_vm}=False
+    [Arguments]    ${app_name}   ${app-vm}   ${process_name}   ${always_check_vm}=False    ${params_string}=${EMPTY}
     Set Test Variable    ${TEST_APP-VM}         ${app-vm}
     Set Test Variable    ${TEST_PROCESS_NAME}   ${process_name}
 
@@ -29,7 +29,7 @@ Start application in VM
     Check that the application is not running   ${process_name}  1
     
     Switch to vm   ${GUI_VM}  user=${USER_LOGIN}
-    Start application   ${app_name}
+    Start application   ${app_name}     params_string=${params_string}
     IF   '${app-vm}' != '${GUI_VM}'   Switch to vm   ${app-vm}
     Check that the application was started    ${process_name}  5
 
@@ -44,9 +44,9 @@ Check that appVM is running
     Log    ${RUNNING_VMS}
 
 Start application
-    [Arguments]      ${app_name}
+    [Arguments]      ${app_name}    ${params_string}=${EMPTY}
     Log    Starting ${app_name}   console=True
-    Run Command  nohup sh -c 'ghaf-open ${app_name}' > ${APP_OUTPUT_FILE} 2>&1 &
+    Run Command  nohup sh -c 'ghaf-open ${app_name} ${params_string}' > ${APP_OUTPUT_FILE} 2>&1 &
 
 Check that the application was started
     [Arguments]    ${process_name}  ${range}=2

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -106,6 +106,20 @@ Tab and enter
     END
     Press Key(s)       ENTER
 
+Take Remote Screenshot And Download
+    [Arguments]    ${from}=${SCREENSHOT_GHAF}     ${to}=${SCREENSHOT_LOCAL}
+    Run Command             mkdir -p test-images
+    ${_}  ${screenshot}     Take a screenshot
+    SSHLibrary.Get File     ${from}  ${to}
+
+    RETURN    ${to}
+
+Verify Text Is On The Screen
+    [Arguments]    ${text}
+    ${screenshot_path}=     Take Remote Screenshot And Download
+    ${is_visible}=          Is Text On The Screen   ${screenshot_path}   ${text}
+    Should Be True          ${is_visible}           msg=Text '${text}' was not found on the screen
+
 Locate on screen
     [Documentation]    Take a screenshot. Locate given image or text on the screenshot.
     ...                Return center coordinates of the item in mouse coordinate system.
@@ -115,7 +129,8 @@ Locate on screen
     ${locate_status}=      Set Variable  FAIL
     Run Command            mkdir -p test-images
     FOR   ${i}   IN RANGE  ${iterations}
-        ${screenshot_status}  ${result}     Take a screenshot   ${i+1}
+        Log To Console           Taking a screenshot (#${i+1})...  no_newline=True
+        ${screenshot_status}  ${result}     Take a screenshot
         IF  '${screenshot_status}' == 'PASS'
             Log To Console       Done, locating ${type} ${searched_item} on screenshot
             SSHLibrary.Get File  ${SCREENSHOT_GHAF}  ${SCREENSHOT_LOCAL}
@@ -149,8 +164,6 @@ Locate on screen
     END
 
 Take a screenshot
-    [Arguments]   ${attempt}=0
-    Log To Console           Taking a screenshot (#${attempt})...  no_newline=True
     ${screenshot_status}  ${result}   Run Keyword And Ignore Error  Run Command  WAYLAND_DISPLAY=wayland-1 grim -t jpeg -q 100 ${SCREENSHOT_GHAF}   timeout=5
     ${LAST_SCREENSHOT_TIME}  Evaluate    time.time()
     Set Global Variable      ${LAST_SCREENSHOT_TIME}

--- a/Robot-Framework/test-suites/gui-tests/gui_security.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_security.robot
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2022-2026 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Settings ***
+Documentation       Testing security via GUI
+Force Tags          gui-security
+
+Test Timeout        10 minutes
+Resource            ../../resources/ssh_keywords.resource
+Resource            ../../resources/common_keywords.resource
+Resource            ../../resources/app_keywords.resource
+Resource            ../../resources/gui_keywords.resource
+
+Test Setup          Run keywords      Start screen recording
+Test Teardown       Run keywords      Switch to vm            ${GUI_VM}  user=${USER_LOGIN}        AND
+...                                   Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
+
+*** Test Cases ***
+Check Access List In Trusted Browser
+    [Tags]    SP-T362   SP-T210  SP-T209  SP-T211   lenovo-x1  darter-pro
+    [Template]    Check Access List In Trusted Browser Template
+    # Pages outside access list shouldn't be available via Trusted Browser. Http and https has different errors
+    https://yle.fi                          text_to_find=This site can’t be reached
+    http://yle.fi                           text_to_find=Access Denied
+
+    # Access List consist of several files with multiple sections. These pages are 1 per section.
+    https://graph.microsoft.com             text_to_find=Microsoft Graph
+    https://excel.cloud.microsoft.com       text_to_find=Welcome to Excel
+    https://word.cloud.microsoft            text_to_find=Welcome to Word
+    https://powerpoint.cloud.microsoft      text_to_find=start using PowerPoint
+    https://teams.live.com                  text_to_find=Video calls with anyone
+    https://www.msn.com                     text_to_find=MSN
+    https://onedrive.live.com               text_to_find=Microsoft 365
+    https://www.akamai.com/                 text_to_find=Akamai
+    https://ghaflogs.vedenemo.dev           text_to_find=Welcome to Grafana
+    https://www.google.com                  text_to_find=Google
+    https://thenationalnews.com             text_to_find=The National
+    https://access.clarivate.com            text_to_find=innovation at Clarivate
+    https://hcm22.sapsf.com                 text_to_find=SAP SuccessFactors
+    https://jira.atlassian.com              text_to_find=Jira Software
+
+*** Keywords ***
+
+Check Access List In Trusted Browser Template
+    [Documentation]    Running Trusted Browser and trying to find text on the opened page.
+    ...                If page is blocked by access list, error depends on the protocol used:
+    ...                   https: 'This site can’t be reached'
+    ...                   http:  'Access Denied'
+    [Arguments]    ${url}   ${text_to_find}
+    Start application in VM   "Trusted Browser"   ${BUSINESS_VM}   google-chrome    params_string=-- ${url}    always_check_vm=True
+    Switch to vm              ${GUI_VM}    user=${USER_LOGIN}
+
+    Wait Until Keyword Succeeds     10x                        1s
+    ...                             Verify Text Is On The Screen    ${text_to_find}
+
+    [Teardown]    Run keywords      Switch to vm           ${BUSINESS_VM}    AND
+    ...                             Kill process by name   google-chrome


### PR DESCRIPTION
New test opens trusted browser, goes to the URL and looks for the text on the page.

yle.fi shouldn't be available, so test looks for the text of error.
HTTP and HTTPS have different errors by design.

Access list consist of 3 files, each file has multiple sections. Each URL for positive testing represents one section.

[Lenovo](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5729/artifact/Robot-Framework/test-suites/SSRCSP-T362/log.html)
[Darter](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5728/artifact/Robot-Framework/test-suites/SSRCSP-T362/log.html)