### PR TITLE
Disable falcon ai test

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -17,7 +17,7 @@ Test Setup          Switch to vm    ${GUI_VM}  user=${USER_LOGIN}
 
 Start Falcon AI
     [Documentation]   Start Falcon AI and verify process started
-    [Tags]            SP-T223  falcon_ai  lenovo-x1  darter-pro
+    [Tags]            SP-T223  falcon_ai
     Get Falcon LLM Name
     Start application  "Falcon AI"
     Wait Until Falcon Download Complete

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -27,11 +27,12 @@
 
 ## TAGs removed
 
-| DATE SET   | TEST CASE                                         | TICKET / Additional Data.                                                              |
-| ---------- | ------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| 24.04.2026 | Rebuild tests removed from regression             | Rebuild tests do not work properly with signed images                                  |
-| 27.02.2026 | Measure Soft Boot Time (Darter Pro)               | Test removed because the Enter finger causes inaccuracy to the result                  |
-| 20.02.2026 | Test ballooning in chrome-vm / business-vm        | Ballooning feature was turned off in ghaf by PR#1770                                   |
-| 04.12.2025 | Start Falcon AI and verify process started (Dell) | Test stucks with circle running on screen. Not relevant case for this HW target.       |
-| 03.09.2025 | Performance/network suite (AGX)                   | SSRCSP-7160. Network-adapter usage had impact on results. Needs further investigation. |
-| 03/2025    | Performance Network.robot - ‘orin-nx’             | SSRCSP-6372 - Works locally but problems when Jenkins used, fails all..                |
+| DATE SET   | TEST CASE                                         | TICKET / Additional Data.                                                                 |
+|------------|---------------------------------------------------|-------------------------------------------------------------------------------------------|
+| 24.04.2026 | Rebuild tests removed from regression             | Rebuild tests do not work properly with signed images                                     |
+| 27.02.2026 | Measure Soft Boot Time (Darter Pro)               | Test removed because the Enter finger causes inaccuracy to the result                     |
+| 20.02.2026 | Test ballooning in chrome-vm / business-vm        | Ballooning feature was turned off in ghaf by PR#1770                                      |
+| 04.12.2025 | Start Falcon AI and verify process started (Dell) | Test stucks with circle running on screen. Not relevant case for this HW target.          |
+| 04.05.2026 | Start Falcon AI and verify process started (All)  | Falcon AI fails to answer because of too low memory (gui-vm memory was decreased to 8GB.) |
+| 03.09.2025 | Performance/network suite (AGX)                   | SSRCSP-7160. Network-adapter usage had impact on results. Needs further investigation.    |
+| 03/2025    | Performance Network.robot - ‘orin-nx’             | SSRCSP-6372 - Works locally but problems when Jenkins used, fails all..                   |


### PR DESCRIPTION
The test fails because of too low memory in gui-vm. Falcon will be also soon disabled in default ghaf.