### PR TITLE
Update persistence skips

### DIFF
--- a/Robot-Framework/test-suites/security-tests/persistence.robot
+++ b/Robot-Framework/test-suites/security-tests/persistence.robot
@@ -30,6 +30,8 @@ Verify camera block persisted
     [Tags]    SP-T305  SP-T305-1
     ${cam_state}      Get device state   cam
     Should Be Equal   ${EXPECTED_CAM_STATE}  ${cam_state}
+    [Teardown]   Run Keyword If Test Failed   Run Keywords   Log persistence setup errors
+    ...    AND   Run Keyword If   "${DEVICE_TYPE}" == "lenovo-x1"   SKIP   Known issue: SSRCSP-8224
 
 Verify microphone block persisted
     [Tags]    SP-T305  SP-T305-2
@@ -50,7 +52,6 @@ Verify brightness persisted
     [Tags]    SP-T326  SP-T326-1
     ${brightness}     Get screen brightness
     Should Be Equal   ${EXPECTED_BRIGHTNESS}  ${brightness}
-    [Teardown]    Run Keyword If Test Failed   SKIP   Known issue: SSRCSP-8347
 
 Verify volume persisted
     [Tags]    SP-T326  SP-T326-2

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -5,11 +5,11 @@
 | DATE SET   | TEST CASE                                               | TICKET / Additional Data.                                                                     |
 | ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | 30.04.2026 | Open PDF from VM                                        | SSRCSP-8367                                                                                   |
-| 27.04.2026 | Verify brightness persisted                             | SSRCSP-8347                                                                                   |
 | 24.04.2026 | GUI Shutdown & GUI Reboot                               | SSRCSP-8341                                                                                   |
 | 08.04.2026 | Automatic suspension (high power after suspension)      | SSRCSP-8288                                                                                   |
 | 30.03.2026 | Check Camera in VMs (Dell)                              | SSRCSP-8266                                                                                   |
 | 30.03.2026 | Check Camera Application (Dell checked in chrome-vm)    | SSRCSP-8266                                                                                   |
+| 23.03.2026 | Verify camera block persisted (Lenovo X1)               | SSRCSP-8224                                                                                   |
 | 26.02.2026 | Check systemctl status in every VM (retry added for NX) | Timeout of Executing command 'systemctl list-units --plain --no-legend --no-pager '.          |
 | 12.02.2026 | Account lockout after failed login                      | SSRCSP-8006                                                                                   |
 | 05.02.2026 | Validate Forward Secure Sealing                         | SSRCSP-7973                                                                                   |


### PR DESCRIPTION
- `Verify brightness persisted` was fixed https://github.com/tiiuae/ghaf/pull/1916 -> remove skip
- `Verify camera block persisted` failed again in the nightly pipeline on X1 -> add skip back

https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5804/