### PR TITLE
Refactor account lockout after failed login

### DIFF
--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -162,7 +162,7 @@ Verify shutdown via network
             Sleep    ${PING_SPACING}
             ${nc}    Run Process    nc    -zvw1    ${DEVICE_IP_ADDRESS}    22    stderr=STDOUT    shell=False
             Log      rc ${nc.rc} \n${nc.stdout}
-            IF    'Connection timed out' in '''${nc.stdout}'''
+            IF    ${nc.rc} == 1
                 ${down_count}    Evaluate    int(${down_count}) + 1
                 Log    Down count: ${down_count}    console=True
             ELSE

--- a/Robot-Framework/resources/security_blacklist_keywords.resource
+++ b/Robot-Framework/resources/security_blacklist_keywords.resource
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2022-2026 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Settings ***
+Documentation       Shared keywords for external blacklisting checks and recovery
+Resource            ../resources/common_keywords.resource
+Resource            ../resources/ssh_keywords.resource
+Resource            ../resources/serial_keywords.resource
+
+
+*** Keywords ***
+
+Verify NetVM Blacklist Contains IP Via Serial
+    [Documentation]    Verify that the provided IP is found from net-vm's ${blacklist} via serial tunnel.
+    [Arguments]        ${ip}  ${blacklist}=BLACKLIST
+    Log                Checking via serial that ${blacklist} contains the attacker IP    console=True
+    ${output}          Run Command on VM Via Serial    ${NET_VM}    echo ${PASSWORD} | sudo -S ipset list ${blacklist}
+    Should Contain     ${output}    ${ip}     Blacklist doesn't contain the attacker's IP.
+
+Clear NetVM Blacklist Via Serial
+    [Documentation]    Remove the attacker IP from net-vm ${blacklist} using serial access.
+    [Arguments]        ${ip}  ${blacklist}=BLACKLIST   ${proto}=ICMP
+    Log                Trying to remove the attacker IP from ${blacklist} via serial     console=True
+    Run Command on VM Via Serial   ${NET_VM}   echo ${PASSWORD} | sudo -S ipset del ${blacklist} ${ip}
+    IF    $proto == 'SSH'
+        Unban IP Address Via Serial    ${ip}
+    END
+    Wait Until Keyword Succeeds    5x    5s    Verify External Connectivity Restored    ${proto}
+
+Unban IP Address Via Serial
+    [Arguments]        ${ip}
+    Log                Trying to unban the attacker IP via serial     console=True
+    Run Command on VM Via Serial   ${NET_VM}   echo ${PASSWORD} | sudo -S fail2ban-client set sshd unbanip ${ip}
+    Verify IP Is Not Banned In Fail2ban Jail Via Serial    ${ip}
+    Verify External Connectivity Restored    SSH
+
+Verify IP Is Not Banned In Fail2ban Jail Via Serial
+    [Documentation]    Verify that the IP is not listed in fail2ban sshd jail banned IP list.
+    [Arguments]        ${ip}  ${jail}=sshd
+    ${output}          Run Command on VM Via Serial    ${NET_VM}    echo ${PASSWORD} | sudo -S fail2ban-client status ${jail}
+    Should Contain     ${output}    Banned IP list:
+    Should Not Match Regexp    ${output}    (?m)^\\s*`- Banned IP list:\\s*.*\\b${ip}\\b
+
+Verify External Connectivity Restored
+    [Documentation]    Verify that the attacker IP was removed from net-vm ${blacklist} by checking connection.
+    ...                Available protocols: ICMP, SSH.
+    [Arguments]        ${proto}=ICMP
+    Log                Verify that the attacker IP is not blocked anymore     console=True
+    IF    $proto == 'ICMP'
+        ${output}          Run Process    sh   -c   ping -c 2 ${DEVICE_IP_ADDRESS}   shell=true
+        Should Be Equal As Integers       ${output.rc}    0     No connection to ${DEVICE_IP_ADDRESS} with ${proto} protocol
+    ELSE IF    $proto == 'SSH'
+        Switch to vm    ${NET_VM}
+    END
+
+Get External Attacker IP
+    [Documentation]    Return source IP that the test agent uses to reach the target device.
+    ${output}          Run Process    sh   -c   /run/current-system/sw/bin/ip route get ${DEVICE_IP_ADDRESS}   shell=true
+    Should Be Equal As Integers       ${output.rc}    0    Failed to resolve route to ${DEVICE_IP_ADDRESS}
+    ${ext_attacker_ip}   Get Source Ip For Route    ${output.stdout}
+    RETURN    ${ext_attacker_ip}

--- a/Robot-Framework/test-suites/security-tests/firewall.robot
+++ b/Robot-Framework/test-suites/security-tests/firewall.robot
@@ -8,10 +8,11 @@ Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/setup_keywords.resource
 Resource            ../../resources/serial_keywords.resource
+Resource            ../../resources/security_blacklist_keywords.resource
 Library             OperatingSystem
 
 Suite Setup         Suite Setup
-
+Suite Teardown      Blacklist Teardown
 
 *** Variables ***
 ${port}             5432
@@ -50,7 +51,7 @@ Check that internal tcp syn flooding triggers blacklisting
     [Teardown]      Run Keyword If Test Failed    Blacklist Teardown
 
 Check that external ping flooding triggers blacklisting
-    [Tags]            SP-T299  SP-T299-3  darter-pro  orin-agx  orin-nx  lab-only
+    [Tags]            SP-T299  SP-T299-3  lenovo-x1  darter-pro  orin-agx  orin-nx  lab-only
     [Documentation]   Validate that ping flooding from the test agent to net-vm triggers firewall blacklisting.
     ${ext_attacker_ip}    Get External Attacker IP
     External Ping Flood NetVM
@@ -59,7 +60,7 @@ Check that external ping flooding triggers blacklisting
     [Teardown]      Run Keyword If Test Failed    Blacklist Teardown
 
 Check that external tcp syn flooding triggers blacklisting
-    [Tags]            SP-T299  SP-T299-4  darter-pro  orin-agx  orin-nx  lab-only
+    [Tags]            SP-T299  SP-T299-4  lenovo-x1  darter-pro  orin-agx  orin-nx  lab-only
     [Documentation]   Validate that tcp syn probing from the test agent to net-vm triggers firewall blacklisting.
     ${ext_attacker_ip}    Get External Attacker IP
     Tcp Syn Flood         ${DEVICE_IP_ADDRESS}
@@ -213,30 +214,6 @@ Check And Clear Blacklist
     Check Attacker IP on Blacklist  ${vm}
     Run Command        ipset del BLACKLIST ${attacker_ip}    sudo=True
     Check Attacker IP on Blacklist  ${vm}   expect_blacklisting=${False}
-
-Verify NetVM Blacklist Contains IP Via Serial
-    [Arguments]        ${ip}
-    [Documentation]    Verify that the provided IP is found from net-vm's BLACKLIST via serial tunnel.
-    ${output}=         Run Command on VM Via Serial    ${NET_VM}    echo ${PASSWORD} | sudo -S ipset list BLACKLIST
-    Should Contain     ${output}    ${ip}
-
-Clear NetVM Blacklist Via Serial
-    [Arguments]        ${ip}
-    [Documentation]    Remove the attacker IP from net-vm BLACKLIST using serial access.
-    Run Command on VM Via Serial    ${NET_VM}    echo ${PASSWORD} | sudo -S ipset del BLACKLIST ${ip}
-    Wait Until Keyword Succeeds    5x    5s    Verify External Connectivity Restored    ${ip}
-
-Verify External Connectivity Restored
-    [Arguments]    ${ip}
-    ${output}    Run Process    sh   -c   ping -c 2 ${DEVICE_IP_ADDRESS}   shell=true
-    Should Be Equal As Integers    ${output.rc}    0     Ping to ${DEVICE_IP_ADDRESS} failed
-
-Get External Attacker IP
-    [Documentation]    Return source IP that the test agent uses to reach the target device.
-    ${output}    Run Process    sh   -c   /run/current-system/sw/bin/ip route get ${DEVICE_IP_ADDRESS}   shell=true
-    Should Be Equal As Integers    ${output.rc}    0    Failed to resolve route to ${DEVICE_IP_ADDRESS}
-    ${ext_attacker_ip}   Get Source Ip For Route    ${output.stdout}
-    RETURN    ${ext_attacker_ip}
 
 External Ping Flood NetVM
     [Documentation]    Trigger ICMP flood from the agent towards net-vm interface.

--- a/Robot-Framework/test-suites/security-tests/network.robot
+++ b/Robot-Framework/test-suites/security-tests/network.robot
@@ -7,20 +7,23 @@ Test Tags           network-security
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/wifi_keywords.resource
 Resource            ../../resources/common_keywords.resource
+Resource            ../../resources/device_control.resource
+Resource            ../../resources/setup_keywords.resource
+Resource            ../../resources/security_blacklist_keywords.resource
 
 
 *** Test Cases ***
 
 Account lockout after failed login
-    [Documentation]  Try to connect from Comms-vm to Chrome-vm with a wrong password for several times, then check that
-    ...              Comms-vm's ip is blacklisted in Chrome-vm and it is not possible to connect even with correct password
-    [Tags]           SP-T268  lenovo-x1  darter-pro
-    Switch to vm     ${COMMS_VM}
-    ${ip}            Get VM IP
-    Try to connect with wrong password    ${CHROME_VM}  jumphost=${COMMS-VM_GHAF_SSH}
-    Check ip is in the blacklist  ${CHROME_VM}  ${ip}
-    [Teardown]    Run Keywords  Remove from the blacklist  ${ip}
-    ...           AND   Run Keyword If Test Failed    Skip  "Known Issue: SSRCSP-8006"
+    [Documentation]  Try to connect from the external test agent to the device with a wrong password for several times, then check that
+    ...              test agent's ip is blacklisted in net-vm and it is not possible to connect even with correct password.
+    ...              Remove IP from blacklist via serial and verify SSH connectivity is restored.
+    [Tags]           SP-T268  lenovo-x1  darter-pro  lab-only
+    ${ip}            Get External Attacker IP
+    Try External Login With Wrong Password
+    Verify NetVM Blacklist Contains IP Via Serial    ${ip}   f2b-sshBlacklist
+    Unban IP Address Via Serial                      ${ip}
+    [Teardown]       Account lockout teardown
 
 Check OpenSSL3 is Available In Nix Store
     [Documentation]  Connect to GUI-VM and check that OpenSSL3 is available in NixStore.
@@ -31,28 +34,29 @@ Check OpenSSL3 is Available In Nix Store
 
 *** Keywords ***
 
-Try to connect with wrong password
-    [Arguments]   ${vm_name}    ${user}=${LOGIN}   ${pw}=${PASSWORD}   ${jumphost}=None   ${timeout}=10
-    ${connection}       Open Connection    ${vm_name}    port=22    prompt=\$    timeout=${timeout}
+Try External Login With Wrong Password
+    [Arguments]     ${user}=${LOGIN}   ${pw}=${PASSWORD}   ${timeout}=10
+    ${connection}   Open Connection    ${DEVICE_IP_ADDRESS}    port=22    prompt=\$    timeout=${timeout}
     FOR    ${i}    IN RANGE     5
         TRY
-            ${status}  ${login_output}   Run Keyword And Ignore Error  Login with timeout  expected_output=${vm_name}  username=${user}  password=wrong  timeout=${timeout}  jumphost=${jumphost}
+            Log To Console    Trying to log in with the wrong password
+            ${status}  ${login_output}   Run Keyword And Ignore Error  Login with timeout  expected_output=${NET_VM}  username=${user}  password=wrong  timeout=${timeout}
         EXCEPT    Keyword timeout ${timeout} seconds exceeded.
             BREAK
         END
     END
     TRY
-        Run Keyword And Ignore Error  Login with timeout  expected_output=${vm_name}  username=${user}  password=${pw}  timeout=${timeout}  jumphost=${jumphost}
+        Log To Console    Trying to log in with the correct password
+        Run Keyword And Ignore Error  Login with timeout  expected_output=${NET_VM}  username=${user}  password=${pw}  timeout=${timeout}
     EXCEPT    Keyword timeout ${timeout} seconds exceeded.
-        Log   Failed to connect with correct password in ${timeout} seconds.
+        Log   Failed to connect with correct password in ${timeout} seconds.    console=True
     END
+    Close Connection
 
-Check ip is in the blacklist
-    [Arguments]     ${vm}  ${ip}
-    Switch to vm    ${vm}
-    ${output} 	    Run Command    ipset list f2b-sshBlacklist   sudo=True
-    Should contain  ${output}    ${ip}
-
-Remove from the blacklist
-    [Arguments]      ${ip}
-    Run Command  ipset del f2b-sshBlacklist ${ip}   sudo=True
+Account lockout teardown
+    Close All Connections
+    # findTime for fail2ban service is 60 sec, wait to avoid being banned again
+    Reboot Laptop      delay=60  verify_shutdown=False
+    Check If Device Is Up
+    Verify External Connectivity Restored    SSH
+    Login to laptop

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -11,7 +11,6 @@
 | 30.03.2026 | Check Camera Application (Dell checked in chrome-vm)    | SSRCSP-8266                                                                                   |
 | 23.03.2026 | Verify camera block persisted (Lenovo X1)               | SSRCSP-8224                                                                                   |
 | 26.02.2026 | Check systemctl status in every VM (retry added for NX) | Timeout of Executing command 'systemctl list-units --plain --no-legend --no-pager '.          |
-| 12.02.2026 | Account lockout after failed login                      | SSRCSP-8006                                                                                   |
 | 05.02.2026 | Validate Forward Secure Sealing                         | SSRCSP-7973                                                                                   |
 | 11.02.2026 | Check device id                                         | SSRCSP-7997                                                                                   |
 | 11.02.2026 | Check net-vm hostname                                   | SSRCSP-7997                                                                                   |


### PR DESCRIPTION
to be merged after https://github.com/tiiuae/ghaf/pull/1930

- Modified  "Account lockout after failed login" test to check that external connection with wrong password.
- Added lenovo-x1 target to External flooding tests
- Moved related keywords to the dedicated resource file
- Modified 'Verify shutdown via network' keyword because sometimes netcat returns different error but RC code is 1, it was not considered before, so reboot could be missed.

Tested with https://github.com/tiiuae/ghaf/pull/1930 :
[Darter Pro](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5858/)
[Lenovo X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5855/)