### PR TITLE
Skip ghaf-journal-alloy-recover.service in all VMs on Orin

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/vm.robot
@@ -30,7 +30,7 @@ Suite Setup         VM Suite Setup
              ...    orin|ghaf-host|systemd-oomd.service|SSRCSP-6685
              ...    orin|admin-vm|stunnel.service|SSRCSP-8067
              ...    orin|ANY|alloy.service|SSRCSP-8071
-             ...    orin|admin-vm|ghaf-journal-alloy-recover.service|SSRCSP-8071
+             ...    orin|ANY|ghaf-journal-alloy-recover.service|SSRCSP-8071
              ...    darter-pro|ghaf-host|systemd-tpm2-setup.service|SSRCSP-8357
 
 # Container for test message. Keyword `Set Test Message` doesn't work properly with Templates.


### PR DESCRIPTION
Previosly service was only in admin-vm so it also only failed randomly in the admin-vm. Now it is in every VM.