### PR TITLE
Temporary skip for logging

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/logging.robot
+++ b/Robot-Framework/test-suites/functional-tests/logging.robot
@@ -64,6 +64,7 @@ Check Grafana logs
             FAIL   Failed to find any logs since last boot for one or more VMs.\nVMs missing all logs since last boot: ${failed_vms_check_2}
         END
     END
+    [Teardown]    Run Keyword If Test Failed    SKIP    Known issue, rate limit exceeded. Fix under work.
 
 Check logging rate
     [Documentation]    Check that host or vms are not creating too much logs

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -4,6 +4,7 @@
 
 | DATE SET   | TEST CASE                                               | TICKET / Additional Data.                                                                     |
 | ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| 07.05.2026 | Check Grafana logs                                      | Known issue, rate limit exceeded. Fix under work.                                             |
 | 30.04.2026 | Open PDF from VM                                        | SSRCSP-8367                                                                                   |
 | 24.04.2026 | GUI Shutdown & GUI Reboot                               | SSRCSP-8341                                                                                   |
 | 08.04.2026 | Automatic suspension (high power after suspension)      | SSRCSP-8288                                                                                   |
@@ -27,7 +28,7 @@
 ## TAGs removed
 
 | DATE SET   | TEST CASE                                         | TICKET / Additional Data.                                                                 |
-|------------|---------------------------------------------------|-------------------------------------------------------------------------------------------|
+| ---------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | 24.04.2026 | Rebuild tests removed from regression             | Rebuild tests do not work properly with signed images                                     |
 | 27.02.2026 | Measure Soft Boot Time (Darter Pro)               | Test removed because the Enter finger causes inaccuracy to the result                     |
 | 20.02.2026 | Test ballooning in chrome-vm / business-vm        | Ballooning feature was turned off in ghaf by PR#1770                                      |


### PR DESCRIPTION
Loki is not able to handle all the logs when there are multiple tests running at the same time. This is a temporary skip while we wait for the limit to be increased.

<img width="1538" height="679" alt="image" src="https://github.com/user-attachments/assets/dd0520b9-52da-4c0f-96a1-08f139a92597" />
Yellow means that the logging has stopped.