### PR TITLE
Extend statistics analysis for mem snapshot

### DIFF
--- a/Robot-Framework/lib/PerformanceDataProcessing.py
+++ b/Robot-Framework/lib/PerformanceDataProcessing.py
@@ -12,9 +12,7 @@ from robot.api.deco import keyword
 from performance_thresholds import *
 from memory_plotting import (
     add_percentage_columns,
-    build_unique_labels,
-    plot_grouped_metric,
-    plot_grouped_metric_pair,
+    plot_vm_memory_snapshot,
 )
 
 
@@ -220,6 +218,61 @@ class PerformanceDataProcessing:
 
         return statistics_dict
 
+    def _analyze_performance_value(
+        self,
+        data_column,
+        baseline_start,
+        threshold,
+        deviation_counter,
+        deviations,
+        new_baseline_start,
+        row_index,
+    ):
+        # Update automatic baseline state and deviation counter for one measurement series.
+        statistics_block = self.detect_deviation(
+            data_column, baseline_start, threshold, deviation_counter, deviations
+        )
+
+        flag = statistics_block['flag']
+        if flag != 0:
+            deviations.append(row_index)
+            if abs(deviation_counter) < 1:
+                # If deviation counter was previously 0 this is potential start point for new baseline
+                new_baseline_start = row_index
+            elif flag * deviation_counter < 0:
+                # Reset deviation counter if sign of deviation has changed
+                deviation_counter = 0
+                new_baseline_start = row_index
+
+            deviation_counter += flag
+            statistics_block['flag'] = flag * abs(deviation_counter)
+            if flag != self.zero_result_flag:
+                if deviation_counter < self.zero_result_flag:
+                    # Reset the deviation counter to -1 in case previous result was "close to zero" (invalid)
+                    # --> baseline won't be switched
+                    deviation_counter = -1
+                    new_baseline_start = row_index
+                if abs(deviation_counter) > static_thresholds['wait_until_reset'] - 1:
+                    # Repeating deviation trend detected --> Switch to new baseline
+                    deviation_counter = 0
+                    deviations = []
+                    baseline_start = new_baseline_start
+            else:
+                # Reset the deviation counter to -1 in case current result is "close to zero" (invalid)
+                deviation_counter = -1
+                statistics_block['flag'] = self.zero_result_flag
+        else:
+            # Test result is within pass limits
+            deviation_counter = 0
+
+        # In case there are not yet valid result history (results below low_limit) and now first valid result
+        if data_column[baseline_start] < self.low_limit and data_column[-1] > self.low_limit:
+            deviation_counter = 0
+            deviations = []
+            baseline_start = row_index
+
+        return statistics_block, baseline_start, new_baseline_start, deviation_counter, deviations
+
     def calculate_statistics(self, test_name, data, monitored_value, threshold):
         # monitored_value: list of labels
         # threshold: dictionary or list of single value
@@ -274,44 +327,21 @@ class PerformanceDataProcessing:
                             select_threshold = 0
                         else:
                             select_threshold = value
-                        statistics_block = self.detect_deviation(data[value], baseline_start[value], threshold[select_threshold], deviation_counter[monitored_value_index], deviations[value])
-
-                        # Monitor deviations of monitored_value(s)
-                        flag = statistics_block['flag']
-                        if flag != 0:
-
-                            # Keep track on deviated results to be able to omit random odd result from baseline
-                            deviations[value].append(row_index)
-                            if abs(deviation_counter[monitored_value_index]) < 1:
-                                # Set potential start for new baseline
-                                new_baseline_start[value] = row_index
-                            else:
-                                # Check if new deviation is to opposite direction than previously
-                                if flag * deviation_counter[monitored_value_index] < 0:
-                                    deviation_counter[monitored_value_index] = 0
-                                    new_baseline_start[value] = row_index
-
-                            # Track of number of successive deviations
-                            deviation_counter[monitored_value_index] += flag
-                            # Save direction (+/-) and number of successive deviations to statistics
-                            statistics_block['flag'] = flag * abs(deviation_counter[monitored_value_index])
-                            # Don't change baseline for invalid (zero) results
-                            if flag != self.zero_result_flag:
-                                # If there is zero label in the deviation_counter from the previous measurements reset deviation_counter to -1
-                                if deviation_counter[monitored_value_index] < self.zero_result_flag:
-                                    deviation_counter[monitored_value_index] = -1
-                                    new_baseline_start[value] = row_index
-                                # Trigger baseline change if number of successive deviations exceeds the defined limit
-                                if abs(deviation_counter[monitored_value_index]) > static_thresholds['wait_until_reset'] - 1:
-                                    deviation_counter[monitored_value_index] = 0
-                                    deviations[value] = []
-                                    baseline_start[value] = new_baseline_start[value]
-                            else:
-                                # Keep the deviation_counter at -1 if the result is zero
-                                deviation_counter[monitored_value_index] = -1
-                                statistics_block['flag'] = self.zero_result_flag
-                        else:
-                            deviation_counter[monitored_value_index] = 0
+                        (
+                            statistics_block,
+                            baseline_start[value],
+                            new_baseline_start[value],
+                            deviation_counter[monitored_value_index],
+                            deviations[value],
+                        ) = self._analyze_performance_value(
+                            data[value],
+                            baseline_start[value],
+                            threshold[select_threshold],
+                            deviation_counter[monitored_value_index],
+                            deviations[value],
+                            new_baseline_start[value],
+                            row_index,
+                        )
 
                         new_statistics_row.update({value: statistics_block})
 
@@ -324,12 +354,6 @@ class PerformanceDataProcessing:
                                 indexed_key = key + str(monitored_value_index)
                             indexed_statistics_block.update({indexed_key: [statistics_block[key]]})
                         indexed_statistics_row.update(indexed_statistics_block)
-
-                        # Switch baseline_start index to a non-zero measurement result as soon as one is available
-                        if data[value][baseline_start[value]] < self.low_limit and data[value][-1] > self.low_limit:
-                            deviation_counter[monitored_value_index] = 0
-                            deviations[value] = []
-                            baseline_start[value] = row_index
 
                         monitored_value_index += 1
 
@@ -827,12 +851,6 @@ class PerformanceDataProcessing:
 
         return return_statistics
 
-    def extract_numeric_part(self, build_identifier):
-        parts = build_identifier.split('-')
-        base_number = int(''.join(filter(str.isdigit, parts[0])))
-        suffix = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else -1
-        return (base_number, suffix)
-
     def read_vms_data_csv_and_plot(self, test_name, vms_dict):
         tests = ['cpu_1thread', 'memory_read_1thread', 'memory_write_1thread', 'cpu', 'memory_read', 'memory_write']
         data = {test: {} for test in tests}
@@ -980,78 +998,103 @@ class PerformanceDataProcessing:
             df = pandas.DataFrame([row])
 
         df.to_csv(file_path, index=False)
-        self._plot_vm_memory_snapshot(test_name, df)
-        return
+        return self.read_vm_memory_snapshot_csv_and_plot(test_name)
 
-    def _plot_vm_memory_snapshot(self, test_name, df):
-        plot_limit = 40
-        if len(df.index) > plot_limit:
-            df = df.tail(plot_limit)
-
-        build_df = df.copy()
-        build_df["build_index"] = list(range(len(build_df.index)))
-        x_labels = build_unique_labels(build_df["commit"].tolist())
-        plot_df = self._normalize_vm_memory_snapshot_df(build_df)
+    def read_vm_memory_snapshot_csv_and_plot(self, test_name):
+        # Match other read_*_csv_and_plot methods: read CSV, analyze, plot, return last result.
+        data = pandas.read_csv(os.path.join(self.data_dir, f"{self.device}_{test_name}.csv"))
+        data["build_index"] = list(range(len(data.index)))
+        plot_df = self._normalize_vm_memory_snapshot_df(data)
         if plot_df.empty:
-            logging.warning("No VM memory snapshot data to plot for %s", test_name)
-            return
+            logging.warning("No VM memory snapshot data to process for %s", test_name)
+            plot_vm_memory_snapshot(test_name, data, plot_df, self.plot_dir, self.device, self.build_type)
+            return {}
 
-        title_suffix = f"\nBuild type: {self.build_type}, Device: {self.device}"
-        plot_grouped_metric_pair(
-            plot_df,
-            "build_index",
-            "mem_avail_mib",
-            "mem_total_mib",
-            self.plot_dir + f"{self.device}_{test_name}__mem_avail.png",
-            f"{test_name} - Mem Available/Total (MiB){title_suffix}",
-            "Build Number",
-            group_col="vm",
-            value_label="avail",
-            sort_col=None,
-            x_labels=x_labels,
-            x_time_format=None,
-        )
-        plot_grouped_metric_pair(
-            plot_df,
-            "build_index",
-            "swap_free_mib",
-            "swap_total_mib",
-            self.plot_dir + f"{self.device}_{test_name}__swap_free.png",
-            f"{test_name} - Swap Free/Total (MiB){title_suffix}",
-            "Build Number",
-            group_col="vm",
-            value_label="free",
-            sort_col=None,
-            x_labels=x_labels,
-            x_time_format=None,
-        )
-        plot_grouped_metric(
-            plot_df,
-            "build_index",
-            "mem_avail_pct",
-            self.plot_dir + f"{self.device}_{test_name}__mem_avail_pct.png",
-            f"{test_name} - Mem Available (%){title_suffix}",
-            "Build Number",
-            group_col="vm",
-            sort_col=None,
-            x_labels=x_labels,
-            x_time_format=None,
-            y_limits=(0, 100),
-        )
-        plot_grouped_metric(
-            plot_df,
-            "build_index",
-            "swap_free_pct",
-            self.plot_dir + f"{self.device}_{test_name}__swap_free_pct.png",
-            f"{test_name} - Swap Free (%){title_suffix}",
-            "Build Number",
-            group_col="vm",
-            sort_col=None,
-            x_labels=x_labels,
-            x_time_format=None,
-            y_limits=(0, 100),
-        )
-        return
+        threshold = thresholds["vm_memory_snapshot"]["mem_avail_pct"]
+        return_statistics, statistics = self._build_vm_memory_analysis(plot_df, threshold)
+        self._write_statistics_to_csv(test_name, statistics)
+        plot_vm_memory_snapshot(test_name, data, plot_df, self.plot_dir, self.device, self.build_type)
+        return return_statistics
+
+    def _build_vm_memory_analysis(self, plot_df, threshold):
+        # Aggregate per-VM mem_avail_pct analysis into Robot return data and statistics CSV rows.
+        plot_df["mem_avail_pct_flag"] = 0
+        current_build_index = plot_df["build_index"].max()
+        return_statistics = {}
+        statistics = self._init_vm_memory_stats_dict()
+
+        for vm, vm_df in plot_df.dropna(subset=["mem_avail_pct"]).groupby("vm", sort=False):
+            vm_statistics = self._analyze_vm_memory_series(vm, vm_df, threshold, plot_df)
+            for key in statistics:
+                statistics[key].extend(vm_statistics[key])
+            if vm_statistics["build_index"] and vm_statistics["build_index"][-1] == current_build_index:
+                return_statistics[vm] = vm_statistics["statistics_block"][-1]
+
+        del statistics["build_index"]
+        del statistics["statistics_block"]
+        return return_statistics, statistics
+
+    def _init_vm_memory_stats_dict(self):
+        # Initialize VM snapshot statistics dictionary layout.
+        return {
+            "commit": [],
+            "vm": [],
+            "build_index": [],
+            "statistics_block": [],
+            "flag": [],
+            "threshold": [],
+            "d_baseline_start": [],
+            "d_mean": [],
+            "baseline_start": [],
+            "baseline_mean": [],
+            "baseline_end": [],
+            "baseline_std": [],
+            "upper_marginal": [],
+            "lower_marginal": [],
+            "measurement": [],
+        }
+
+    def _analyze_vm_memory_series(self, vm, vm_df, threshold, plot_df):
+        # Analyze one VM's mem_avail_pct history and write its flags back to plot_df.
+        statistics = self._init_vm_memory_stats_dict()
+        vm_df = vm_df.sort_values("build_index")
+        baseline_start = 0
+        new_baseline_start = 0
+        deviation_counter = 0
+        deviations = []
+        data_column = []
+
+        for row_index, (df_index, row) in enumerate(vm_df.iterrows()):
+            data_column.append(float(row["mem_avail_pct"]))
+            (
+                statistics_block,
+                baseline_start,
+                new_baseline_start,
+                deviation_counter,
+                deviations,
+            ) = self._analyze_performance_value(
+                data_column,
+                baseline_start,
+                threshold,
+                deviation_counter,
+                deviations,
+                new_baseline_start,
+                row_index,
+            )
+
+            plot_df.loc[df_index, "mem_avail_pct_flag"] = statistics_block["flag"]
+            self._append_vm_memory_stat_row(statistics, row, vm, statistics_block)
+
+        return statistics
+
+    def _append_vm_memory_stat_row(self, statistics, row, vm, statistics_block):
+        # Append one analyzed VM measurement to the statistics CSV data structure.
+        statistics["commit"].append(row["commit"])
+        statistics["vm"].append(vm)
+        statistics["build_index"].append(row["build_index"])
+        statistics["statistics_block"].append(statistics_block)
+        for key in statistics_block:
+            statistics[key].append(statistics_block[key])
 
     def _normalize_vm_memory_snapshot_df(self, df):
         rows = []
@@ -1094,6 +1137,12 @@ class PerformanceDataProcessing:
 
     # ---------------------------------------------------------------------
     # Unused functions
+
+    def extract_numeric_part(self, build_identifier):
+        parts = build_identifier.split('-')
+        base_number = int(''.join(filter(str.isdigit, parts[0])))
+        suffix = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else -1
+        return (base_number, suffix)
 
     def calc_statistics(self, csv_file_name):
         build_info_size = 1 # First columns containing buildata

--- a/Robot-Framework/lib/memory_plotting.py
+++ b/Robot-Framework/lib/memory_plotting.py
@@ -57,6 +57,7 @@ def plot_grouped_metric(
     y_limits=None,
     legend_loc="upper left",
     marker="o",
+    flag_col=None,
 ):
     fig, ax = plt.subplots(figsize=PLOT_FIGSIZE)
     plt.set_loglevel("WARNING")
@@ -75,6 +76,8 @@ def plot_grouped_metric(
             label=group_name,
             linewidth=PLOT_LINEWIDTH,
         )
+        if flag_col and flag_col in group_df.columns:
+            _plot_flagged_points(ax, group_df, x_col, y_values, flag_col)
 
     ax.set_title(title, fontsize=18, fontweight="bold")
     ax.set_xlabel(xlabel, fontsize=16)
@@ -91,6 +94,35 @@ def plot_grouped_metric(
     fig.savefig(out_path)
     plt.close(fig)
     logging.info("Wrote plot to %s", out_path)
+
+
+def _plot_flagged_points(ax, group_df, x_col, y_values, flag_col):
+    # Overlay pass/fail analysis markers without adding marginal lines.
+    marker_specs = [
+        (-100, "x", "r", "r"),
+        (1, "^", "y", "r"),
+        (-1, "v", "y", "r"),
+    ]
+    flags = pandas.to_numeric(group_df[flag_col], errors="coerce").fillna(0)
+
+    for flag_value, marker, marker_face_color, marker_edge_color in marker_specs:
+        if flag_value == -100:
+            flagged = flags == flag_value
+        elif flag_value > 0:
+            flagged = flags > 0
+        else:
+            flagged = (flags < 0) & (flags != -100)
+        if not flagged.any():
+            continue
+        ax.plot(
+            group_df.loc[flagged, x_col],
+            y_values.loc[flagged],
+            marker=marker,
+            markersize=12,
+            linestyle="None",
+            mfc=marker_face_color,
+            mec=marker_edge_color,
+        )
 
 
 # Plot data as two-series-per-group
@@ -160,3 +192,80 @@ def plot_grouped_metric_pair(
     fig.savefig(out_path)
     plt.close(fig)
     logging.info("Wrote plot to %s", out_path)
+
+
+def plot_vm_memory_snapshot(test_name, df, plot_df, plot_dir, device, build_type):
+    # Build all VM memory snapshot plots from already-normalized snapshot data.
+    if plot_df.empty:
+        logging.warning("No VM memory snapshot data to plot for %s", test_name)
+        return
+
+    build_df = df.copy()
+    plot_limit = 40
+    if "build_index" not in build_df:
+        build_df["build_index"] = list(range(len(build_df.index)))
+    if len(build_df.index) > plot_limit:
+        build_df = build_df.tail(plot_limit)
+
+    plot_df = plot_df[plot_df["build_index"].isin(build_df["build_index"])]
+    if plot_df.empty:
+        logging.warning("No VM memory snapshot data to plot for %s", test_name)
+        return
+
+    x_labels = build_unique_labels(build_df["commit"].tolist())
+    title_suffix = f"\nBuild type: {build_type}, Device: {device}"
+    plot_grouped_metric_pair(
+        plot_df,
+        "build_index",
+        "mem_avail_mib",
+        "mem_total_mib",
+        plot_dir + f"{device}_{test_name}__mem_avail.png",
+        f"{test_name} - Mem Available/Total (MiB){title_suffix}",
+        "Build Number",
+        group_col="vm",
+        value_label="avail",
+        sort_col=None,
+        x_labels=x_labels,
+        x_time_format=None,
+    )
+    plot_grouped_metric_pair(
+        plot_df,
+        "build_index",
+        "swap_free_mib",
+        "swap_total_mib",
+        plot_dir + f"{device}_{test_name}__swap_free.png",
+        f"{test_name} - Swap Free/Total (MiB){title_suffix}",
+        "Build Number",
+        group_col="vm",
+        value_label="free",
+        sort_col=None,
+        x_labels=x_labels,
+        x_time_format=None,
+    )
+    plot_grouped_metric(
+        plot_df,
+        "build_index",
+        "mem_avail_pct",
+        plot_dir + f"{device}_{test_name}__mem_avail_pct.png",
+        f"{test_name} - Mem Available (%){title_suffix}",
+        "Build Number",
+        group_col="vm",
+        sort_col=None,
+        x_labels=x_labels,
+        x_time_format=None,
+        y_limits=(0, 100),
+        flag_col="mem_avail_pct_flag",
+    )
+    plot_grouped_metric(
+        plot_df,
+        "build_index",
+        "swap_free_pct",
+        plot_dir + f"{device}_{test_name}__swap_free_pct.png",
+        f"{test_name} - Swap Free (%){title_suffix}",
+        "Build Number",
+        group_col="vm",
+        sort_col=None,
+        x_labels=x_labels,
+        x_time_format=None,
+        y_limits=(0, 100),
+    )

--- a/Robot-Framework/lib/performance_thresholds.py
+++ b/Robot-Framework/lib/performance_thresholds.py
@@ -49,6 +49,9 @@ thresholds = {
     'iperf': "40%",
     'cpu_isolation': 7,
     'fileio_isolation': 10,
+    'vm_memory_snapshot': {
+        'mem_avail_pct': 20
+    },
 
 }
 

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -41,10 +41,9 @@ Record memory usage test
 VM memory usage snapshot
     [Documentation]    Log current memory usage (available/total) and swap usage (free/total) in every VM and ghaf-host and plot it across builds.
     [Tags]             SP-T360  memory_usage  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  orin-nx
-    ${low_mem_limit}  Set Variable    5.0
+    ${low_mem_limit}   Set variable    3.0
     @{vms}         Get VM list    with_host=True
     &{mem_data}    Create Dictionary
-    ${failed_mem_vms}    Create List
     FOR    ${vm}    IN    @{vms}
         Switch to vm    ${vm}
         ${out}    Run Command
@@ -57,9 +56,7 @@ VM memory usage snapshot
         ${mem_avail_pct}     Evaluate    (float($mem_avail_mib) / float($mem_total_mib)) * 100 if float($mem_total_mib) > 0 else 0
         ${pct_str}           Evaluate    f"{float($mem_avail_pct):.2f}%"
         IF    ${mem_avail_pct} < ${low_mem_limit}
-            Append To List   ${failed_mem_vms}    ${vm}: ${pct_str}
-            ${red_msg}       Evaluate  "\\033[31m${vm} available memory is below 5% of the total memory\\033[0m"
-            Log              ${red_msg}    console=True
+            Run Keyword And Continue On Failure    FAIL    ${vm} available memory is below ${low_mem_limit}% of the total memory
         END
         Log    Memory in ${vm}: avail ${mem_avail_mib}/${mem_total_mib} MiB, swap free ${swap_free_mib}/${swap_total_mib} MiB    console=True
         Set To Dictionary    ${mem_data}    mem_avail_mib__${vm}=${mem_avail_mib}
@@ -68,15 +65,15 @@ VM memory usage snapshot
         Set To Dictionary    ${mem_data}    swap_total_mib__${vm}=${swap_total_mib}
     END
 
-    Save VM Memory Snapshot Data    ${TEST NAME}    ${mem_data}
+    &{statistics}    Save VM Memory Snapshot Data    ${TEST NAME}    ${mem_data}
     Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}__mem_avail.png" alt="VM Mem Available (MiB) Plot" width="1200">    HTML
     Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}__swap_free.png" alt="VM Swap Free (MiB) Plot" width="1200">    HTML
     Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}__mem_avail_pct.png" alt="VM Mem Available (%) Plot" width="1200">    HTML
     Log    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}__swap_free_pct.png" alt="VM Swap Free (%) Plot" width="1200">    HTML
-    ${failed_count}    Get Length    ${failed_mem_vms}
-    IF    ${failed_count} > 0
-        FAIL    VMs with available memory < ${low_mem_limit}%: ${failed_mem_vms}
-    END
+    Determine Test Status    ${statistics}
+
+    [Teardown]      Run Keywords    Close All Connections
+    ...             AND             Switch to vm   ${HOST}
 
 nvpmodel check test
     [Documentation]     If power mode changed it would probably have an effect on performance test results.


### PR DESCRIPTION
- Harmonize result analysis and pass/fail determination of `VM memory usage snapshot` with other performance test cases.
- Set 20 %-unit limit for relative deviation of `VM memory usage snapshot - mem_avail_pct results`
- Set 3% hard lower limit for `VM memory usage snapshot` relative available memory
- Refactored some python tooling for more flexible reusability.
- Added some clarifying comments.

orin-agxANDperformance
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5886/

lenovo-x1ANDperformance
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5894/
after fixing the memory_usage test
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5922/

dell-7330ANDmemory_usage
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5936/

darter-proANDperformance
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5924/