### PR TITLE
Add shutdown&reboot skip for storeDisk

### DIFF
--- a/Robot-Framework/test-suites/gui-tests/gui_power_menu.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power_menu.robot
@@ -79,12 +79,13 @@ GUI Reboot
     ${end_time}       Get Time    epoch
     Login to laptop   enable_dnd=True
     ${elapsed}        Evaluate    ${end_time} - ${start_time}
+    ${reboot_limit}   Set Variable If    "${DEVICE_TYPE}" == "darter-pro"    100    90
     Log               Reboot took ${elapsed} seconds   console=True
-    IF   ${elapsed} > 90
-        IF  "${DEVICE_TYPE}" == "darter-pro"
-            SKIP   Known issue: SSRCSP-8341 (Reboot took too long: ${elapsed} seconds (expected < 90))
+    IF   ${elapsed} > ${reboot_limit}
+        IF  "system76-darp11-b-storeDisk" in "${JOB}"
+            SKIP   Known issue: SSRCSP-8412 (Reboot took too long: ${elapsed} seconds (expected < ${reboot_limit}))
         ELSE
-            FAIL   Reboot took too long: ${elapsed} seconds (expected < 90)
+            FAIL   Reboot took too long: ${elapsed} seconds (expected < ${reboot_limit})
         END
     END
 
@@ -107,7 +108,11 @@ GUI Shutdown
     Turn Laptop On and Connect
     Login to laptop   enable_dnd=True
     IF   ${elapsed} > 20
-        SKIP   Known issue: SSRCSP-8341 (Shutdown took too long: ${elapsed} seconds (expected < 20))
+        IF  "system76-darp11-b-storeDisk" in "${JOB}"
+            SKIP   Known issue: SSRCSP-8412 (Shutdown took too long: ${elapsed} seconds (expected < 20))
+        ELSE
+            FAIL   Shutdown took too long: ${elapsed} seconds (expected < 20)
+        END
     END
 
 GUI Log out and log in

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -4,8 +4,8 @@
 
 | DATE SET   | TEST CASE                                               | TICKET / Additional Data.                                                                     |
 | ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| 11.05.2026 | GUI Shutdown & GUI Reboot (storeDisk)                   | SSRCSP-8412                                                                                   |
 | 30.04.2026 | Open PDF from VM                                        | SSRCSP-8367                                                                                   |
-| 24.04.2026 | GUI Shutdown & GUI Reboot                               | SSRCSP-8341                                                                                   |
 | 08.04.2026 | Automatic suspension (high power after suspension)      | SSRCSP-8288                                                                                   |
 | 30.03.2026 | Check Camera in VMs (Dell)                              | SSRCSP-8266                                                                                   |
 | 30.03.2026 | Check Camera Application (Dell checked in chrome-vm)    | SSRCSP-8266                                                                                   |


### PR DESCRIPTION
Long reboot and shutdown issue was fixed https://github.com/tiiuae/ghaf/pull/1928

After the fix, they stopped failing on targets other than Darter Pro storeDisk images. I opened a new bug about that https://jira.tii.ae/browse/SSRCSP-8412

This PR updates the skips accordingly and also gives Darter Pro extra 10 seconds for the reboot test. Due to the Enter finger, it can take a bit longer to reboot. In previous nightly tests it exceeded the limit by a couple of seconds a few times.

Testrun on Darter with storeDisk image https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5974/