### PR TITLE
Tighten log rate limits

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -76,12 +76,22 @@ Check if process is running
     RETURN   '${status}' == 'PASS'
 
 Kill process by name
-    [Arguments]   ${process_name}   ${sudo}=True   ${require_exists}=${True}   ${signal}=9
-    Log   Killing process ${process_name}   console=True
+    [Arguments]   ${process_name}   ${sudo}=True   ${require_exists}=${True}   ${signal}=TERM   ${fallback_signal}=KILL
+    IF    ${require_exists}
+        ${was_running}   Check if process is running   ${process_name}
+        IF    not ${was_running}   FAIL   Process ${process_name} is not running
+    END
+    Log   Killing process ${process_name} with signal ${signal} (fallback: ${fallback_signal})   console=True
     # A = ignore pkill process (ancestor), e = display what is killed, f = use full process name to kill
-    ${output}   Run Command    pkill -${signal} -Aef "${process_name}"  sudo=${sudo}  return=rc  rc_match=skip  timeout=15
-    IF  ${require_exists}
-        Should Be Equal As Integers   ${output}[0]   0
+    Run Command    pkill -${signal} -Aef "${process_name}"  sudo=${sudo}  return=rc  rc_match=skip  timeout=15
+    ${still_running}   Wait Until Keyword Succeeds   5x   1s   Check if process is running   ${process_name}
+    IF  ${still_running}
+        Log   Process ${process_name} still running after signal ${signal}, retrying with ${fallback_signal}   console=True
+        Run Command    pkill -${fallback_signal} -Aef "${process_name}"  sudo=${sudo}  return=rc  rc_match=skip  timeout=15
+        ${still_running}   Wait Until Keyword Succeeds   5x   1s   Check if process is running   ${process_name}
+        IF  ${still_running}
+            FAIL   Process ${process_name} is still running after ${signal} and ${fallback_signal}
+        END
     END
 
 Save Time

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -357,18 +357,11 @@ Stop screen recording
     ${pass_status}   ${output}    Run Keyword And Ignore Error   Check that the application was started   gpu-screen-recorder
     IF  $pass_status=='PASS'
         Log To Console   Stopping screen recording
-        # Stop the recorder gracefully so it can flush buffered frames and finalize the video file
-        Kill process by name   gpu-screen-recorder   sudo=False   signal=INT
-        ${stopped}    Run Keyword And Return Status   Check that the application is not running   gpu-screen-recorder   10
-        IF  not ${stopped}
-            Log To Console   Screen recording did not stop gracefully, force killing it
-            Kill process by name   gpu-screen-recorder   sudo=False
-        END
+        Kill process by name   gpu-screen-recorder   sudo=False
     ELSE
         Log To Console  Screen recording was not running
     END
     Save screen recording   ${test_status}   ${test_name}
-    [Teardown]   Kill process by name   gpu-screen-recorder   sudo=False   require_exists=False
 
 Save screen recording
     [Arguments]    ${test_status}   ${test_name}

--- a/Robot-Framework/test-suites/functional-tests/logging.robot
+++ b/Robot-Framework/test-suites/functional-tests/logging.robot
@@ -69,12 +69,11 @@ Check logging rate
     [Documentation]    Check that host or vms are not creating too much logs
     [Tags]             SP-T359  log_rate  pre-merge  orin-agx  orin-agx-64  orin-nx
     ${check_interval}  Set Variable   100
-    ${saved_entries}   Set Variable   500
+    ${saved_entries}   Set Variable   2000
 
-    ${entry_limit}          Set Variable   2000
-    ${orin_entry_limit}     Set Variable   5000
-    ${gui_vm_entry_limit}   Set Variable   10000
-    ${bytes_per_entry}      Set Variable   200
+    ${entry_limit}            Set Variable   500
+    ${orin_entry_limit}       Set Variable   1000
+    ${bytes_per_entry}        Set Variable   200
 
     &{spam_metrics}    Create Dictionary
     &{ok_metrics}      Create Dictionary
@@ -83,8 +82,6 @@ Check logging rate
         Switch to vm   ${vm}
         IF  "orin" in "${DEVICE_TYPE}"
             ${vm_entry_limit}   Set Variable   ${orin_entry_limit}
-        ELSE IF  '${vm}' == 'gui-vm'
-            ${vm_entry_limit}   Set Variable   ${gui_vm_entry_limit}
         ELSE
             ${vm_entry_limit}   Set Variable   ${entry_limit}
         END
@@ -95,13 +92,15 @@ Check logging rate
         IF  ${entries} > ${vm_entry_limit} or ${byte_rate} > ${vm_byte_limit}
             ${recent_logs}       Run Command        journalctl -n ${saved_entries}
             Set To Dictionary    ${spam_logs}       ${vm}=${recent_logs}
-            Set To Dictionary    ${spam_metrics}    ${vm}=entries:${entries}_byterate:${byte_rate}_limits:${vm_entry_limit}/${vm_byte_limit}
+            Set To Dictionary    ${spam_metrics}    ${vm}=Entries: ${entries}, Byterate: ${byte_rate}, Limit: ${vm_entry_limit}/${vm_byte_limit}
         ELSE
-            Set To Dictionary    ${ok_metrics}      ${vm}=entries:${entries}_byterate:${byte_rate}_limits:${vm_entry_limit}/${vm_byte_limit}
+            Set To Dictionary    ${ok_metrics}      ${vm}=Entries: ${entries}, Byterate: ${byte_rate}, Limit: ${vm_entry_limit}/${vm_byte_limit}
         END
     END
-    Log                VMs with acceptable logging rates:\n${ok_metrics}       console=True
-    Log                Log spamming detected in these VMs:\n${spam_metrics}    console=True
+    ${ok_metrics_report}      Evaluate    '\\n'.join([f'{k}: {v}' for k, v in $ok_metrics.items()]) if $ok_metrics else 'None'
+    ${spam_metrics_report}    Evaluate    '\\n'.join([f'{k}: {v}' for k, v in $spam_metrics.items()]) if $spam_metrics else 'None'
+    Log                       VMs with acceptable logging rates:\n${ok_metrics_report}       console=True
+    Log                       Log spamming detected in these VMs:\n${spam_metrics_report}    console=True
     ${status}          Run Keyword And Return Status    Should Be Empty  ${spam_metrics}
     IF  not ${status}
         Log            Sample of ${saved_entries} log entries from VMs demonstrating too high logging rates
@@ -109,7 +108,7 @@ Check logging rate
             Log        ${vm}
             Log        ${logs}
         END
-        FAIL           meas interval: ${check_interval}s\n${spam_metrics}
+        FAIL           Too high logging rate detected\nmeas interval: ${check_interval}s\n${spam_metrics_report}
     END
 
 Validate Forward Secure Sealing


### PR DESCRIPTION
* https://github.com/tiiuae/ghaf/pull/1935 decreased the logs by about 85 %. This PR updates the log rate limits to match with the new expected values.
    * It is possible that the limits can be decreased even more, but I want to see how these changes behave in pre-merge and main pipelines before doing that.
* Use `TERM` to terminate processes by default in `Kill process by name`.
    * Killing apps with `KILL` signal causes the `givc-admin.service` to try to recover them. After app tests have run, for the rest of the run it is creating 42 logs / 5 seconds = 504 logs / min about the recovery. Using `TERM` to terminate the process removes almost all of these logs and is a lot cleaner way to close the apps.
    * I previously (accidentally) tested using `TERM` as the only kill signal, but it caused issues with Element (https://github.com/tiiuae/ci-test-automation/pull/565) and could also not work properly with some other apps in some cases. That is why `KILL` is left as an backup for killing the app.
* Format the log rate output to make it easier to read.

**Testruns**

Testing this was a bit hard, because `Check logging rate` results depend on the previous tests. Hopefully I covered all relevant cases.
* Lenovo X1 - [pre-merge](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5994/)
* Lenovo X1 - [all affected tests](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5987/)
* Darter Pro - [pre-merge](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5995/)
* Darter Pro - [all affected tests](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5993/)
* Dell 7330 - [pre-merge](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/1968/)
* Dell 7330 - [regressionNOTsecurity](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/1969/)
* Native AGX - [pre-merge](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5991/)
* Cross NX - [pre-merge](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5992/)