### PR TITLE
Refactor files tests

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/files.robot
+++ b/Robot-Framework/test-suites/functional-tests/files.robot
@@ -19,29 +19,21 @@ Open PDF from chrome-vm
     [Documentation]    Open PDF file from Chrome VM and check that Ghaf Isolated Document Viewer started
     [Tags]             SP-T131  SP-T131-1  pre-merge  bat
     Open PDF from app-vm    ${CHROME_VM}
-    [Teardown]         Run Keywords   Kill PDF Reader   ${CHROME_VM}
-    ...                         AND   Run Keyword If Test Failed    SKIP   Known issue: SSRCSP-8367
 
 Open PDF from comms-vm
     [Documentation]    Open PDF file from Comms VM and check that Ghaf Isolated Document Viewer started
     [Tags]             SP-T131  SP-T131-2
     Open PDF from app-vm    ${COMMS_VM}
-    [Teardown]         Run Keywords   Kill PDF Reader   ${COMMS_VM}
-    ...                         AND   Run Keyword If Test Failed    SKIP   Known issue: SSRCSP-8367
 
 Open PDF from business-vm
     [Documentation]    Open PDF file from Business VM and check that Ghaf Isolated Document Viewer started
     [Tags]             SP-T131  SP-T131-3
     Open PDF from app-vm    ${BUSINESS_VM}
-    [Teardown]         Run Keywords   Kill PDF Reader   ${BUSINESS_VM}
-    ...                         AND   Run Keyword If Test Failed    SKIP   Known issue: SSRCSP-8367
 
 Open PDF from gui-vm
     [Documentation]    Open PDF file from Gui VM and check that Ghaf Isolated Document Viewer started
     [Tags]             SP-T131  SP-T131-4
-    Open PDF from app-vm    ${GUI_VM}
-    [Teardown]         Run Keywords   Kill PDF Reader   ${GUI_VM}
-    ...                         AND   Run Keyword If Test Failed    SKIP   Known issue: SSRCSP-8367
+    Open PDF from app-vm    ${GUI_VM}  user=${USER_LOGIN}  sudo=False
 
 Open image with Oculante
     [Documentation]    Open PNG image in the Gui VM and check that Oculante app is started and opens the image
@@ -49,19 +41,19 @@ Open image with Oculante
     Switch to vm       ${GUI_VM}  user=${USER_LOGIN}
 
     Run Command        WAYLAND_DISPLAY=wayland-1 grim ./screenshot.png   timeout=5
-    Open Image         ./screenshot.png
+    Open file with XDG handler   ./screenshot.png   sudo=False
 
     Switch to vm       ${MEDIA_VM}
     Check that the application was started    oculante    10
     [Teardown]  Run Keywords  Remove the file in VM       ./screenshot.png  ${GUI_VM}   ${USER_LOGIN}   AND
-    ...                       Kill App Process And Save Logs  ${GUI_VM}    ${USER_LOGIN}    ${OUTPUT_FILE}    oculante    ${MEDIA_VM}
+    ...                       Kill app and XDG process    oculante
 
 Open text file with Cosmic Text Editor
     [Documentation]    Open text file and check that Cosmic Text Editor app is started
     [Tags]             SP-T262  pre-merge  bat
     Switch to vm       ${GUI_VM}  user=${USER_LOGIN}
     Create text file   test    /tmp/test_text.txt
-    Open text file     /tmp/test_text.txt
+    Open file to gui-vm with XDG handler    /tmp/test_text.txt
     Check that the application was started    cosmic-edit    10
     [Teardown]  Run Keywords  Remove the file in VM    /tmp/test_text.txt    ${GUI_VM}    ${USER_LOGIN}    AND
     ...                       Kill App Process And Save Logs    ${GUI_VM}    ${USER_LOGIN}    ${OUTPUT_FILE}    cosmic-edit    ${GUI_VM}
@@ -74,32 +66,38 @@ Remove the file in VM
     Switch to vm       ${vm}   user=${user}
     Remove file        ${file_name}
 
-Kill PDF Reader
-    [Arguments]   ${pdf_launcher_vm}
+Kill app and XDG process
+    [Arguments]        ${app}
     Switch to vm       ${MEDIA_VM}
-    Kill App By Name   xdg-open-pdf    sudo=True
-    Kill App By Name   cosmic-reader   sudo=True
+    Log                Killing ${app} and xdg-open process in ${MEDIA_VM}    console=true
+    Kill App By Name   ${app}|xdg-open        sudo=True
 
 Open PDF from app-vm
-    [Arguments]        ${vm}
-    Switch to vm       ${vm}
-    Put File           ../test-files/test_pdf.pdf         /tmp/test_pdf_${vm}.pdf
-    Open PDF           /tmp/test_pdf_${vm}.pdf
-    Switch to vm       ${MEDIA_VM}
-    Check that the application was started    cosmic-reader    10
-    [Teardown]         Remove the file in VM    /tmp/test_pdf_${vm}.pdf    ${vm}
+    [Arguments]       ${vm}   ${user}=ghaf   ${sudo}=True
+    Switch to vm                 ${vm}   user=${user}
+    Put File                     ../test-files/test_pdf.pdf   /tmp/test_pdf_${vm}.pdf
+    ${open_timestamp}            Run Command    date +%s
+    Open file with XDG handler   /tmp/test_pdf_${vm}.pdf   sudo=${sudo}
+    Switch to vm                 ${MEDIA_VM}
+    Check that the application was started    cosmic-reader   10
+    [Teardown]    Run Keywords   Remove the file in VM        /tmp/test_pdf_${vm}.pdf   ${vm}  ${user}
+    ...                    AND   Kill app and XDG process     cosmic-reader
+    ...                    AND   Run Keyword If   '${KEYWORD_STATUS}' == 'FAIL'   Check for cosmic-reader crash   ${open_timestamp}   ${vm}
 
-Open PDF
-    [Arguments]      ${pdf_file}
-    Log To Console   Trying to open ${pdf_file}
-    Run Command      xdg-open ${pdf_file}    sudo=True
+Open file with XDG handler
+    [Arguments]      ${file}  ${sudo}=True
+    Log To Console   Trying to open ${file}
+    Run Command      WAYLAND_DISPLAY=wayland-1 xdg-open ${file}   sudo=${sudo}
 
-Open Image
-    [Arguments]      ${pic_file}
-    Log To Console   Trying to open ${pic_file}
-    Run Command      nohup sh -c 'xdg-open-ghaf image ${pic_file}' > ${OUTPUT_FILE} 2>&1 &
-
-Open text file
+Open file to gui-vm with XDG handler
     [Arguments]      ${text_file}
     Log To Console   Trying to open ${text_file}
-    Run Command      WAYLAND_DISPLAY=wayland-1 nohup sh -c 'cosmic-edit -f ${text_file}' > ${OUTPUT_FILE} 2>&1 &
+    Run Command      WAYLAND_DISPLAY=wayland-1 nohup sh -c 'xdg-open ${text_file}' > ${OUTPUT_FILE} 2>&1 &
+
+Check for cosmic-reader crash
+    [Documentation]     Cosmic-reader crashes sometimes before it opens the file (SSRCSP-8367). Check if process started and skip the test if it did.
+    [Arguments]         ${journal_since}  ${vm}
+    Switch to vm        ${MEDIA_VM}
+    ${reader_started}   Run Keyword And Return Status   Run Command    journalctl -b --since @${journal_since} | grep -E "Started \\[systemd-run\\].*cosmic-reader.*/run/xdg/pdf/${vm}/test_pdf_${vm}\\.pdf\\."
+    Run Command         journalctl -b --since @${journal_since}   # All logs for debugging
+    IF  ${reader_started}   SKIP   Known Issue: SSRCSP-8367


### PR DESCRIPTION
- Refactor file tests to always use `xdg-open`
- Add a proper skip for pdf issues. Cosmic-reader crashes sometimes right after it has been opened. Instead of always skipping the pdf tests, check if cosmic-reader was started for a moment and only skip if it was.

**Testruns**
- [Dell 7330](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6008/artifact/Robot-Framework/test-suites/files/report.html#totals)
- [Darter Pro](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6012/artifact/Robot-Framework/test-suites/files/report.html#totals)
- [Darter storeDisk](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6015/artifact/Robot-Framework/test-suites/files/report.html#totals) (2 tests skipped)