### PR TITLE
Plot log rate measurements

### DIFF
--- a/Robot-Framework/lib/ParseMeasurementData.py
+++ b/Robot-Framework/lib/ParseMeasurementData.py
@@ -139,3 +139,79 @@ class ParseMeasurementData:
 
         plt.savefig(self.plot_dir + f'{param_label}_{build_id}.png')
         return
+
+    def append_measurement_history_result(self, test_name, metric_name, unit, build_id, device, measurements):
+        file_path = os.path.join(self.csv_dir, f"{device}_{test_name}__{metric_name}.csv")
+        row = {"build_id": build_id, "unit": unit}
+        for column, value in measurements.items():
+            row[str(column)] = value
+
+        if os.path.exists(file_path):
+            data = pd.read_csv(file_path)
+            columns = list(data.columns)
+            for column in row:
+                if column not in columns:
+                    columns.append(column)
+            for column in columns:
+                if column not in row:
+                    row[column] = pd.NA
+            data = pd.concat(
+                [data.reindex(columns=columns), pd.DataFrame([row], columns=columns)],
+                ignore_index=True,
+            )
+        else:
+            columns = ["build_id", "unit"] + [str(column) for column in measurements.keys()]
+            for column in columns:
+                if column not in row:
+                    row[column] = pd.NA
+            data = pd.DataFrame([row], columns=columns)
+        data.to_csv(file_path, index=False)
+        return file_path
+
+    def generate_measurement_history_graph(self, test_name, metric_name, device):
+        file_path = os.path.join(self.csv_dir, f"{device}_{test_name}__{metric_name}.csv")
+        data = pd.read_csv(file_path)
+        if data.empty:
+            logging.warning("No measurement history data to plot for %s/%s", test_name, metric_name)
+            return
+
+        value_columns = [column for column in data.columns if column not in {"build_id", "unit"}]
+        if not value_columns:
+            logging.warning("No measurement columns found to plot for %s/%s", test_name, metric_name)
+            return
+
+        build_labels = data["build_id"].astype(str).tolist()
+        build_indices = list(range(len(build_labels)))
+
+        fig, ax = plt.subplots(figsize=(20, 10))
+        plt.set_loglevel('WARNING')
+        ax.ticklabel_format(axis='y', style='plain')
+        ax.tick_params(axis='y', labelsize=14)
+
+        has_numeric_values = False
+        for column in value_columns:
+            values = pd.to_numeric(data[column], errors="coerce")
+            if values.notna().any():
+                has_numeric_values = True
+                ax.plot(
+                    build_indices,
+                    values,
+                    marker="o",
+                    linestyle="-",
+                    label=str(column),
+                    linewidth=2.5,
+                )
+
+        unit = data["unit"].dropna().iloc[0] if "unit" in data.columns and not data["unit"].dropna().empty else metric_name
+        ax.set_title(f'{device} - {test_name} - {metric_name}', loc='center', fontweight="bold", fontsize=16)
+        ax.set_xlabel('Build', fontsize=16)
+        ax.set_ylabel(unit, fontsize=16)
+        ax.grid(True)
+        ax.set_xticks(build_indices)
+        ax.set_xticklabels(build_labels, rotation=90, fontsize=10)
+        if has_numeric_values:
+            ax.legend(loc='upper left', fontsize=12)
+        fig.tight_layout()
+        fig.savefig(self.plot_dir + f'{device}_{test_name}__{metric_name}.png')
+        plt.close(fig)
+        return

--- a/Robot-Framework/resources/measurement_keywords.resource
+++ b/Robot-Framework/resources/measurement_keywords.resource
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***
+Resource            ../config/variables.robot
 Library             ../lib/ParseMeasurementData.py    ${LOGGED_PARAMS_DIR}    ${PLOT_DIR}
 Library             DateTime
 Library             SSHLibrary
@@ -175,3 +176,11 @@ Plot parameter log
     END
     Generate param graph         ${script}_interval.csv  ${param_label}  ${param_unit}  ${BUILD_ID}
     Log                          <img src="${PLOT_DIR}${param_label}_${BUILD_ID}.png" alt="Stats plot" width="1200">    HTML
+
+Save measurement history data
+    [Documentation]    Save one build worth of measurement series values and plot the accumulated history.
+    [Arguments]        ${test_name}    ${metric_name}    ${unit}    &{measurements}
+    ${build_id}    Set Variable    ${BUILD_ID}-${COMMIT_HASH}
+    Append measurement history result    ${test_name}    ${metric_name}    ${unit}    ${build_id}    ${DEVICE}    ${measurements}
+    Generate measurement history graph    ${test_name}    ${metric_name}    ${DEVICE}
+    Log    <img src="${REL_PLOT_DIR}${DEVICE}_${test_name}__${metric_name}.png" alt="${metric_name} history" width="1200">    HTML

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -141,7 +141,7 @@ Check If Device Is Up
 
     ${diff}=    Evaluate    int(time.time()) - int(${start_time})
 
-    IF  ${IS_AVAILABLE}    Log To Console    Device woke up after ${diff} sec.
+    IF  ${IS_AVAILABLE}    Log    Device woke up after ${diff} sec.    console=True
 
     IF  ${IS_AVAILABLE} == False
         Log To Console    Device is not available via SSH, waited for ${diff} sec!

--- a/Robot-Framework/test-suites/functional-tests/logging.robot
+++ b/Robot-Framework/test-suites/functional-tests/logging.robot
@@ -12,6 +12,7 @@ Library             ../../lib/helper_functions.py
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/service_keywords.resource
+Resource            ../../resources/measurement_keywords.resource
 
 Suite Setup         Logging Suite Setup
 
@@ -68,39 +69,77 @@ Check Grafana logs
 Check logging rate
     [Documentation]    Check that host or vms are not creating too much logs
     [Tags]             SP-T359  log_rate  pre-merge  orin-agx  orin-agx-64  orin-nx
-    ${check_interval}  Set Variable   100
-    ${saved_entries}   Set Variable   2000
 
-    ${entry_limit}            Set Variable   500
-    ${orin_entry_limit}       Set Variable   2000
-    ${bytes_per_entry}        Set Variable   200
+    ${check_interval}     Set Variable   100
+    ${saved_entries}      Set Variable   2000
+    ${entry_limit}        Set Variable   500
+    ${orin_entry_limit}   Set Variable   2000
+    ${bytes_per_entry}    Set Variable   200
 
-    &{spam_metrics}    Create Dictionary
-    &{ok_metrics}      Create Dictionary
-    &{spam_logs}       Create Dictionary
+    &{spam_metrics}       Create Dictionary
+    &{ok_metrics}         Create Dictionary
+    &{spam_logs}          Create Dictionary
+    &{unavailable_vms}    Create Dictionary
+    &{entry_history}      Create Dictionary
+    &{byte_history}       Create Dictionary
+
     FOR  ${vm}  IN  @{VM_LIST}
-        Switch to vm   ${vm}
-        IF  "orin" in "${DEVICE_TYPE}"
-            ${vm_entry_limit}   Set Variable   ${orin_entry_limit}
-        ELSE
-            ${vm_entry_limit}   Set Variable   ${entry_limit}
+        Set To Dictionary    ${entry_history}    ${vm}=${EMPTY}
+        Set To Dictionary    ${byte_history}     ${vm}=${EMPTY}
+    END
+    FOR  ${vm}  IN  @{VM_LIST}
+        ${vm_is_ready}    Run Keyword And Return Status    Check if ssh is ready on vm    ${vm}    timeout=5
+        IF  not ${vm_is_ready}
+            Log    Skipping ${vm}: ssh is not ready    console=True
+            Set To Dictionary    ${unavailable_vms}    ${vm}=ssh not ready
+            CONTINUE
         END
-        ${vm_byte_limit}    Evaluate    ${vm_entry_limit} * ${bytes_per_entry}
+        ${switch_status}    ${switch_output}    Run Keyword And Ignore Error    Switch to vm    ${vm}    timeout=10
+        IF  '${switch_status}' == 'FAIL'
+            Log    Skipping ${vm}: ${switch_output}    console=True
+            Set To Dictionary    ${unavailable_vms}    ${vm}=${switch_output}
+            Switch to vm    ${HOST}    timeout=10
+            CONTINUE
+        END
+        IF  '${switch_status}' == 'PASS'
+            IF  "orin" in "${DEVICE_TYPE}"
+                ${vm_entry_limit}   Set Variable   ${orin_entry_limit}
+            ELSE
+                ${vm_entry_limit}   Set Variable   ${entry_limit}
+            END
+            ${vm_byte_limit}    Evaluate    ${vm_entry_limit} * ${bytes_per_entry}
 
-        ${byte_rate}   Run Command    journalctl --since "$(date -d '${check_interval} seconds ago' '+%Y-%m-%d %H:%M:%S')" | wc -c | awk '{print $1}'
-        ${entries}     Run Command    journalctl --since "${check_interval} seconds ago" | wc -l
-        IF  ${entries} > ${vm_entry_limit} or ${byte_rate} > ${vm_byte_limit}
-            ${recent_logs}       Run Command        journalctl -n ${saved_entries}
-            Set To Dictionary    ${spam_logs}       ${vm}=${recent_logs}
-            Set To Dictionary    ${spam_metrics}    ${vm}=Entries: ${entries}, Byterate: ${byte_rate}, Limit: ${vm_entry_limit}/${vm_byte_limit}
-        ELSE
-            Set To Dictionary    ${ok_metrics}      ${vm}=Entries: ${entries}, Byterate: ${byte_rate}, Limit: ${vm_entry_limit}/${vm_byte_limit}
+            ${byte_status}    ${byte_rate}    Run Keyword And Ignore Error
+            ...    Run Command    journalctl --since "$(date -d '${check_interval} seconds ago' '+%Y-%m-%d %H:%M:%S')" | wc -c | awk '{print $1}'
+            ${entries_status}    ${entries}    Run Keyword And Ignore Error
+            ...    Run Command    journalctl --since "${check_interval} seconds ago" | wc -l
+            IF  '${byte_status}' == 'PASS'
+                Set To Dictionary    ${byte_history}    ${vm}=${byte_rate}
+            END
+            IF  '${entries_status}' == 'PASS'
+                Set To Dictionary    ${entry_history}    ${vm}=${entries}
+            END
+            IF  '${entries_status}' == 'PASS' and '${byte_status}' == 'PASS' and (${entries} > ${vm_entry_limit} or ${byte_rate} > ${vm_byte_limit})
+                ${recent_logs}       Run Command        journalctl -n ${saved_entries}
+                Set To Dictionary    ${spam_logs}       ${vm}=${recent_logs}
+                Set To Dictionary    ${spam_metrics}    ${vm}=Entries: ${entries}, Byterate: ${byte_rate}, Limit: ${vm_entry_limit}/${vm_byte_limit}
+            ELSE IF  '${entries_status}' == 'PASS' and '${byte_status}' == 'PASS'
+                Set To Dictionary    ${ok_metrics}      ${vm}=Entries: ${entries}, Byterate: ${byte_rate}, Limit: ${vm_entry_limit}/${vm_byte_limit}
+            END
         END
     END
+
     ${ok_metrics_report}      Evaluate    '\\n'.join([f'{k}: {v}' for k, v in $ok_metrics.items()]) if $ok_metrics else 'None'
     ${spam_metrics_report}    Evaluate    '\\n'.join([f'{k}: {v}' for k, v in $spam_metrics.items()]) if $spam_metrics else 'None'
     Log                       VMs with acceptable logging rates:\n${ok_metrics_report}       console=True
     Log                       Log spamming detected in these VMs:\n${spam_metrics_report}    console=True
+
+    ${has_unavailable_vms}    Run Keyword And Return Status    Should Not Be Empty    ${unavailable_vms}
+    IF  ${has_unavailable_vms}
+        Log                VMs not accessible during logging check:\n${unavailable_vms}    console=True
+    END
+    Save measurement history data    ${TEST NAME}    log_entries    entries/100s    &{entry_history}
+    Save measurement history data    ${TEST NAME}    log_byte_rate    bytes/100s    &{byte_history}
     ${status}          Run Keyword And Return Status    Should Be Empty  ${spam_metrics}
     IF  not ${status}
         Log            Sample of ${saved_entries} log entries from VMs demonstrating too high logging rates


### PR DESCRIPTION
- Save vm log rate measurements to a csv file.
- Plot log rate measurement history.
- Keep the hardcoded limits in `Check logging rate`
- Improve `Check logging rate` so that it continues even if some vm is not available.

- Created generic keywords for recording and plotting any measurement values (from all vms) across builds (without performance thresholds, analysis, pass/fail logic).
- Previously we have had generate_param_graph but that is for plotting arbitrary measurement 
results over time within single test run, not over multiple builds.

Darter-Pro
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6027/ (some older storeDisk image)
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6034/ (fresh storeDisk image)
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6035/ (after logging in and waiting few minutes before test)

Orin NX
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6029/