### PR TITLE
Update skips and tags

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -354,13 +354,8 @@ Start screen recording
 
 Stop screen recording
     [Arguments]      ${test_status}   ${test_name}=""
-    ${pass_status}   ${output}    Run Keyword And Ignore Error   Check that the application was started   gpu-screen-recorder
-    IF  $pass_status=='PASS'
-        Log To Console   Stopping screen recording
-        Kill process by name   gpu-screen-recorder   sudo=False
-    ELSE
-        Log To Console  Screen recording was not running
-    END
+    Log To Console   Stopping screen recording
+    Kill process by name   gpu-screen-recorder   sudo=False   require_exists=False
     Save screen recording   ${test_status}   ${test_name}
 
 Save screen recording

--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -53,7 +53,7 @@ Check all VMs are running
 
 Check all VMs are running on Orins
     [Documentation]    Check that all VMs are running.
-    [Tags]             SP-T68  SP-T68-2  pre-merge  bat  orin-nx  orin-agx  orin-agx-64
+    [Tags]             SP-T68  SP-T68-2  pre-merge  bat  orin-agx  orin-agx-64  orin-nx
     Switch to vm    ${HOST}
     ${output}       Run Command        microvm -l
     ${output}       Replace String Using Regexp    ${output}    \x1b\\[[0-9;]*m    ${EMPTY}

--- a/Robot-Framework/test-suites/functional-tests/logging.robot
+++ b/Robot-Framework/test-suites/functional-tests/logging.robot
@@ -165,8 +165,7 @@ Validate Forward Secure Sealing
             Run Keyword And Continue On Failure   FAIL   ${msg}
         END
     END
-    [Teardown]  Run Keyword If Test Failed   SKIP   Known issue: SSRCSP-7973
-
+    [Teardown]  Run Keyword If Test Failed   SKIP   Known issue: SSRCSP-8425
 
 *** Keywords ***
 

--- a/Robot-Framework/test-suites/functional-tests/vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/vm.robot
@@ -24,7 +24,7 @@ Suite Setup         VM Suite Setup
              ...    ANY|gui-vm|setup-ghaf-user.service|SSRCSP-7234
              ...    ANY|ANY|tuned.service|SSRCSP-7717
              ...    ANY|ANY|fail2ban.service|SSRCSP-7759
-             ...    ANY|ANY|journal-fss-verify.service|SSRCSP-7973
+             ...    ANY|ANY|journal-fss-verify.service|SSRCSP-8425
              ...    orin|ghaf-host|nvfancontrol.service|SSRCSP-6303
              ...    orin-agx|ghaf-host|systemd-rfkill.service|SSRCSP-6303
              ...    orin|ghaf-host|systemd-oomd.service|SSRCSP-6685

--- a/Robot-Framework/test-suites/gui-tests/gui_app_store.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_app_store.robot
@@ -24,7 +24,7 @@ Install Firefox
 Install Onlyoffice and save documents
     [Documentation]    Install and launch Onlyoffice from App Store
     ...                Save different types of files to Shares
-    [Tags]    SP-T355  SP-T312  SP-T313  SP-T314
+    [Tags]    SP-T312  SP-T313  SP-T314  SP-T355
     Install and Launch App Store app   onlyoffice
 
     Save a file from Onlyoffice   Document       test_Document.docx

--- a/Robot-Framework/test-suites/gui-tests/gui_security.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_security.robot
@@ -17,7 +17,7 @@ Test Teardown       Run keywords      Switch to vm            ${GUI_VM}  user=${
 
 *** Test Cases ***
 Check Access List In Trusted Browser
-    [Tags]    SP-T362   SP-T210  SP-T209  SP-T211   lenovo-x1  darter-pro
+    [Tags]    SP-T209  SP-T210  SP-T211  SP-T362  lenovo-x1  darter-pro
     [Template]    Check Access List In Trusted Browser Template
     # Pages outside access list shouldn't be available via Trusted Browser. Http and https has different errors
     https://yle.fi                          text_to_find=This site can’t be reached

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -4,6 +4,7 @@
 
 | DATE SET   | TEST CASE                                               | TICKET / Additional Data.                                                                     |
 | ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| 13.05.2026 | Validate Forward Secure Sealing                         | SSRCSP-8425                                                                                   |
 | 11.05.2026 | GUI Shutdown & GUI Reboot (storeDisk)                   | SSRCSP-8412                                                                                   |
 | 30.04.2026 | Open PDF from VM                                        | SSRCSP-8367                                                                                   |
 | 08.04.2026 | Automatic suspension (high power after suspension)      | SSRCSP-8288                                                                                   |
@@ -11,7 +12,6 @@
 | 30.03.2026 | Check Camera Application (Dell checked in chrome-vm)    | SSRCSP-8266                                                                                   |
 | 23.03.2026 | Verify camera block persisted (Lenovo X1)               | SSRCSP-8224                                                                                   |
 | 26.02.2026 | Check systemctl status in every VM (retry added for NX) | Timeout of Executing command 'systemctl list-units --plain --no-legend --no-pager '.          |
-| 05.02.2026 | Validate Forward Secure Sealing                         | SSRCSP-7973                                                                                   |
 | 11.02.2026 | Check device id                                         | SSRCSP-7997                                                                                   |
 | 11.02.2026 | Check net-vm hostname                                   | SSRCSP-7997                                                                                   |
 | 07.11.2025 | Measure time to launch COSMIC Settings                  | SSRCSP-7518                                                                                   |
@@ -26,12 +26,11 @@
 
 ## TAGs removed
 
-| DATE SET   | TEST CASE                                         | TICKET / Additional Data.                                                                 |
-| ---------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| 24.04.2026 | Rebuild tests removed from regression             | Rebuild tests do not work properly with signed images                                     |
-| 27.02.2026 | Measure Soft Boot Time (Darter Pro)               | Test removed because the Enter finger causes inaccuracy to the result                     |
-| 20.02.2026 | Test ballooning in chrome-vm / business-vm        | Ballooning feature was turned off in ghaf by PR#1770                                      |
-| 04.12.2025 | Start Falcon AI and verify process started (Dell) | Test stucks with circle running on screen. Not relevant case for this HW target.          |
-| 04.05.2026 | Start Falcon AI and verify process started (All)  | Falcon AI fails to answer because of too low memory (gui-vm memory was decreased to 8GB.) |
-| 03.09.2025 | Performance/network suite (AGX)                   | SSRCSP-7160. Network-adapter usage had impact on results. Needs further investigation.    |
-| 03/2025    | Performance Network.robot - ‘orin-nx’             | SSRCSP-6372 - Works locally but problems when Jenkins used, fails all..                   |
+| DATE SET   | TEST CASE                                  | TICKET / Additional Data.                                                              |
+| ---------- | ------------------------------------------ | -------------------------------------------------------------------------------------- |
+| 04.05.2026 | Start Falcon AI and verify process started | Falcon is no longer included in the default image (Ghaf#1944)                          |
+| 24.04.2026 | Rebuild tests removed from regression      | Rebuild tests do not work properly with signed images                                  |
+| 27.02.2026 | Measure Soft Boot Time (Darter Pro)        | Test removed because the Enter finger causes inaccuracy to the result                  |
+| 20.02.2026 | Test ballooning in chrome-vm / business-vm | Ballooning feature was turned off in ghaf by PR#1770                                   |
+| 03.09.2025 | Performance/network suite (AGX)            | SSRCSP-7160. Network-adapter usage had impact on results. Needs further investigation. |
+| 03/2025    | Performance Network.robot - ‘orin-nx’      | SSRCSP-6372 - Works locally but problems when Jenkins used, fails all..                |

--- a/pkgs/tag-helper/organize_robot_tags.py
+++ b/pkgs/tag-helper/organize_robot_tags.py
@@ -6,6 +6,7 @@ TAGS_RE = re.compile(r"^(\s*(?:\[Tags\]|Test Tags)\s+)(.+)$")
 TAG_PRIORITY = ["pre-merge", "bat", "regression",   # Test set tags from smallest to biggest
                 "gui", "performance", "security", "suspension", "update",  # Test suite tags in an alphabetical order (there should be only one of these for each test)
                 "lenovo-x1", "darter-pro", "dell-7330", "orin-agx", "orin-agx-64", "orin-nx", # Device tags
+                "installer-only", "excl-installer", "storeDisk-only", "excl-storeDisk", "secboot-only", "excl-secboot",  # Image type tags
                 "lab-only", "fmo"]  # Other important tags
 
 


### PR DESCRIPTION
- Remove app is running check from `Stop screen recording`, no need to check it before running `Kill process by name`. In the nightly there was an failure where screen recorder was running when `Stop screen recording` checked it but not when `Kill process by name` checked the same thing.
- Arrange tags with `organize_robot_tags.py`. Add new tags to the tag priority list.
- Update `Validate Forward Secure Sealing` skip to point to the new bug.
- Add a note about Falcon being removed to `list_of_skipped_tests.md`.

Lenovo X1 gui https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6038/
