### PR TITLE
Save logs from failed Orin boots

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -27,6 +27,8 @@ ${PERF_DATA_DIR}          ../../../Performance_test_results/
 ${PLOT_DIR}               ./
 ${REL_PLOT_DIR}           ./
 ${FLASHED}                false
+${UART_CAPTURE_ACTIVE}    ${False}
+${BOOT_DIAGNOSTICS_DIR}   ./    # Later ./boot_diagnostics when move of the dir implemented in ghaf-infra
 
 
 *** Keywords ***

--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -36,7 +36,7 @@ Run Command
     ELSE IF    '${rc_match}' == 'not_equal'
         Should Not Be Equal As Integers    ${rc}  ${compare_rc}   Error with command: ${cmd} \nReturn code: ${rc}, expected not to be equal with: ${compare_rc} \nError: ${err} \n
     ELSE IF    '${rc_match}' != 'skip'
-        ERROR   Wrong rc_match type: ${rc_match}
+        Fatal Error   Wrong rc_match type: ${rc_match}
     END
 
     IF  'err' in '${return}' or 'rc' in '${return}'

--- a/Robot-Framework/resources/security_blacklist_keywords.resource
+++ b/Robot-Framework/resources/security_blacklist_keywords.resource
@@ -14,14 +14,14 @@ Verify NetVM Blacklist Contains IP Via Serial
     [Documentation]    Verify that the provided IP is found from net-vm's ${blacklist} via serial tunnel.
     [Arguments]        ${ip}  ${blacklist}=BLACKLIST
     Log                Checking via serial that ${blacklist} contains the attacker IP    console=True
-    ${output}          Run Command on VM Via Serial    ${NET_VM}    echo ${PASSWORD} | sudo -S ipset list ${blacklist}
+    ${output}          Run Command on VM Via Serial    ${NET_VM}    ipset list ${blacklist}    sudo=${True}
     Should Contain     ${output}    ${ip}     Blacklist doesn't contain the attacker's IP.
 
 Clear NetVM Blacklist Via Serial
     [Documentation]    Remove the attacker IP from net-vm ${blacklist} using serial access.
     [Arguments]        ${ip}  ${blacklist}=BLACKLIST   ${proto}=ICMP
     Log                Trying to remove the attacker IP from ${blacklist} via serial     console=True
-    Run Command on VM Via Serial   ${NET_VM}   echo ${PASSWORD} | sudo -S ipset del ${blacklist} ${ip}
+    Run Command on VM Via Serial   ${NET_VM}   ipset del ${blacklist} ${ip}    sudo=${True}
     IF    $proto == 'SSH'
         Unban IP Address Via Serial    ${ip}
     END
@@ -30,14 +30,14 @@ Clear NetVM Blacklist Via Serial
 Unban IP Address Via Serial
     [Arguments]        ${ip}
     Log                Trying to unban the attacker IP via serial     console=True
-    Run Command on VM Via Serial   ${NET_VM}   echo ${PASSWORD} | sudo -S fail2ban-client set sshd unbanip ${ip}
+    Run Command on VM Via Serial   ${NET_VM}   fail2ban-client set sshd unbanip ${ip}    sudo=${True}
     Verify IP Is Not Banned In Fail2ban Jail Via Serial    ${ip}
     Verify External Connectivity Restored    SSH
 
 Verify IP Is Not Banned In Fail2ban Jail Via Serial
     [Documentation]    Verify that the IP is not listed in fail2ban sshd jail banned IP list.
     [Arguments]        ${ip}  ${jail}=sshd
-    ${output}          Run Command on VM Via Serial    ${NET_VM}    echo ${PASSWORD} | sudo -S fail2ban-client status ${jail}
+    ${output}          Run Command on VM Via Serial    ${NET_VM}    fail2ban-client status ${jail}    sudo=${True}
     Should Contain     ${output}    Banned IP list:
     Should Not Match Regexp    ${output}    (?m)^\\s*`- Banned IP list:\\s*.*\\b${ip}\\b
 

--- a/Robot-Framework/resources/serial_keywords.resource
+++ b/Robot-Framework/resources/serial_keywords.resource
@@ -4,7 +4,9 @@
 *** Settings ***
 Library             ../lib/KMTronicLibrary.py   ${RELAY_SERIAL_PORT}
 Library             ../lib/output_parser.py
+Library             ../lib/helper_functions.py
 Library             AdvancedLogging
+Library             OperatingSystem
 Library             SerialLibrary    encoding=ascii
 Library             String
 Resource            ../resources/device_control.resource
@@ -13,7 +15,7 @@ Resource            ../resources/device_control.resource
 *** Keywords ***
 
 Open Serial Port
-    [Arguments]   ${timeout}=1.0
+    [Arguments]   ${timeout}=2.0
     TRY
         Add Port      ${SERIAL_PORT}
         ...           baudrate=115200
@@ -79,10 +81,11 @@ Check Serial Connection
 
 Log In To Ghaf OS
     [Documentation]       Log in with ${LOGIN} and ${PASSWORD}
+    [Arguments]           ${attempts}=10
     Log To Console        Trying to log in via serial...
-    FOR    ${i}    IN RANGE    10
+    FOR    ${i}    IN RANGE    ${attempts}
         Write Data        ${\n}
-        ${output}         SerialLibrary.Read Until    terminator=${HOST} login    timeout=5
+        ${output}         SerialLibrary.Read Until    terminator=${HOST} login
         ${status}         Run Keyword And Return Status    Should contain    ${output}    ${HOST} login
         IF  ${status}
             Write Data    ${LOGIN}${\n}
@@ -91,12 +94,11 @@ Log In To Ghaf OS
         END
         ${status}         Run Keyword And Return Status    Should contain    ${output}    @${HOST}
         IF  ${status}
-            Log           Successfully logged in      console=True
-            BREAK
+            Log To Console    Successfully logged in
+            RETURN
         END
     END
-    RETURN    ${status}
-    IF    ${status}==False    FAIL      Console is not ready
+    FAIL    Serial console is not ready
 
 Verify init.scope status via serial
     [Arguments]         ${range}=60
@@ -129,7 +131,7 @@ Connect via serial
     [Arguments]         ${timeout}=1.0
     ${status}           Open Serial Port    timeout=${timeout}
     IF    ${status}
-        ${status}   Log In To Ghaf OS
+        ${status}   Run Keyword And Return Status    Log In To Ghaf OS
     END
     RETURN    ${status}
 
@@ -179,58 +181,355 @@ Verify shutdown via serial
     RETURN            ${time}
     [Teardown]        Delete All Ports
 
+Run Command On Serial
+    [Documentation]    Run a host command on the serial console and wait for the shell prompt.
+    [Arguments]    ${command}    ${timeout}=30    ${sudo}=${False}    ${pre_flush}=${True}
+    ${opened_here}     Set Variable    ${False}
+    IF    not ${UART_CAPTURE_ACTIVE}
+        ${status}    Connect via serial    timeout=${timeout}
+        IF    ${status} == False
+            FAIL    Failed to connect via serial. Cannot execute host command.
+        END
+        ${opened_here}    Set Variable    ${True}
+    END
+    ${effective_command}    Set Variable    ${command}
+    IF    ${sudo}
+        ${effective_command}    Set Variable    sudo ${command}
+    END
+    Run Keyword If    ${pre_flush}    Drain Serial Output
+    Write Data    ${effective_command}${\n}
+    ${first_line}    SerialLibrary.Read Until    terminator=${\n}
+    IF  ${sudo}
+        ${search}    Set Variable    assword
+        ${status}    ${output}    Run Keyword And Ignore Error
+        ...    SerialLibrary.Read Until    terminator=${search}
+        IF    $search in $output
+            Send Password Via Serial Quietly
+        END
+    END
+    ${output}    SerialLibrary.Read Until    terminator=ghaf@${HOST}:
+    IF    ${opened_here}
+        Delete All Ports
+    END
+    ${clean_output}    Normalize Serial Output    ${output}
+    ${lower_output}    Convert To Lowercase    ${clean_output}
+    ${has_host_error}    Evaluate    'permission denied' in $lower_output or 'sorry, try again' in $lower_output
+    IF    ${has_host_error}
+        IF    ${sudo}
+            FAIL    Failed to execute sudo command '${command}' on host via serial: ${clean_output}
+        END
+        FAIL    Failed to execute '${command}' on host via serial: ${clean_output}
+    END
+    RETURN    ${clean_output}
+
 Run Command on VM Via Serial
-    [Arguments]        ${vm}    ${command}    ${timeout}=5
+    [Documentation]    Execute a command on a VM through the host serial console and tunneling via ssh.
+    [Arguments]        ${vm}    ${command}    ${output_redirect}=NONE    ${timeout}=5    ${sudo}=${False}    ${pre_flush}=${True}    ${logging}=${True}
     IF    "${SERIAL_PORT}" == "NONE"
         FAIL    Serial port is not configured. Cannot execute ${vm} commands via serial.
     END
-    ${status}          Connect via serial   timeout=${timeout}
-    IF    ${status} == False
-        FAIL    Failed to connect via serial. Cannot execute ${vm} commands.
+    ${opened_here}     Set Variable    ${False}
+    IF    not ${UART_CAPTURE_ACTIVE}
+        ${status}          Connect via serial   timeout=${timeout}
+        IF    ${status} == False
+            FAIL    Failed to connect via serial. Cannot execute ${vm} commands.
+        END
+        ${opened_here}    Set Variable    ${True}
     END
-    ${marker_seed}     Generate Random String    8
-    ${marker}          Set Variable    __SERIAL_CMD_${marker_seed}__
-    ${escaped_cmd}     Replace String    ${command}    "    \\" 
-    ${ssh_command}     Set Variable    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${vm} "${escaped_cmd}"; echo ${marker}
-    Log                Running command in ${vm}     console=True
+    ${effective_command}    Set Variable    ${command}
+    ${ssh_options}         Set Variable
+    ...    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR
+    IF    ${sudo}
+        ${effective_command}    Set Variable    sudo ${command}
+        ${ssh_options}         Set Variable    -t ${ssh_options}
+    END
+    ${escaped_cmd}     Replace String    ${effective_command}    "    \\" 
+    ${ssh_command}     Set Variable    ssh ${ssh_options} ${vm} "${escaped_cmd}"
+    IF  $output_redirect != 'NONE'
+        ${ssh_command}     Set Variable    ${ssh_command} > ${output_redirect}
+    END
+    Run Keyword If     ${pre_flush}    Drain Serial Output
+    IF  ${logging}
+        IF    ${sudo}
+            Log    Running sudo command in ${vm}    console=True
+        ELSE
+            Log    Running command in ${vm}    console=True
+        END
+    END
     Write Data         ${ssh_command}${\n}
-    # Consume echoed command line to avoid matching marker before command output
+    # Consume echoed command line
     SerialLibrary.Read Until    terminator=${\n}
-    ${pre_output}      Set Variable    ${EMPTY}
     ${search1}         Set Variable    (yes/no/[fingerprint])?
     ${search2}         Set Variable    assword
     ${status}  ${output}  Run Keyword And Ignore Error  SerialLibrary.Read Until  terminator=${search1}
     IF  $search1 in $output
-        ${pre_output}    Catenate    SEPARATOR=    ${pre_output}    ${output}
         Write Data       yes${\n}
         SerialLibrary.Read Until    terminator=${\n}
         ${status}  ${output}  Run Keyword And Ignore Error  SerialLibrary.Read Until  terminator=${search2}
         IF  $search2 in $output
-            ${pre_output}    Catenate    SEPARATOR=    ${pre_output}    ${output}
-            Write Data    ${PASSWORD}${\n}
+            Send Password Via Serial Quietly
         END
     ELSE
         IF  $search2 in $output
-            ${pre_output}    Catenate    SEPARATOR=    ${pre_output}    ${output}
-            Write Data    ${PASSWORD}${\n}
+            Send Password Via Serial Quietly
         END
     END
-    IF  not $marker in $output
-        ${output}          SerialLibrary.Read Until    terminator=${marker}
+    # If the command was run with sudo expect another password prompt
+    IF    ${sudo}
+        ${status}  ${output}  Run Keyword And Ignore Error  SerialLibrary.Read Until  terminator=${search2}
+        IF  $search2 in $output
+            Send Password Via Serial Quietly
+        END
     END
-    IF  not $marker in $output
-        Log    ${output}
-        FAIL   Failed to run command on ${vm} via serial
+    ${prompt_output}   SerialLibrary.Read Until    terminator=ghaf@${HOST}:
+    IF    ${opened_here}
+        Delete All Ports
     END
-    ${output}          Replace String    ${output}    ${marker}    ${EMPTY}
-    ${output}          Replace String    ${output}    \r    ${EMPTY}
-    ${output}          Catenate    SEPARATOR=    ${pre_output}    ${output}
-    SerialLibrary.Read Until    ghaf@${HOST}:
-    Delete All Ports
-    ${clean_output}    Strip String    ${output}
+    ${clean_output}    Normalize Serial Output    ${prompt_output}
     Log                ${clean_output}
     ${lower_output}    Convert To Lowercase    ${clean_output}
-    IF  'permission denied' in $lower_output or 'could not resolve hostname' in $lower_output or 'no route to host' in $lower_output
+    ${has_vm_error}    Evaluate    'permission denied' in $lower_output or 'could not resolve hostname' in $lower_output or 'no route to host' in $lower_output or 'sorry, try again' in $lower_output
+    IF    ${has_vm_error}
+        IF    ${sudo}
+            FAIL    Failed to execute sudo command '${command}' on ${vm} via serial: ${clean_output}
+        END
         FAIL    Failed to execute '${command}' on ${vm} via serial: ${clean_output}
     END
     RETURN            ${clean_output}
+
+Send Password Via Serial Quietly
+    [Documentation]    Send a password over serial with logging disabled.
+    ${previous_log_level}    Set Log Level    NONE
+    Write Data    ${PASSWORD}${\n}
+    Set Log Level    ${previous_log_level}
+
+Start UART Log Capture
+    [Documentation]    Open the serial port for passive UART capture and initialize the target log file.
+    [Arguments]    ${log_file}=${EMPTY}
+    IF  "${SERIAL_PORT}" == "NONE"
+        Log To Console         No serial port defined. Cannot start UART log capture.
+        Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
+        RETURN
+    END
+    Create Directory   ${BOOT_DIAGNOSTICS_DIR}
+    ${test_name}       Replace String     ${TEST_NAME}   ${SPACE}   _
+    ${capture_file}    Set Variable If    '${log_file}' == '${EMPTY}'    ${BOOT_DIAGNOSTICS_DIR}/${BUILD_ID}_${test_name}.txt    ${log_file}
+    ${status}    Open Serial Port    timeout=5.0
+    IF    not ${status}
+        Log To Console    Failed to open serial port for UART capture.
+        Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
+        RETURN
+    END
+    Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${True}
+    Set Global Variable    ${UART_CAPTURE_FILE}      ${capture_file}
+    OperatingSystem.Create File    ${UART_CAPTURE_FILE}
+
+Drain Serial Output
+    [Documentation]    Drain pending serial output until idle or timeout, optionally appending normalized output to the UART log file.
+    [Arguments]    ${save_output}=${False}    ${max_seconds}=3
+    ${empty_reads}    Set Variable    0
+    ${start_time}    Get Time    epoch
+    WHILE    True
+        ${elapsed}    Evaluate    int(time.time()) - int(${start_time})
+        IF    ${elapsed} >= ${max_seconds}
+            BREAK
+        END
+        ${status}    ${output}    Run Keyword And Ignore Error    SerialLibrary.Read Until    terminator=${\n}
+        IF    '${status}' != 'PASS'
+            BREAK
+        END
+        ${clean_output}    Strip String    ${output}
+        IF    $clean_output == '${EMPTY}'
+            ${empty_reads}    Evaluate    ${empty_reads} + 1
+            IF    ${empty_reads} > 2
+                BREAK
+            END
+            CONTINUE
+        END
+        ${empty_reads}    Set Variable    0
+        IF  ${save_output}
+            Append Normalized UART Capture    ${output}
+        END
+    END
+
+Append Normalized UART Capture
+    [Documentation]    Normalize raw serial text and append only readable content to the active UART log file.
+    [Arguments]    ${output}
+    IF    not ${UART_CAPTURE_ACTIVE}
+        RETURN
+    END
+    ${normalized_output}    Normalize Serial Output    ${output}
+    IF    $normalized_output != ''
+        OperatingSystem.Append To File    ${UART_CAPTURE_FILE}    ${normalized_output}${\n}
+    END
+
+Collect Failure Diagnostics Via Serial
+    [Documentation]    Collect host and VM diagnostics via serial after a failed boot.
+    ...                Use various ways to collect specific command output, depending on
+    ...                - how small/large output is expected,
+    ...                - if sudo is required
+    ...                - target location for running the command ( host / vm )
+    IF    ${UART_CAPTURE_ACTIVE}
+        ${status}    Run Keyword And Return Status    Wait Until Keyword Succeeds    24x    5s    Log In To Ghaf OS    attempts=1
+    ELSE
+        ${status}    Run Keyword And Return Status    Connect via serial    timeout=20
+    END
+    IF    not ${status}
+        Log    Failed to connect via serial, UART diagnostics were not collected.
+        RETURN
+    END
+    Log To Console    Collecting failure diagnostics via UART...
+
+    @{diagnostic_commands}    Create List
+    ...    uname -r
+    ...    uptime
+    ...    systemd-analyze
+    ...    ip -br a
+    ...    ss -tlnp
+    ...    systemctl --failed --no-legend
+
+    ${dmesg_command}   Set Variable   dmesg | tail -200
+
+    # Commands with expected small output
+    Run Diagnostic Commands Via Serial    ${HOST}    @{diagnostic_commands}
+
+    # Collect expected large outputs by splitting them into batches
+    Run Command On Serial    sh -c '${dmesg_command} > /tmp/${HOST}-dmesg.txt'    sudo=${True}    pre_flush=${False}
+    Sleep    1
+    Save Serial File Output To File    /tmp/${HOST}-dmesg.txt    ${BOOT_DIAGNOSTICS_DIR}/${HOST}-dmesg.txt
+    Run Command On Serial    sh -c 'journalctl -b --no-pager -o short-monotonic > /tmp/${HOST}_journalctl_-b.txt'    pre_flush=${True}
+    Sleep    1
+    Save Serial File Output To File    /tmp/${HOST}_journalctl_-b.txt    ${BOOT_DIAGNOSTICS_DIR}/${HOST}_journalctl_-b.txt
+    Run Command On Serial    sh -c 'journalctl -u microvm@net-vm --no-pager > /tmp/ghaf-host-microvm-net-vm-journal.txt'    pre_flush=${False}
+    Sleep    1
+    Save Serial File Output To File    /tmp/ghaf-host-microvm-net-vm-journal.txt    ${BOOT_DIAGNOSTICS_DIR}/ghaf-host-microvm-net-vm-journal.txt
+
+    Drain Serial Output
+    ${vm_list_output}    Run Command On Serial    command ls --color=never -1 /var/lib/microvms/
+    @{vm_list}    Get Regexp Matches    ${vm_list_output}    (?m)^[A-Za-z0-9_.-]+$
+    Should Not Be Empty    ${vm_list}    VM list is empty
+    FOR    ${vm}    IN    @{vm_list}
+        Run Diagnostic Commands Via Serial    ${vm}    @{diagnostic_commands}
+
+        ${dmesg_output}    Run Command on VM Via Serial    ${vm}    sh -c '${dmesg_command}'    sudo=${True}    pre_flush=${False}    logging=${False}
+        OperatingSystem.Create File        ${BOOT_DIAGNOSTICS_DIR}/${vm}-dmesg.txt    ${dmesg_output}
+
+        Run Command on VM Via Serial    ${vm}    sh -c 'journalctl -b --no-pager -o short-monotonic'    output_redirect=/tmp/${vm}_journalctl_-b.txt    pre_flush=${True}    logging=${False}
+        Sleep    1
+        Save Serial File Output To File    /tmp/${vm}_journalctl_-b.txt    ${BOOT_DIAGNOSTICS_DIR}/${vm}_journalctl_-b.txt
+    END
+
+Run Diagnostic Commands Via Serial
+    [Documentation]    Run each diagnostic command, store its output on the host, and copy it to the local output directory.
+    [Arguments]    ${vm}    @{commands}
+    Log    Collecting diagnostics from ${vm}    console=True
+    FOR    ${command}    IN    @{commands}
+        ${output_name}    Replace String    ${command}    ${SPACE}    _
+        IF  $vm != '${HOST}'
+            ${dmesg_output}    Run Command on VM Via Serial    ${vm}    sh -c '${command}'    pre_flush=${True}    logging=${False}
+            OperatingSystem.Create File        ${BOOT_DIAGNOSTICS_DIR}/${vm}_${output_name}.txt    ${dmesg_output}
+            Log    Saved "${command}" output from ${vm} to ${BOOT_DIAGNOSTICS_DIR}/${vm}_${output_name}.txt    console=True
+        ELSE
+            ${dmesg_output}    Run Command On Serial    sh -c '${command}'    pre_flush=${True}
+            OperatingSystem.Create File        ${BOOT_DIAGNOSTICS_DIR}/${HOST}_${output_name}.txt    ${dmesg_output}
+            Log    Saved "${command}" output from ${HOST} to ${BOOT_DIAGNOSTICS_DIR}/${HOST}_${output_name}.txt    console=True
+        END
+    END
+
+Save Serial File Output To File
+    [Documentation]    Copy a host-side file through serial session to a local file in fixed-size line batches.
+    [Arguments]    ${remote_file}    ${output_file}    ${batch_size}=300
+    Save File Output Via Serial Chunk Read    ${output_file}    ${batch_size}    Read Serial File Chunk    ${remote_file}
+
+Save VM File Output To File
+    [Documentation]    Copy a VM-side file through serial connection and ssh tunnel to a local file in fixed-size line batches.
+    [Arguments]    ${vm}    ${remote_file}    ${output_file}    ${batch_size}=300
+    Save File Output Via Serial Chunk Read    ${output_file}    ${batch_size}    Read VM File Chunk    ${vm}    ${remote_file}
+
+Save File Output Via Serial Chunk Read
+    [Documentation]    Shared chunked file-copy loop used by host and VM serial readers to avoid large in-memory outputs.
+    [Arguments]    ${output_file}    ${batch_size}    ${read_chunk_keyword}    @{read_chunk_args}    ${timeout}=30
+    OperatingSystem.Create File    ${output_file}
+    ${start_line}      Set Variable    1
+    ${copied_lines}    Set Variable    0
+    ${start_time}      Get Time	epoch
+    # Prevent outputs from previous commands leaking into the output files
+    Drain Serial Output
+    WHILE    True
+        ${elapsed}     Evaluate    int(time.time()) - int(${start_time})
+        IF    ${elapsed} > ${timeout}
+            BREAK
+        END
+        ${end_line}    Evaluate    ${start_line} + ${batch_size} - 1
+        ${chunk}    Run Keyword    ${read_chunk_keyword}    @{read_chunk_args}    ${start_line}    ${end_line}
+        ${chunk}    Strip String    ${chunk}
+        IF    $chunk == ''
+            Log To Console    No more lines to copy from serial source after line ${start_line}.
+            BREAK
+        END
+        OperatingSystem.Append To File    ${output_file}    ${chunk}${\n}
+        ${chunk_line_count}               Evaluate    len($chunk.splitlines())
+        ${copied_lines}                   Evaluate    ${copied_lines} + ${chunk_line_count}
+        ${start_line}                     Evaluate    ${start_line} + ${batch_size}
+        Log To Console                    Copied ${chunk_line_count} lines (${copied_lines} total) from serial source to ${output_file}
+        ${break_limit}                    Evaluate    int(${batch_size} / 2)
+        IF    ${chunk_line_count} < ${break_limit}
+            BREAK
+        END
+    END
+
+Read Serial File Chunk
+    [Documentation]    Read a line range from a host-side file over the serial shell.
+    [Arguments]    ${remote_file}    ${start_line}    ${end_line}
+    ${chunk_command}    Set Variable    sed -n '${start_line},${end_line}p' ${remote_file}
+    ${chunk}    Run Command On Serial    ${chunk_command}    timeout=30    pre_flush=${False}
+    RETURN    ${chunk}
+
+Read VM File Chunk
+    [Documentation]    Read a line range from a VM-side file through the serial SSH tunnel.
+    [Arguments]    ${vm}    ${remote_file}    ${start_line}    ${end_line}
+    ${chunk_command}    Set Variable    sed -n '${start_line},${end_line}p' ${remote_file}
+    ${chunk}    Run Command on VM Via Serial    ${vm}    ${chunk_command}    pre_flush=${False}    logging=${False}
+    RETURN    ${chunk}
+
+Normalize Serial Output
+    [Documentation]    Remove terminal control related sequences. Keep only readable serial text.
+    [Arguments]    ${raw}
+    ${output}    Replace String    ${raw}    \r    ${EMPTY}
+    # Strip CSI escape sequences used for screen control, colors, cursor moves, and terminal resets.
+    ${output}    Replace String Using Regexp    ${output}    \\x1B\\[[0-?]*[ -/]*[@-~]    ${EMPTY}
+    # Strip OSC escape sequences, such as title-setting and similar terminal metadata.
+    ${output}    Replace String Using Regexp    ${output}    \\x1B\\][^\\x07]*(\\x07|\\x1B\\\\)    ${EMPTY}
+    # Strip DCS / PM / APC style escape sequences that some firmware and consoles emit.
+    ${output}    Replace String Using Regexp    ${output}    \\x1B[P^_].*?\\x1B\\\\    ${EMPTY}
+    # Remove remaining ASCII control characters, keeping printable text only.
+    ${output}    Replace String Using Regexp    ${output}    [\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F]    ${EMPTY}
+    ${lines}    Split To Lines    ${output}
+    ${clean_output}    Set Variable    ${EMPTY}
+    FOR    ${line}    IN    @{lines}
+        ${line}    Strip String    ${line}
+
+        # Drop lines which are not considered as command output
+        IF    $line == ''
+            CONTINUE
+        END
+        ${is_host_prompt}    Run Keyword And Return Status
+        ...    Should Match Regexp    ${line}    ^\\[ghaf@[^]]+\\]\\$$
+        IF    ${is_host_prompt}
+            CONTINUE
+        END
+        ${is_osc_prompt}    Run Keyword And Return Status
+        ...    Should Match Regexp    ${line}    ^\\[]0;ghaf@[^:]+:.*$
+        IF    ${is_osc_prompt}
+            CONTINUE
+        END
+        ${is_password_prompt}    Run Keyword And Return Status
+        ...    Should Match Regexp    ${line}    ^\\(ghaf@[^)]+\\) Password:( \\(ghaf@[^)]+\\) Password:)*\\s*$
+        IF    ${is_password_prompt}
+            CONTINUE
+        END
+
+        ${clean_output}    Catenate    SEPARATOR=\n    ${clean_output}    ${line}
+    END
+    ${clean_output}    Strip String    ${clean_output}
+    RETURN    ${clean_output}

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -116,11 +116,16 @@ Check Network Availability
     FAIL    Expected availability of ${host}: ${expected_result}, in fact: ${availability}
 
 Check If Device Is Up
-    [Arguments]    ${range}=50
-    Set Global Variable    ${IS_AVAILABLE}       False
+    [Arguments]    ${range}=50    ${timeout}=500
     ${start_time}=    Get Time	epoch
+    ${ping}    Set Variable    ${False}
     FOR    ${i}    IN RANGE    ${range}
+        ${elapsed}    Evaluate    int(time.time()) - int(${start_time})
+        IF    ${elapsed} >= ${timeout}
+            BREAK
+        END
         Log         Ping ${DEVICE_IP_ADDRESS}...    console=True
+        Run Keyword If    ${UART_CAPTURE_ACTIVE}    Drain Serial Output    save_output=${True}
         ${ping}=    Ping Host   ${DEVICE_IP_ADDRESS}
         Sleep       ${PING_SPACING}
         IF    ${ping}
@@ -145,7 +150,9 @@ Check If Device Is Up
 
     IF  ${IS_AVAILABLE} == False
         Log To Console    Device is not available via SSH, waited for ${diff} sec!
-        IF  "${SERIAL_PORT}" == "NONE"
+        IF  ${UART_CAPTURE_ACTIVE}
+            Log To Console    UART capture is active, leaving serial recovery for teardown.
+        ELSE IF  "${SERIAL_PORT}" == "NONE"
             Log To Console    There is no address for serial connection
         ELSE
             Check Serial Connection

--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -17,9 +17,10 @@ Suite Teardown      Teardown
 
 
 *** Variables ***
-${CONNECTION_TYPE}       ssh
-${IS_AVAILABLE}          False
-${DEVICE_TYPE}           ${EMPTY}
+${CONNECTION_TYPE}           ssh
+${IS_AVAILABLE}              False
+${DEVICE_TYPE}               ${EMPTY}
+${SAVE_BOOT_LOGS_ON_PASS}    ${True}
 
 
 *** Test Cases ***
@@ -28,12 +29,13 @@ Verify booting after restart by power
     [Documentation]    Restart device by power and verify init service is running
     [Tags]             relayboot  orin-agx  orin-agx-64  orin-nx
     Reboot Orin
-    Check If Device Is Up   range=70
+    Start UART Log Capture
 
+    Check If Device Is Up   timeout=140
     IF      "${DEVICE_TYPE}" == "orin-nx" and ${IS_AVAILABLE} == False
             Log                     message=Orin-nx failed to start, rebooting via relay one more time...    level=WARN
             Reboot Orin
-            Check If Device Is Up   range=70
+            Check If Device Is Up   timeout=140
     END
 
     IF    ${IS_AVAILABLE} == False
@@ -51,6 +53,7 @@ Verify booting after restart by power
     ELSE IF  "${CONNECTION_TYPE}" == "serial"
         Verify init.scope status via serial
     END
+
     [Teardown]   Test Teardown
 
 Verify booting laptop
@@ -58,14 +61,14 @@ Verify booting laptop
     [Tags]             SP-T287  SP-T290  relayboot  lenovo-x1  darter-pro  dell-7330
     Reboot Laptop      verify_shutdown=False
     IF    "installer" in "${JOB}"
-        Check If Device Is Up    range=240
+        Check If Device Is Up    range=240    timeout=490
     ELSE
-        Check If Device Is Up
+        Check If Device Is Up    timeout=110
     END
     IF    ${IS_AVAILABLE} == False
         Log To Console    Turning device on again...
         Turn Laptop On
-        Check If Device Is Up
+        Check If Device Is Up    timeout=110
     END
     IF    ${IS_AVAILABLE} == False
         FAIL    The device did not start
@@ -177,10 +180,16 @@ Break the system
 Test Teardown
     IF  ${IS_AVAILABLE}
         IF  "${CONNECTION_TYPE}" == "ssh"
-            Run Keyword If Test Failed    ssh_keywords.Save log
+            Run Keyword If Test Failed    Run Keyword And Ignore Error    ssh_keywords.Save log
         ELSE IF  "${CONNECTION_TYPE}" == "serial"
-            Run Keyword If Test Failed    serial_keywords.Save log
+            Run Keyword If Test Failed    Run Keyword And Ignore Error    ssh_keywords.Save log
         END
+    END
+    IF  not ${IS_LAPTOP}
+        Run Keyword If Test Failed    Collect Failure Diagnostics Via Serial
+    END
+    IF    ${UART_CAPTURE_ACTIVE} and not ${SAVE_BOOT_LOGS_ON_PASS}
+        Run Keyword If Test Passed    OperatingSystem.Remove File    ${UART_CAPTURE_FILE}
     END
 
 Teardown
@@ -235,13 +244,13 @@ Save commit hash on target device
     ${file_found}     Run Keyword And Return Status    Check file exists    ${commit_path}    sudo=True
     ${flashed_bool}   Convert To Boolean    ${FLASHED}
     IF  ${file_found}
-        IF  ${flashed_bool}
-            FAIL    Expected fresh installation but found existing ${commit_path}\nProbably something has gone wrong in flashing or installing.
-        END
         ${saved_commit}    Get File Content Or Default        /persist/build_commit
         ${saved_job}       Get File Content Or Default        /persist/job
         Log    Ghaf commit hash entry found on the target device: ${saved_commit}    console=True
         Log    Job entry found on the target device: ${saved_job}                    console=True
+        IF  ${flashed_bool}
+            FAIL    Expected fresh installation but found existing ${commit_path}\nProbably something has gone wrong in flashing or installing.
+        END
         RETURN
     END
     IF  ${flashed_bool}


### PR DESCRIPTION
Gather various logs requested by Vadim for Orin boot diagnostics.

Modified keywords in serial_keywords.resource in such a way which might have impact on tests using serial. --> Running some firewall tests in addition to boot tests.

Boot & firewall tests on darter-pro
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6105/