### PR TITLE
Fix logout test and screen recording

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -145,7 +145,7 @@ Locate on screen
         ELSE
             ${error}     Get Regexp Matches   ${result}   (?s)Error:\s*(.+)$
             ${log_msg}   Set Variable If   ${error}   ${error}[0]   ${result}
-            Log     FAIL: ${log_msg}   console=True
+            Log     Screenshot failed: ${log_msg}   console=True
             Sleep   0.5
         END
     END
@@ -326,12 +326,13 @@ Run ydotool command
     Sleep   0.2
 
 Start screen recording
-    [Setup]          Kill App By Name   gpu-screen-recorder
+    [Setup]          Stop screen recording service
     [Timeout]        1 minute
     Log To Console   Starting screen recording
     ${test_name}     Replace String   ${TEST_NAME}   ${SPACE}   _
     ${cmd}=    Catenate    SEPARATOR=${SPACE}
-    ...    systemd-run --user --collect /bin/sh -lc 'exec gpu-screen-recorder
+    ...    systemd-run --user --collect --no-block --unit=robot-screen-recording --property=PartOf=graphical-session.target --property=KillMode=control-group
+    ...    /bin/sh -lc 'WAYLAND_DISPLAY=wayland-1 exec gpu-screen-recorder
     ...    -w portal -c mkv -k h264 -ac opus -f 60 -cursor yes -restore-portal-session yes
     ...    -cr limited -encoder gpu -q very_high -a device:default_output
     ...    -o /home/${USER_LOGIN}/Videos/${test_name}.mkv
@@ -349,14 +350,22 @@ Start screen recording
         END
         Set Global Variable  ${SCREEN_SELECTED}  ${True}
     END
-    Check that the application was started   gpu-screen-recorder
+    Wait Until Keyword Succeeds    5x    1s    Run Command    ls -la /home/${USER_LOGIN}/Videos/${test_name}.mkv
     [Teardown]       Run Keyword If   '${KEYWORD_STATUS}' == 'FAIL'   Timestamp last screenshot
 
 Stop screen recording
     [Arguments]      ${test_status}   ${test_name}=""
     Log To Console   Stopping screen recording
-    Kill process by name   gpu-screen-recorder   sudo=False   require_exists=False
+    Stop screen recording service
     Save screen recording   ${test_status}   ${test_name}
+
+Stop screen recording service
+    ${service_state}    Run Command    systemctl --user is-active robot-screen-recording.service    rc_match=skip
+    IF   '${service_state}' == 'active'
+        Log           Screen recorder is running, stopping it                     console=True
+        Run Command   systemctl --user stop robot-screen-recording.service        rc_match=skip
+        Run Command   systemctl --user is-active robot-screen-recording.service   rc_match=not_equal   compare_rc=0
+    END
 
 Save screen recording
     [Arguments]    ${test_status}   ${test_name}

--- a/Robot-Framework/test-suites/gui-tests/__init__.robot
+++ b/Robot-Framework/test-suites/gui-tests/__init__.robot
@@ -22,5 +22,5 @@ GUI Tests Setup
 GUI Tests Teardown
     [Timeout]    5 minutes
     # In case the screen recording was not stopped
-    Kill App By Name        gpu-screen-recorder
+    Stop screen recording service
     Clean Up Test Environment   disable_dnd=True

--- a/Robot-Framework/test-suites/gui-tests/gui_power.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power.robot
@@ -48,7 +48,7 @@ Lock and Unlock from power menu
 Reboot from power menu
     [Documentation]   Reboot the device via GUI power menu reboot icon.
     ...               Check that it shuts down. Check that it turns on and boots to login screen.
-    [Tags]            SP-T75  SP-T75-4  lenovo-x1  darter-pro
+    [Tags]            SP-T75  SP-T75-4  lenovo-x1  darter-pro  lab-only
     Select power menu option   x=870   y=120   confirmation=True
     ${start_time}     Get Time    epoch
     Verify shutdown via network
@@ -106,6 +106,7 @@ Log out and log in with shortcut
     ...               Login and verify that desktop is available.
     [Tags]            SP-T186  lenovo-x1  darter-pro
     Press Key(s)                LEFTMETA+LEFTSHIFT+ESC
+    Locate on screen            text  Quit  10
     Tab and enter               tabs=1
     ${logout_status}            Check if logged out
     Should Be True              ${logout_status}    Logout failed
@@ -113,7 +114,7 @@ Log out and log in with shortcut
 
 Suspend and wake up from lock screen
     [Documentation]   Suspend the device from lock screen suspend icon and wake up.
-    [Tags]            SP-T245  lenovo-x1  darter-pro
+    [Tags]            SP-T245  lenovo-x1  darter-pro  lab-only
     Press Key(s)          LEFTMETA+ESC
     Locate on screen      image  ${LOCK_ICON}   0.95  10
     Run ydotool command   mousemove --absolute -x 320 -y 275


### PR DESCRIPTION
Fixes two issues
* Screen recording not working after logout-login
* Logout failure in `Log out and log in with shortcut`

Changes
* Tie screen recorder to the graphical session, when session ends (user logs out) the recording process also automatically stops. Previously recording stopped but the process stayed running in the background and caused issues when new recording was started.
* Confirm that the screen recorder started to record to a file after starting it. Note: This might cause failures, but will help to notice if there are more issues with the recording starting. Previously these issue where ignored which caused the issue to go unnoticed for a long time.
* Stop screen recording with `systemctl --user stop` to allow it to terminate gracefully.
* Check that confirmation window was opened before logging out in `Log out and log in with shortcut`.
* Mark reboot and suspend tests as `lab-only` (robot fingers needed).

Testruns
- Darter https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6101/
- Darter with all videos https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6100/
