### PR TITLE
Refactor saving logs

### DIFF
--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -83,8 +83,29 @@ Turn Laptop On and Connect
 Soft Reboot Device And Connect
     [Documentation]  Reboot device from ${vm} and connect after the reboot
     [Arguments]      ${vm}=${HOST}
-    Soft Reboot Device   ${vm}
-    Connect After Reboot   soft_reboot=True
+    ${reboot_log_since}    Get Time    epoch
+    ${soft_reboot_ok}      Run Keyword And Return Status
+    ...    Run Keywords
+    ...    Soft Reboot Device   ${vm}
+    ...    AND
+    ...    Connect After Reboot   soft_reboot=True
+    IF    not ${soft_reboot_ok}
+        Collect Logs After Failed Soft Reboot    ${reboot_log_since}
+        FAIL    Soft reboot failed.
+    END
+
+Collect Logs After Failed Soft Reboot
+    [Arguments]    ${since}
+    ${device_is_up}    Run Keyword And Return Status    Ping Host    ${DEVICE_IP_ADDRESS}
+    IF    ${device_is_up}
+        ${ssh_is_ready}    Run Keyword And Return Status    ssh_keywords.Check if ssh is ready on device
+        IF    ${ssh_is_ready}
+            Run Keyword And Continue On Failure    ssh_keywords.Save log   ${HOST}    ${since}
+            Run Keyword And Continue On Failure    ssh_keywords.Save log   ${GUI_VM}  ${since}
+        ELSE
+            Run Keyword And Continue On Failure    serial_keywords.Save log    ${since}
+        END
+    END
 
 Soft Reboot Device
     [Documentation]  Reboot device from ${vm}

--- a/Robot-Framework/resources/serial_keywords.resource
+++ b/Robot-Framework/resources/serial_keywords.resource
@@ -134,11 +134,16 @@ Connect via serial
     RETURN    ${status}
 
 Save log
+    [Arguments]         ${since}=${EMPTY}
     ${status}            Connect via serial   timeout=60.0
     IF    ${status}==False
         Log    Failed to connect via serial, journalctl logs will be not saved.
     ELSE
-        Write Data           sh -c 'journalctl | tee jrnl.txt | cat'${\n}
+        ${journalctl_cmd}    Set Variable    journalctl
+        IF    '${since}' != '${EMPTY}'
+            ${journalctl_cmd}    Set Variable    journalctl --since "@${since}"
+        END
+        Write Data           sh -c '${journalctl_cmd} | tee /tmp/jrnl.txt | cat'${\n}
         ${output}            SerialLibrary.Read Until    ghaf@${HOST}:
         Write Advanced Testlog    journalctl.txt     ${output}
         Log  ${output}

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -225,10 +225,14 @@ Connect to VM
     RETURN   ${connection}
 
 Save log
-    Switch to vm  ${HOST}
-    Run Command   journalctl > jrnl.txt${\n}
-    Run Command   cat jrnl.txt${\n}
-    Close All Connections
+    [Arguments]       ${host}=${HOST}  ${since}=${EMPTY}
+    Switch to vm  ${host}
+    ${journalctl_cmd}    Set Variable    journalctl
+    IF    '${since}' != '${EMPTY}'
+        ${journalctl_cmd}    Set Variable    journalctl --since "@${since}"
+    END
+    Run Command   ${journalctl_cmd} > /tmp/jrnl.txt${\n}
+    Run Command   cat /tmp/jrnl.txt${\n}
 
 Check if ssh is ready on vm
     [Arguments]    ${vm}  ${timeout}=40

--- a/Robot-Framework/test-suites/gui-tests/gui_power.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power.robot
@@ -124,16 +124,19 @@ Suspend and wake up from lock screen
 *** Keywords ***
 
 GUI Power Test Setup
+    ${gui_power_log_since}    BuiltIn.Get Time   epoch
+    Set Test Variable         ${gui_power_log_since}
     Switch to vm    ${GUI_VM}   user=${USER_LOGIN}
     Start screen recording
 
 GUI Power Test Teardown
     IF  $TEST_STATUS == 'FAIL' and not 'took too long' in $TEST_MESSAGE
-        Run keyword and continue on failure    serial_keywords.Save log
         Reboot Laptop
         Connect After Reboot
         IF    ${IS_AVAILABLE}
-            Login to laptop   enable_dnd=True
+            ssh_keywords.Save log   ${GUI_VM}  ${gui_power_log_since}
+            ssh_keywords.Save log   ${HOST}    ${gui_power_log_since}
+            Login to laptop         enable_dnd=True
             Save screen recording   ${TEST_STATUS}   ${TEST_NAME}
         END
     ELSE


### PR DESCRIPTION
Added saving logs via serial for all Soft reboot's, will save only logs since time of reboot, because long journalctl currently is not saved fully, end is cut
[Example of saving log](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6108/artifact/Robot-Framework/test-suites/SP-T75-4/log.html#s1-s1-s1-t1-k11-k1-k1-k1-k3-k6), made test fail by removing rebooting command from the test, so log is very short
And [the test run](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6123/artifact/Robot-Framework/test-suites/SP-T75-4/log.html#s1-s1-s1-t1-k11-k1-k3) with no failings, but it shows that nothing was broken