### PR TITLE
Change Cosmic Settings process name

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/apps.robot
+++ b/Robot-Framework/test-suites/functional-tests/apps.robot
@@ -40,7 +40,7 @@ Start COSMIC Media Player
 Start COSMIC Settings
     [Documentation]   Start Cosmic Settings and verify process started
     [Tags]            SP-T254  fmo
-    Start application in VM   "COSMIC Settings"   ${GUI_VM}   cosmic-settings-wrapped
+    Start application in VM   "COSMIC Settings"   ${GUI_VM}   cosmic-settings$
 
 Start COSMIC Terminal
     [Documentation]   Start Cosmic Terminal and verify process started

--- a/Robot-Framework/test-suites/gui-tests/gui_settings.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_settings.robot
@@ -26,7 +26,7 @@ Change timezone in settings
 
     [Teardown]   Run Keywords   Set timezone   ${ORIGINAL_TIMEZONE}
     ...          AND   Move cursor to corner
-    ...          AND   Kill process by name    cosmic-settings-wrapped   sudo=False
+    ...          AND   Kill process by name    cosmic-settings$   sudo=False
     ...          AND   Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
 *** Keywords ***

--- a/Robot-Framework/test-suites/performance-tests/time_to_launch_apps.robot
+++ b/Robot-Framework/test-suites/performance-tests/time_to_launch_apps.robot
@@ -94,11 +94,10 @@ Measure time to launch COSMIC Media Player
 Measure time to launch COSMIC Settings
     [Documentation]   Start COSMIC Settings via GUI and measure time of launching
     [Tags]            SP-T285-11
-    Start app via GUI   ${GUI_VM}  cosmic-settings-wrapped  display_name="COSMIC Settings"
-    Close app via GUI   ${GUI_VM}  cosmic-settings-wrapped  ghaf-close.png
-    Save launch time    cosmic-settings-wrapped
-    [Teardown]    Run Keyword If Test Failed    Run Keywords  Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
-    ...                                                 AND   Skip  "Known Issue: SSRCSP-7518"
+    Start app via GUI   ${GUI_VM}  cosmic-settings$  display_name="COSMIC Settings"
+    Close app via GUI   ${GUI_VM}  cosmic-settings$  ghaf-close.png
+    ${status}    ${message}    Run Keyword And Ignore Error    Save launch time    cosmic-settings$
+    Run Keyword If    '${status}' == 'FAIL'    SKIP    Known Issue: SSRCSP-7518 (${message})
 
 Measure time to launch COSMIC Terminal
     [Documentation]   Start COSMIC Terminal via GUI and measure time of launching


### PR DESCRIPTION
To be merged together with https://github.com/tiiuae/ghaf/pull/1936

- Update process name for Cosmic Settings
- Improve `Measure time to launch COSMIC Settings` skip condition so that the test is only skipped when it fails due to a long launch time. Previously it was also skipped if it did not start at all.

https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6164/