### PR TITLE
Add skip for brightness and Dell logging

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/logging.robot
+++ b/Robot-Framework/test-suites/functional-tests/logging.robot
@@ -70,11 +70,12 @@ Check logging rate
     [Documentation]    Check that host or vms are not creating too much logs
     [Tags]             SP-T359  log_rate  pre-merge  orin-agx  orin-agx-64  orin-nx
 
-    ${check_interval}     Set Variable   100
-    ${saved_entries}      Set Variable   2000
-    ${entry_limit}        Set Variable   500
-    ${orin_entry_limit}   Set Variable   2000
-    ${bytes_per_entry}    Set Variable   200
+    ${check_interval}          Set Variable   100
+    ${saved_entries}           Set Variable   2000
+    ${entry_limit}             Set Variable   500
+    ${dell_host_entry_limit}   Set Variable   1000   # Known Issue: SSRCSP-8481
+    ${orin_entry_limit}        Set Variable   2000
+    ${bytes_per_entry}         Set Variable   200
 
     &{spam_metrics}       Create Dictionary
     &{ok_metrics}         Create Dictionary
@@ -104,6 +105,8 @@ Check logging rate
         IF  '${switch_status}' == 'PASS'
             IF  "orin" in "${DEVICE_TYPE}"
                 ${vm_entry_limit}   Set Variable   ${orin_entry_limit}
+            ELSE IF  "${DEVICE_TYPE}" == "dell-7330" and '${vm}' == '${HOST}'
+                ${vm_entry_limit}   Set Variable   ${dell_host_entry_limit}  # Known Issue: SSRCSP-8481
             ELSE
                 ${vm_entry_limit}   Set Variable   ${entry_limit}
             END

--- a/Robot-Framework/test-suites/security-tests/persistence.robot
+++ b/Robot-Framework/test-suites/security-tests/persistence.robot
@@ -31,7 +31,7 @@ Verify camera block persisted
     ${cam_state}      Get device state   cam
     Should Be Equal   ${EXPECTED_CAM_STATE}  ${cam_state}
     [Teardown]   Run Keyword If Test Failed   Run Keywords   Log persistence setup errors
-    ...    AND   Run Keyword If   "${DEVICE_TYPE}" == "lenovo-x1"   SKIP   Known issue: SSRCSP-8224
+    ...    AND   Run Keyword If   "${DEVICE_TYPE}" == "lenovo-x1" or "${DEVICE_TYPE}" == "x1-sec-boot"   SKIP   Known issue: SSRCSP-8224
 
 Verify microphone block persisted
     [Tags]    SP-T305  SP-T305-2
@@ -52,6 +52,8 @@ Verify brightness persisted
     [Tags]    SP-T326  SP-T326-1
     ${brightness}     Get screen brightness
     Should Be Equal   ${EXPECTED_BRIGHTNESS}  ${brightness}
+    [Teardown]   Run Keyword If Test Failed   Run Keywords   Log persistence setup errors
+    ...                                                AND   SKIP   Known issue: SSRCSP-8482
 
 Verify volume persisted
     [Tags]    SP-T326  SP-T326-2

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -4,6 +4,8 @@
 
 | DATE SET   | TEST CASE                                               | TICKET / Additional Data.                                                                     |
 | ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| 22.05.2026 | Verify brightness persisted                             | SSRCSP-8482                                                                                   |
+| 22.05.2026 | Check logging rate (Dell)                               | SSRCSP-8481                                                                                   |
 | 13.05.2026 | Validate Forward Secure Sealing                         | SSRCSP-8425                                                                                   |
 | 11.05.2026 | GUI Shutdown & GUI Reboot (storeDisk)                   | SSRCSP-8412                                                                                   |
 | 30.04.2026 | Open PDF from VM                                        | SSRCSP-8367                                                                                   |


### PR DESCRIPTION
- Add a separate higher log rate limit for ghaf-host on Dell-7330
  - Bug: https://jira.tii.ae/browse/SSRCSP-8481
- Add a skip for `Verify brightness persisted`
  - Bug: https://jira.tii.ae/browse/SSRCSP-8482
- Extend `Verify camera block persisted` skip to `x1-sec-boot` laptop, previously only skipped on normal `lenovo-x1` laptops
  - Bug: https://jira.tii.ae/browse/SSRCSP-8224

Testruns
- Dell [log_rate](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6188/artifact/Robot-Framework/test-suites/dell-7330ANDpre-merge/log.html#s1-s1-s6-t3)
- Lenovo X1 [persistence](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6187/artifact/Robot-Framework/test-suites/lenovo-x1ANDpersistence/report.html#totals)
- Secure Boot X1 [persistence](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2015/artifact/Robot-Framework/test-suites/lenovo-x1ANDpersistence/report.html#totals) (forced camera test to fail)