### PR TITLE
Add zephyr

### DIFF
--- a/Robot-Framework/lib/Zephyr.py
+++ b/Robot-Framework/lib/Zephyr.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: 2022-2026 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import requests
+from robot.api import logger
+from http import HTTPStatus
+
+class ZephyrError(Exception):
+    pass
+
+class ZephyrTestStatuses:
+    """Container for supported Zephyr Scale Plugin test statuses"""
+    NOT_EXECUTED = 'Not Executed'
+    IN_PROGRESS = 'In Progress'
+    PASS = 'Pass'
+    FAIL = 'Fail'
+    BLOCKED = 'Blocked'
+
+class Zephyr:
+    """Class for integration with Zephyr Scale Plugin"""
+    connected: bool
+    zephyr_api: str
+    project_key: str
+    test_statuses = ZephyrTestStatuses
+
+    def __init__(self, project_key="SSRCSP"):
+        """ Initialize Zephyr Scale API client."""
+        self.token = os.getenv("JIRA_TOKEN")
+        self.jira_link = os.getenv("JIRA_LINK")
+
+        self.zephyr_api = f"{self.jira_link}/rest/atm/1.0"
+        self.project_key = project_key
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+        self.session = requests.Session()
+        self.session.headers.update(headers)
+        self.session.verify = False
+
+        self.check_connection()
+
+    def check_connection(self):
+        """Check connection to Zephyr Scale."""
+        try:
+            if not self.jira_link:
+                raise ZephyrError("No jira link found")
+
+            if not self.token:
+                raise ZephyrError("No token found")
+
+            self.get_testcases(query=f'projectKey = "{self.project_key}"', maxResults=1 )
+            logger.console("Successfully connected to Zephyr")
+            self.connected = True
+
+        except Exception as exc:
+            logger.warn(f"Failed to connect to Zephyr!\n Trying to do test request, but failed with an error:\n {exc}")
+            self.connected = False
+
+    def check_http_status(self, resp, error_message, *expected_statuses):
+        """Validate HTTP response status code."""
+        if resp.status_code not in expected_statuses:
+            raise ZephyrError(f"{error_message}\nHTTP Status Code: {resp.status_code} {resp.text}")
+
+    def get_testcases(self, query, maxResults=200, startAt=0):
+        """
+        Search Zephyr Scale test cases.
+
+        Further description of query parameter copied from
+            https://support.smartbear.com/zephyr-scale-server/api-docs/v1/, /testcase/search GET section
+
+        query: A query to filter Test Cases. The query syntax is similar to the JIRA JQL.
+
+        Available fields: projectKey, key, name, status, priority, component, folder, estimatedTime, labels, owner and
+            custom fields. When filtering by custom fields, the field name must be quoted.
+        Available operators: =, >, >=, <, <=, IN
+        For Single and Multi Choice custom fields, operator "=" is not supported, use "IN" instead
+        Available logical operators: AND
+        """
+        url = f"{self.zephyr_api}/testcase/search"
+
+        payload = {
+            "query": query,
+            "maxResults": maxResults,
+            "startAt": startAt
+        }
+        resp = self.session.get(url=url, params=payload)
+        self.check_http_status(resp, f"Failed to find test cases.\n Query: {query}", HTTPStatus.OK)
+
+        return resp.json()
+
+    def create_test_result(
+            self,
+            test_run_key: str,
+            test_case_key: str,
+            status: str,
+            comment = ""
+    ):
+        """
+        Create a test result for a test case inside a test cycle.
+
+        POST /testrun/{run}/testcase/{case}/testresult
+
+        test_run_key == test_cycle_key: Zephyr API uses 'test run' naming in the URL, but in the GUI it's 'test cycle'.
+        """
+
+        url = f"{self.zephyr_api}/testrun/{test_run_key}/testcase/{test_case_key}/testresult"
+
+        payload = {
+            "status": status,
+            "comment": comment
+        }
+
+        resp = self.session.post(url=url, json=payload)
+        self.check_http_status(resp,
+                               f"Failed to create test result.\n"
+                               f" Test Cycle: {test_run_key}\n"
+                               f" Test Case: {test_case_key}\n"
+                               f" Status: {status}\n",
+                               HTTPStatus.CREATED, HTTPStatus.OK)
+
+        return resp.json()

--- a/Robot-Framework/lib/ZephyrListener.py
+++ b/Robot-Framework/lib/ZephyrListener.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2022-2026 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+from Zephyr import Zephyr, ZephyrTestStatuses
+from robot.running import TestCase
+from robot.result import TestCase as TestResult
+from robot.libraries.BuiltIn import BuiltIn
+from robot.api import logger
+
+
+robot_status_to_zephyr = {
+        'PASS': ZephyrTestStatuses.PASS,
+        'FAIL': ZephyrTestStatuses.FAIL,
+        'NOT RUN': ZephyrTestStatuses.NOT_EXECUTED,
+        'SKIP': ZephyrTestStatuses.BLOCKED
+}
+
+target_to_cycle_map = {
+    'orin-agx': "SSRCSP-C184",
+    'orin-agx-64': "SSRCSP-C185",
+    'orin-nx': "SSRCSP-C186",
+    'lenovo-x1': "SSRCSP-C187",
+    'dell-7330': "SSRCSP-C188",
+    'darter-pro': "SSRCSP-C189",
+    'x1-sec-boot': "SSRCSP-C190",
+}
+
+
+class ZephyrListener:
+    """Robot Framework listener for saving results to Jira Zephyr"""
+    ROBOT_LIBRARY_SCOPE = "GLOBAL"
+    ROBOT_LISTENER_API_VERSION = 3
+
+    def __init__(self):
+        self.zephyr = Zephyr()
+
+    def get_test_cycle(self):
+        """Getting test cycle for saving results"""
+        device_type = BuiltIn().get_variable_value("${DEVICE_TYPE}")
+        return target_to_cycle_map[device_type]
+
+    def find_zephyr_tag(self, tags):
+        """Getting test tag from tags section"""
+        for tag in tags:
+            if tag.startswith('SP-T'):
+                return "SSRCSP-T114"  #PLACEHOLDER!
+                return tag
+
+    def end_test(self, test: TestCase, result: TestResult):
+        """Code executed after each test to save its result to Zephyr"""
+        if self.zephyr.connected:
+            zephyr_tag = self.find_zephyr_tag(result.tags)
+            status = robot_status_to_zephyr[result.status]
+            test_cycle = self.get_test_cycle()
+            if test_cycle and zephyr_tag:
+                self.zephyr.create_test_result(test_run_key=test_cycle, test_case_key=zephyr_tag, status=status, comment=result.message)
+            else:
+                logger.error(f"Failed to save test results to Zephyr.\n Test name: {test.name}\n Test tag: {zephyr_tag}\n Test Cycle: {test_cycle}\n")
+        else:
+            logger.error(f"Failed to save results to Zephyr: not connected")


### PR DESCRIPTION
Integration with the Jira Zephyr. 

Now it saves all the results for all the cases to the [same place](https://jira.tii.ae/secure/Tests.jspa#/testCase/SSRCSP-T114), because some cases have multiple tags and we need to decide ho we will use it.

After merging it will not be used immediately, we need to make PR to the infra with getting credentials and adding listener to the command that runs tests

This [Jenkins Run ](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6178/) has manually edited groovy script with getting creds and using listener. 

Where and how creds should be stored is discussed right now, but doesn't have a lot of influence to this code