### PR TITLE
Refactor FleetDM test

### DIFF
--- a/Robot-Framework/test-suites/security-tests/fleetdm.robot
+++ b/Robot-Framework/test-suites/security-tests/fleetdm.robot
@@ -54,9 +54,9 @@ Check device on fleetdm
     Set Log Level       INFO
     Log                 ${output.stdout}
     IF  ${expected_online}
-        Should Contain      ${output.stdout}  "status": "online",
+        Should Match Regexp    ${output.stdout}    "status"\\s*:\\s*"online",
     ELSE
-        Should Contain      ${output.stdout}  "status": "offline",
+        Should Match Regexp    ${output.stdout}    "status"\\s*:\\s*"offline",
     END
     RETURN              ${output}
 


### PR DESCRIPTION
Passed with this changes: [DarterPRO](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6200/artifact/Robot-Framework/test-suites/fleetdm/log.html)
Failed with main, output format seems to be changed: [DarterPRO](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6200/artifact/Robot-Framework/test-suites/fleetdm/log.html)