### PR TITLE
Improvements to boot diagnostics

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -28,7 +28,7 @@ ${PLOT_DIR}               ./
 ${REL_PLOT_DIR}           ./
 ${FLASHED}                false
 ${UART_CAPTURE_ACTIVE}    ${False}
-${BOOT_DIAGNOSTICS_DIR}   ./    # Later ./boot_diagnostics when move of the dir implemented in ghaf-infra
+${BOOT_DIAGNOSTICS_DIR}   ./boot_diagnostics
 
 
 *** Keywords ***

--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -68,7 +68,7 @@ Turn Laptop On
     END
 
 Turn Laptop On and Connect
-    Log To Console    ${\n}Booting the device by pressing the power button
+    Log To Console     ${\n}Booting the device by pressing the power button
     Turn Laptop On
     Check If Device Is Up
     IF    ${IS_AVAILABLE} == False

--- a/Robot-Framework/resources/serial_keywords.resource
+++ b/Robot-Framework/resources/serial_keywords.resource
@@ -427,18 +427,18 @@ Collect Failure Diagnostics Via Serial
 Run Diagnostic Commands Via Serial
     [Documentation]    Run each diagnostic command, store its output on the host, and copy it to the local output directory.
     [Arguments]    ${vm}    @{commands}
-    Log    Collecting diagnostics from ${vm}    console=True
+    Log               Collecting diagnostics from ${vm}    console=True
+    ${output_file}    Set Variable    ${BOOT_DIAGNOSTICS_DIR}/${vm}-diagnostics.txt
+    OperatingSystem.Create File       ${output_file}
     FOR    ${command}    IN    @{commands}
         ${output_name}    Replace String    ${command}    ${SPACE}    _
         IF  $vm != '${HOST}'
-            ${dmesg_output}    Run Command on VM Via Serial    ${vm}    sh -c '${command}'    pre_flush=${True}    logging=${False}
-            OperatingSystem.Create File        ${BOOT_DIAGNOSTICS_DIR}/${vm}_${output_name}.txt    ${dmesg_output}
-            Log    Saved "${command}" output from ${vm} to ${BOOT_DIAGNOSTICS_DIR}/${vm}_${output_name}.txt    console=True
+            ${cmd_output}    Run Command on VM Via Serial    ${vm}    sh -c '${command}'    pre_flush=${True}    logging=${False}
         ELSE
-            ${dmesg_output}    Run Command On Serial    sh -c '${command}'    pre_flush=${True}
-            OperatingSystem.Create File        ${BOOT_DIAGNOSTICS_DIR}/${HOST}_${output_name}.txt    ${dmesg_output}
-            Log    Saved "${command}" output from ${HOST} to ${BOOT_DIAGNOSTICS_DIR}/${HOST}_${output_name}.txt    console=True
+            ${cmd_output}    Run Command On Serial    sh -c '${command}'    pre_flush=${True}
         END
+        OperatingSystem.Append To File     ${output_file}    ${command}\n$${cmd_output}\n\n
+        Log    Saved "${command}" output from ${vm} to ${output_file}    console=True
     END
 
 Save Serial File Output To File

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -119,6 +119,7 @@ Check If Device Is Up
     [Arguments]    ${range}=50    ${timeout}=500
     ${start_time}=    Get Time	epoch
     ${ping}    Set Variable    ${False}
+    Set Global Variable        ${IS_AVAILABLE}       False
     FOR    ${i}    IN RANGE    ${range}
         ${elapsed}    Evaluate    int(time.time()) - int(${start_time})
         IF    ${elapsed} >= ${timeout}


### PR DESCRIPTION
- Write short diagnostic outputs all to single file ${VM}-diagnostics.txt file instead of creating separate file for each output.

- Set separate directory for diagnostic files instead of letting them to artifactory root. This didn't require anything from ghaf-infra side.

- Also fix a bug in `Check If Device Is Up`

relaybootANDorin-nx with forced FAIL
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6270/

dell-7330ANDbat
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6272/