### PR TITLE
Update lab-only tags

### DIFF
--- a/Robot-Framework/lib/KMTronicLibrary.py
+++ b/Robot-Framework/lib/KMTronicLibrary.py
@@ -12,9 +12,9 @@ class KMTronicLibrary:
 
     def __init__(self, port):
         """Initialize the serial connection"""
-        if port == 'NONE':
+        if not port or port == 'NONE':
             self.ser = None
-            print("No serial connection initialized (port set to 'NONE').")
+            print("No serial connection initialized (relay serial port is empty or set to 'NONE').")
         else:
             self.ser = serial.Serial(
                 port=port,  # Port to which the device is connected

--- a/Robot-Framework/test-suites/security-tests/firewall.robot
+++ b/Robot-Framework/test-suites/security-tests/firewall.robot
@@ -12,7 +12,6 @@ Resource            ../../resources/security_blacklist_keywords.resource
 Library             OperatingSystem
 
 Suite Setup         Suite Setup
-Suite Teardown      Blacklist Teardown
 
 *** Variables ***
 ${port}             5432

--- a/Robot-Framework/test-suites/security-tests/fleetdm.robot
+++ b/Robot-Framework/test-suites/security-tests/fleetdm.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       Test device visibility in fleetdm
-Test Tags           fleetdm  lenovo-x1  darter-pro
+Test Tags           fleetdm  lenovo-x1  darter-pro  lab-only
 
 Library             Process
 Library             String

--- a/Robot-Framework/test-suites/security-tests/logging.robot
+++ b/Robot-Framework/test-suites/security-tests/logging.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       Check security in logs
-Test Tags           logging  lenovo-x1  darter-pro  lab-only
+Test Tags           logging  lenovo-x1  darter-pro
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/wifi_keywords.resource
 Resource            ../../resources/common_keywords.resource
@@ -12,16 +12,18 @@ Resource            ../../resources/setup_keywords.resource
 Library             DateTime
 Library             String
 
-Suite Setup         Setup logs
-Suite Teardown      Remove Wifi configuration  ${TEST_WIFI_SSID}
+Suite Setup         Logging Setup
 
 
 *** Test Cases ***
 
 Wifi password is not revealed in Grafana
     [Documentation]  Check that logs in Grafana don't contain wifi password
-    [Tags]           SP-T328  SP-T328-1
+    [Tags]           SP-T328  SP-T328-1  lab-only
+    Configure wifi   ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
+    Sleep   3        # Time for needed data to be logged
     Is password revealed in Grafana    ${TEST_WIFI_SSID}    ${TEST_WIFI_PSWD}
+    [Teardown]       Remove Wifi configuration  ${TEST_WIFI_SSID}
 
 User password is not revealed in Grafana
     [Documentation]  Check that logs in Grafana don't contain user's password
@@ -30,7 +32,7 @@ User password is not revealed in Grafana
 
 Check Grafana log forwarding after disconnected state
     [Documentation]  Check that logs are sent to Grafana from time of disconnection during previous boot
-    [Tags]           SP-T283
+    [Tags]           SP-T283  lab-only
     Switch to vm      ${ADMIN_VM}
     ${id}             Get Actual Device ID
     Log To Console    Creating log entry and verifying forwarding to grafana
@@ -40,10 +42,10 @@ Check Grafana log forwarding after disconnected state
 
     Log To Console    Blocking log forwarding from admin-vm
     ${rule}           Set Variable   OUTPUT -p tcp --dport 443 -m owner --uid-owner "$(systemctl show alloy -p UID --value)" -j REJECT
-    Run Command   iptables -I ${rule}    sudo=True
+    Run Command       iptables -I ${rule}    sudo=True
     Sleep             3
     Log To Console    Creating log entry and waiting 50 sec      no_newline=true
-    Run Command   logger --priority=user.info "logtest1_${BUILD_ID}"    sudo=True
+    Run Command       logger --priority=user.info "logtest1_${BUILD_ID}"    sudo=True
     FOR   ${i}   IN RANGE   50
         Log To Console   .  no_newline=true
         Sleep            1
@@ -58,9 +60,7 @@ Check Grafana log forwarding after disconnected state
 
 *** Keywords ***
 
-Setup logs
-    Configure wifi      ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
-    Sleep   3           # Time for needed data to be logged
+Logging Setup
     Switch to vm        ${HOST}
     ${device_id}        Get Actual Device ID
     Set Suite Variable  ${device_id}


### PR DESCRIPTION
Some quality of life improvements for those of us who run tests locally
* Update lab-only tags in security tests.
* Refactor `logging.robot` so that `User password is not revealed in Grafana` can be executed locally.
* Remove accidentally added Suite Teardown `Blacklist Teardown` from `firewall.robot`. It is executed if blacklist test fails, but does not need to be run every time.
* Fix an error caused by `KMTronicLibrary.py` when relay serial port is not set.

Testruns
* Darter Pro [security](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6271/)
* Orin AGX 64 [regression](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6273/) (to verify the KMTronic changes did not break anything)