### PR TITLE
Prevent teardown from failing tests

### DIFF
--- a/Robot-Framework/resources/teardown_keywords.resource
+++ b/Robot-Framework/resources/teardown_keywords.resource
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2022-2026 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+*** Keywords ***
+
+Run Teardown Safely
+    [Documentation]    Wrapper to prevent teardown from failing and causing test cases getting failed status.
+    ...                Log only ERROR message if the keyword fails.
+    [Arguments]    ${keyword}
+    ${status}    ${message} =    Run Keyword And Ignore Error    ${keyword}
+
+    Run Keyword If    '${status}' == 'FAIL'
+    ...    Log    [TEARDOWN ERROR] ${keyword} failed after ${PREV_TEST_NAME}: ${message}    level=ERROR
+
+    RETURN    ${status}    ${message}

--- a/Robot-Framework/test-suites/functional-tests/__init__.robot
+++ b/Robot-Framework/test-suites/functional-tests/__init__.robot
@@ -3,12 +3,13 @@
 
 *** Settings ***
 Documentation       Functional tests
+Resource            ../../resources/teardown_keywords.resource
 Test Tags           regression
 
 Resource            ../../resources/setup_keywords.resource
 
 Suite Setup         Functional tests setup
-Suite Teardown      Functional tests teardown
+Suite Teardown      Run Teardown Safely    Functional tests teardown
 Test Timeout        10 minutes
 
 
@@ -21,3 +22,4 @@ Functional tests setup
 Functional tests teardown
     [Timeout]    5 minutes
     Clean Up Test Environment
+    FAIL


### PR DESCRIPTION
Use a wrapper keyword for executing teardown keywords.