### PR TITLE
Suite setup overhaul

### DIFF
--- a/Robot-Framework/resources/setup_keywords.resource
+++ b/Robot-Framework/resources/setup_keywords.resource
@@ -17,6 +17,7 @@ ${CONNECTION_TYPE}       ssh
 
 Prepare Test Environment
     [Arguments]   ${enable_dnd}=False
+    [Timeout]     5 minutes
     Check If Device Is Up    range=5
     IF    ${IS_AVAILABLE} == False
         FAIL    The device is not available via SSH or serial.
@@ -24,13 +25,15 @@ Prepare Test Environment
         FAIL    The device is available only via serial, but tests require SSH.
     END
     Close All Connections
-    Switch to vm    ${HOST}
+    Switch to vm          ${HOST}
+    ${timestamp}          Run Command    date '+%Y-%m-%d %H:%M:%S'
+    Set Suite Variable    ${SUITE_START_TIME}   ${timestamp}
 
     Log versions and device unique data
     IF  ${IS_LAPTOP}
         Verify boot from expected device
         Create test user
-        Save gui icons and icon path
+        Save login and logout icons
         Login to laptop   ${enable_dnd}
     END
 
@@ -61,22 +64,18 @@ Clean Up Test Environment
     [Arguments]   ${disable_dnd}=False
     IF    ${IS_AVAILABLE} == True and "${CONNECTION_TYPE}" == "ssh"
         # Temporarily taking journal log taking our from Orin-NX [SSRCSP-7453]
-        IF  "${DEVICE_TYPE}" != "orin-nx"
-            Switch to vm   ${HOST}
-            Save host journalctl
-        END
-        IF  ${IS_LAPTOP}
-            Log out from laptop
-        END
+        Run Keyword If   "${SUITE STATUS}" != "PASS" and "${DEVICE_TYPE}" != "orin-nx"    Save host journalctl
+        Run Keyword If   ${IS_LAPTOP}    Log out from laptop
     END
     Close All Connections
 
 Save host journalctl
-    Run Command    journalctl -b 0 > /tmp/jrnl.txt
+    [Setup]        Switch to vm   ${HOST}
+    Run Command    journalctl --since "${SUITE_START_TIME}" > /tmp/jrnl.txt
     Run Command    ls -lh /tmp/jrnl.txt
     # Copy journal log file to Robot outputs
-    SSHLibrary.Get file  /tmp/jrnl.txt   ${OUTPUT_DIR}/jrnl.txt
-    OperatingSystem.File Should Exist    ${OUTPUT_DIR}/jrnl.txt
+    SSHLibrary.Get file  /tmp/jrnl.txt   ${OUTPUT_DIR}/journal_${SUITE_NAME}.txt
+    OperatingSystem.File Should Exist    ${OUTPUT_DIR}/journal_${SUITE_NAME}.txt
 
 Log versions and device unique data
     ${ghaf_commit}      Get File Content Or Default        /persist/build_commit
@@ -133,21 +132,14 @@ Stop ydotoold
         Run Command       systemctl stop ydotoold-persistent.service    sudo=True
     END
 
-Save gui icons and icon path
-    [Documentation]         Save the icons that are used in multiple test cases
+Save login and logout icons
+    [Documentation]         Save the icons that are used in login and logout
     ...                     Save path to icons
-    Log To Console          Saving commonly used test icons
-    ${ICONS}                Run Command   find $(echo $XDG_DATA_DIRS | tr ':' ' ') -type d -name "icons" 2>/dev/null   rc_match=skip
-    Set Global Variable     ${ICONS}
-    Get icon                ${ICONS}/hicolor/scalable/apps  com.system76.CosmicAppLibrary.svg  crop=0  background=black  output_filename=launcher.png
-    Get icon                ${ICONS}/Cosmic/scalable/actions  window-close-symbolic.svg  crop=0  background=white  output_filename=window-close.png
-    Negate app icon         ${ICONS_DIR}/window-close.png  ${ICONS_DIR}/window-close-neg.png
-    Get icon                ${ICONS}/Cosmic/scalable/actions  system-search-symbolic.svg  crop=0  background=white  output_filename=search.png
-    Negate app icon         ${ICONS_DIR}/search.png  ${ICONS_DIR}/search-neg.png
-    Get icon                ${ICONS}/Papirus/24x24/actions  system-shutdown.svg  crop=0  background=black  output_filename=power.png
-    Get icon                ${ICONS}/Papirus/48x48/apps  Zoom.svg  crop=0  background=black  output_filename=Zoom.png
-    Get icon                ${ICONS}/Cosmic/scalable/actions  system-lock-screen-symbolic.svg  background=black  output_filename=lock.png
-    OperatingSystem.Copy File    ../test-files/ghaf-close.png    ${ICONS_DIR}/
+    [Setup]                 Switch to vm    ${GUI_VM}  user=${USER_LOGIN}
+    Log To Console          Saving login and logout icons
+    ${icons}                Run Command   find $(echo $XDG_DATA_DIRS | tr ':' ' ') -type d -name "icons" 2>/dev/null   rc_match=skip
+    Get icon                ${icons}/hicolor/scalable/apps  com.system76.CosmicAppLibrary.svg  crop=0  background=black  output_filename=launcher.png
+    Get icon                ${icons}/Cosmic/scalable/actions  system-lock-screen-symbolic.svg  background=black  output_filename=lock.png
 
 Login to laptop
     [Documentation]   Log in to the laptop

--- a/Robot-Framework/test-suites/boot-test/__init__.robot
+++ b/Robot-Framework/test-suites/boot-test/__init__.robot
@@ -3,9 +3,4 @@
 
 *** Settings ***
 Documentation       Boot test
-
-Resource            ../../config/variables.robot
-Resource            ../../resources/ssh_keywords.resource
-
-Suite Setup         Set Variables   ${DEVICE}
-Suite Teardown      Close All Connections
+Test Timeout        15 minutes

--- a/Robot-Framework/test-suites/functional-tests/__init__.robot
+++ b/Robot-Framework/test-suites/functional-tests/__init__.robot
@@ -7,17 +7,6 @@ Test Tags           regression
 
 Resource            ../../resources/setup_keywords.resource
 
-Suite Setup         Functional tests setup
-Suite Teardown      Functional tests teardown
+Suite Setup         Prepare Test Environment
+Suite Teardown      Clean Up Test Environment
 Test Timeout        10 minutes
-
-
-*** Keywords ***
-
-Functional tests setup
-    [Timeout]    5 minutes
-    Prepare Test Environment
-
-Functional tests teardown
-    [Timeout]    5 minutes
-    Clean Up Test Environment

--- a/Robot-Framework/test-suites/gui-tests/__init__.robot
+++ b/Robot-Framework/test-suites/gui-tests/__init__.robot
@@ -5,7 +5,7 @@
 Documentation       GUI tests
 Test Tags           regression    gui
 
-Resource            ../../resources/app_keywords.resource
+Resource            ../../resources/gui_keywords.resource
 Resource            ../../resources/setup_keywords.resource
 
 Suite Setup         GUI Tests Setup
@@ -18,9 +18,26 @@ Test Timeout        5 minutes
 GUI Tests Setup
     [Timeout]    5 minutes
     Prepare Test Environment   enable_dnd=True
+    Save gui icons and icon path
 
 GUI Tests Teardown
     [Timeout]    5 minutes
     # In case the screen recording was not stopped
     Stop screen recording service
     Clean Up Test Environment   disable_dnd=True
+
+Save gui icons and icon path
+    [Documentation]         Save the icons that are used in GUI tests
+    Log To Console          Saving GUI test icons
+    ${icons}                Run Command   find $(echo $XDG_DATA_DIRS | tr ':' ' ') -type d -name "icons" 2>/dev/null   rc_match=skip
+    # Window controls
+    Get icon                ${icons}/Cosmic/scalable/actions  window-close-symbolic.svg  crop=0  background=white  output_filename=window-close.png
+    Negate app icon         ${ICONS_DIR}/window-close.png  ${ICONS_DIR}/window-close-neg.png
+    OperatingSystem.Copy File    ../test-files/ghaf-close.png    ${ICONS_DIR}/
+    # Desktop
+    Get icon                ${icons}/Cosmic/scalable/actions  system-search-symbolic.svg  crop=0  background=white  output_filename=search.png
+    Negate app icon         ${ICONS_DIR}/search.png  ${ICONS_DIR}/search-neg.png
+    Get icon                ${icons}/Papirus/24x24/actions  system-shutdown.svg  crop=0  background=black  output_filename=power.png
+    # App icons
+    Get icon                ${icons}/Papirus/48x48/apps  Zoom.svg  crop=0  background=black  output_filename=Zoom.png
+    Get icon                ${icons}/hicolor/48x48/apps  com.system76.CosmicSettings.svg  background=black  output_filename=settings.png

--- a/Robot-Framework/test-suites/gui-tests/gui_settings.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_settings.robot
@@ -33,7 +33,6 @@ Change timezone in settings
 
 Search in Cosmic Settings
     [Arguments]     ${search_term}
-    Get icon        ${ICONS}/hicolor/48x48/apps  com.system76.CosmicSettings.svg  background=black  output_filename=settings.png
     Move cursor to corner
     Locate and click  image  settings.png  0.95
     # Wait for settings to open

--- a/Robot-Framework/test-suites/performance-tests/__init__.robot
+++ b/Robot-Framework/test-suites/performance-tests/__init__.robot
@@ -5,23 +5,7 @@
 Documentation       Performance tests
 Test Tags           performance
 
-Library             SSHLibrary
-Resource            ../../config/variables.robot
-Resource            ../../resources/ssh_keywords.resource
-Resource            ../../resources/serial_keywords.resource
 Resource            ../../resources/setup_keywords.resource
 
-Suite Setup         Performance Setup
-Suite Teardown      Performance Teardown
-
-*** Keywords ***
-
-Performance Setup
-    [Timeout]    5 minutes
-    Prepare Test Environment   enable_dnd=True
-
-Performance Teardown
-    IF  ${IS_LAPTOP}
-        Log out from laptop
-    END
-    Close All Connections
+Suite Setup         Prepare Test Environment
+Suite Teardown      Clean Up Test Environment

--- a/Robot-Framework/test-suites/performance-tests/ballooning.robot
+++ b/Robot-Framework/test-suites/performance-tests/ballooning.robot
@@ -183,7 +183,7 @@ Procedure After Timeout
     Reboot Laptop
     ${rebooted}     Set Variable  True
     Check If Device Is Up
-    Login to laptop    enable_dnd=True
+    Login to laptop
 
 Clean Test Files
     Run Command   rm /dev/shm/test/*      sudo=True   rc_match=skip

--- a/Robot-Framework/test-suites/performance-tests/boot_time.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time.robot
@@ -150,7 +150,7 @@ Log Journal To Debug
 
 Boot Time Test Teardown
     Run Keyword If Test Failed   Failed Boot Time Test Teardown
-    Login to laptop              enable_dnd=True
+    Login to laptop
 
 Failed Boot Time Test Teardown
     Reboot Laptop

--- a/Robot-Framework/test-suites/security-tests/__init__.robot
+++ b/Robot-Framework/test-suites/security-tests/__init__.robot
@@ -7,16 +7,5 @@ Test Tags           regression  security
 
 Resource            ../../resources/setup_keywords.resource
 
-Suite Setup         Security tests setup
-Suite Teardown      Security tests teardown
-
-
-*** Keywords ***
-
-Security tests setup
-    [Timeout]    5 minutes
-    Prepare Test Environment
-
-Security tests teardown
-    [Timeout]    5 minutes
-    Clean Up Test Environment
+Suite Setup         Prepare Test Environment
+Suite Teardown      Clean Up Test Environment

--- a/Robot-Framework/test-suites/security-tests/persistence.robot
+++ b/Robot-Framework/test-suites/security-tests/persistence.robot
@@ -73,17 +73,17 @@ Persistence Suite Setup
     ${PERSISTENCE_SETUP_ERRORS}    Create List
     Set Suite Variable             ${PERSISTENCE_SETUP_ERRORS}
     Switch to vm      ${NET_VM}
-    Login to laptop   enable_dnd=True
+    Login to laptop
     Save original values
     Set values        EXPECTED
     Soft Reboot Device And Connect   vm=${GUI_VM}
-    Login to laptop   enable_dnd=True
+    Login to laptop
 
 Persistence Suite Teardown
     IF  $SUITE_STATUS=='FAIL'
         Reboot Laptop
         Connect After Reboot
-        Login to laptop   enable_dnd=True
+        Login to laptop
     END
     Set values   ORIGINAL
 

--- a/Robot-Framework/test-suites/suspension-test/__init__.robot
+++ b/Robot-Framework/test-suites/suspension-test/__init__.robot
@@ -8,16 +8,5 @@ Test Tags           regression  suspension
 Resource            ../../resources/device_control.resource
 Resource            ../../resources/setup_keywords.resource
 
-Suite Setup         Suspension test setup
-Suite Teardown      Suspension test teardown
-
-
-*** Keywords ***
-
-Suspension test setup
-    [Timeout]    5 minutes
-    Prepare Test Environment
-
-Suspension test teardown
-    [Timeout]    5 minutes
-    Clean Up Test Environment
+Suite Setup         Prepare Test Environment
+Suite Teardown      Clean Up Test Environment

--- a/Robot-Framework/test-suites/update-tests/__init__.robot
+++ b/Robot-Framework/test-suites/update-tests/__init__.robot
@@ -7,16 +7,5 @@ Test Tags           update  lenovo-x1  darter-pro  excl-storeDisk  excl-secboot
 
 Resource            ../../resources/setup_keywords.resource
 
-Suite Setup         Update tests setup
-Suite Teardown      Update tests teardown
-
-
-*** Keywords ***
-
-Update tests setup
-    [Timeout]    5 minutes
-    Prepare Test Environment
-
-Update tests teardown
-    [Timeout]    5 minutes
-    Clean Up Test Environment
+Suite Setup         Prepare Test Environment
+Suite Teardown      Clean Up Test Environment

--- a/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
+++ b/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
@@ -196,7 +196,7 @@ Run Nixos Rebuild
         FAIL  nixos-rebuild didn't finish successfully withing the given time
     END
     Soft Reboot Device And Connect
-    Login to laptop   enable_dnd=True
+    Login to laptop
 
 Clone Ghaf Repository
     [Arguments]               ${repository_path}    ${commit}=${EMPTY}
@@ -223,13 +223,13 @@ Rebuild Teardown
         Reboot Laptop
         Close All Connections
         Connect After Reboot
-        Login to laptop   enable_dnd=True
+        Login to laptop
     END
     Switch to vm    ${HOST}
     Remove Ghaf Repository
     Roll back to original generation
     Soft Reboot Device And Connect
-    Login to laptop   enable_dnd=True
+    Login to laptop
 
 Check That Logging Is Working in VM
     [Documentation]  Check that the test log is sent to Grafana


### PR DESCRIPTION
* Unify all `__init__` files.
* Save host log from the suite if the suite failed.
    * This fixes an issue where older journal was overwritten by newer tests. In the nightly the `jrnl.txt` has only shown the logs from the last reboot until the end of tests.
    * I decided to save the log only if there were failures, but this behavior is easy to change.
* Save only the necessary icons in `Prepare Test Environment`. Icons that are only needed for GUI tests are fetched in the GUI suite setup. It is not reasonable for all tests to fail because a single application icon is missing.
* Remove `enable_dnd=True` from tests other than GUI tests. It is used to prevent image recognition from closing a notification instead of the intended window. This is now only an issue in GUI tests.

**Testruns**
- [Darter Pro storeDisk installer](https://ci-dev.vedenemo.dev/job/ghaf-hw-test/1264/artifact/Robot-Framework/test-suites/regression/report.html#totals)
- [Lenovo X1 installer](https://ci-dev.vedenemo.dev/job/ghaf-hw-test/1258/artifact/Robot-Framework/test-suites/regression/report.html#totals)
- [Dell 7330](https://ci-dev.vedenemo.dev/job/ghaf-hw-test/1259/artifact/Robot-Framework/test-suites/regression/report.html#totals)
- [Orin AGX](https://ci-dev.vedenemo.dev/job/ghaf-hw-test/1255/artifact/Robot-Framework/test-suites/regression/report.html#totals)
- [Orin NX](https://ci-dev.vedenemo.dev/job/ghaf-hw-test/1254/artifact/Robot-Framework/test-suites/regression/report.html#totals)
- [Full nightly](https://ci-dev.vedenemo.dev/job/ghaf-nightly/343/) - all previous links are from this run
- [Performance pipeline](https://ci-dev.vedenemo.dev/job/ghaf-nightly-perftest/312/) - I checked that there was no errors related to setups or teardowns