### PR TITLE
Update skips for generic image

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -163,7 +163,7 @@ Check Persistent Storage Size
 
 Check device id failure
     [Arguments]    ${actual_device_id}
-    IF    "system76-darp11-b-storeDisk-debug-installer" in "${JOB}"
+    IF    "storeDisk-debug-installer" in "${JOB}" and "${DEVICE_TYPE}" == "darter-pro"
         &{ids}    Create Dictionary
         ...    DarterPRO-prod=00-c0-44-19-76
         ...    DarterPRO-rel=00-89-3c-52-5d

--- a/Robot-Framework/test-suites/functional-tests/net-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/net-vm.robot
@@ -85,7 +85,7 @@ Interfaces Should Be In Same Network
     Should Be Equal    ${ip1_net}    ${ip2_net}
 
 Check net-vm hostname failure
-    IF    "system76-darp11-b-storeDisk-debug-installer" in "${JOB}"
+    IF    "storeDisk-debug-installer" in "${JOB}" and "${DEVICE_TYPE}" == "darter-pro"
         &{ids}    Create Dictionary
         ...    DarterPRO-prod=ghaf-3225688438
         ...    DarterPRO-rel=ghaf-2302431837

--- a/Robot-Framework/test-suites/gui-tests/gui_power.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power.robot
@@ -67,7 +67,7 @@ Reboot from power menu
     ${reboot_limit}   Set Variable If    "${DEVICE_TYPE}" == "darter-pro"    100    90
     Log               Reboot took ${elapsed} seconds   console=True
     IF   ${elapsed} > ${reboot_limit}
-        IF  "system76-darp11-b-storeDisk" in "${JOB}"
+        IF  "storeDisk" in "${JOB}" and "${DEVICE_TYPE}" == "darter-pro"
             SKIP   Known issue: SSRCSP-8412 (Reboot took too long: ${elapsed} seconds (expected < ${reboot_limit}))
         ELSE
             FAIL   Reboot took too long: ${elapsed} seconds (expected < ${reboot_limit})
@@ -93,7 +93,7 @@ Shutdown from power menu
     Turn Laptop On and Connect
     Login to laptop   enable_dnd=True
     IF   ${elapsed} > 20
-        IF  "system76-darp11-b-storeDisk" in "${JOB}"
+        IF  "storeDisk" in "${JOB}" and "${DEVICE_TYPE}" == "darter-pro"
             SKIP   Known issue: SSRCSP-8412 (Shutdown took too long: ${elapsed} seconds (expected < 20))
         ELSE
             FAIL   Shutdown took too long: ${elapsed} seconds (expected < 20)


### PR DESCRIPTION
Update storeDisk skips to also work with intel-laptop-storeDisk image

[Without this PR](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2055/artifact/Robot-Framework/test-suites/darter-proANDregressionNOTexcl-storeDiskNOTexcl-installer/report.html#totals)
[With this PR](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2056/artifact/Robot-Framework/test-suites/SP-T351-1ORSP-352-1ORgui-power/report.html#totals)