### PR TITLE
Check if cachix revision differs from current ghaf before update

### DIFF
--- a/Robot-Framework/test-suites/update-tests/update-tests.robot
+++ b/Robot-Framework/test-suites/update-tests/update-tests.robot
@@ -34,12 +34,6 @@ Update via givc-cli
 
 Update with
     [Arguments]           ${update_method}
-    Switch to vm          ${HOST}
-    # Get bootloader generations
-    ${gen_before}         Get current generation
-    Log                   Generation before update: ${gen_before}    console=True
-    Set Suite Variable    ${gen_before}
-    Log To Console        Updating...
     IF  "${DEVICE_TYPE}" == "lenovo-x1"
         ${release_name}   Set Variable  lenovo-x1-carbon-gen11-debug
     ELSE IF  "${DEVICE_TYPE}" == "darter-pro"
@@ -47,6 +41,13 @@ Update with
     ELSE
         Log               DEVICE_TYPE: ${DEVICE_TYPE} not allowed in update tests   console=True
     END
+    Switch to vm          ${HOST}
+    Compare current with cachix revision    ${release_name}
+    # Get bootloader generations
+    ${gen_before}         Get current generation
+    Log                   Generation before update: ${gen_before}    console=True
+    Set Suite Variable    ${gen_before}
+    Log To Console        Updating...
     IF  "${update_method}"=="ota-update"
         ${output}             Run Command  ota-update cachix --cache ghaf-release ${release_name}  sudo=True   timeout=600
         Should Not Contain    ${output}  Error
@@ -63,4 +64,13 @@ Update with
     Set Suite Variable    ${gen_after}
     IF  ${gen_before}==${gen_after}
         FAIL    Update via ${update_method} failed OR attempted updating to already existing revision
+    END
+
+Compare current with cachix revision
+    [Documentation]  Make sure that pinned cachix revision differs from current running ghaf version.
+    [Arguments]      ${release_name}
+    ${current_rev}  Run Command  readlink -f /run/current-system
+    ${cachix_rev}   Run Command  nix-shell -p jq --run "curl -sL https://cachix.org/api/v1/cache/ghaf-release/pin | jq -r '.[] | select(.name==\\"${release_name}\\") | .lastRevision.storePath'"
+    IF  $current_rev == $cachix_rev
+        SKIP    Identical ghaf revision pinned in cachix. Nothing to update.
     END


### PR DESCRIPTION
Skip update test if cachix revision matches with the current ghaf version.

https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6302/