### PR TITLE
Remove brightness skip, add cert skip

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/vm.robot
@@ -32,6 +32,7 @@ Suite Setup         VM Suite Setup
              ...    orin|ANY|alloy.service|SSRCSP-8071
              ...    orin|ANY|ghaf-journal-alloy-recover.service|SSRCSP-8071
              ...    darter-pro|ghaf-host|systemd-tpm2-setup.service|SSRCSP-8357
+             ...    orin-agx|ghaf-host|ghaf-provision-ek-certs.service|SSRCSP-8535
 
 # Container for test message. Keyword `Set Test Message` doesn't work properly with Templates.
 # Accumulates messages from tests that use 'Check systemctl status Template' to be added to the main test message in teardown

--- a/Robot-Framework/test-suites/security-tests/persistence.robot
+++ b/Robot-Framework/test-suites/security-tests/persistence.robot
@@ -52,8 +52,6 @@ Verify brightness persisted
     [Tags]    SP-T326  SP-T326-1
     ${brightness}     Get screen brightness
     Should Be Equal   ${EXPECTED_BRIGHTNESS}  ${brightness}
-    [Teardown]   Run Keyword If Test Failed   Run Keywords   Log persistence setup errors
-    ...                                                AND   SKIP   Known issue: SSRCSP-8482
 
 Verify volume persisted
     [Tags]    SP-T326  SP-T326-2

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -5,7 +5,6 @@
 | DATE SET   | TEST CASE                                               | TICKET / Additional Data.                                                                     |
 | ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | 29.05.2026 | Check Grafana log forwarding after disconnected state   | SSRCSP-8525                                                                                   |
-| 22.05.2026 | Verify brightness persisted                             | SSRCSP-8482                                                                                   |
 | 22.05.2026 | Check logging rate (Dell)                               | SSRCSP-8481                                                                                   |
 | 13.05.2026 | Validate Forward Secure Sealing                         | SSRCSP-8425                                                                                   |
 | 30.04.2026 | Open PDF from VM                                        | SSRCSP-8367                                                                                   |


### PR DESCRIPTION
Brightness issue was fixed with https://github.com/tiiuae/ghaf/pull/1958

`ghaf-provision-ek-certs.service` has now failed a few times on AGX, adding as skip for it so that it does not block pre merge tests