### PR TITLE
Tidy GUI app keywords

### DIFF
--- a/Robot-Framework/resources/app_keywords.resource
+++ b/Robot-Framework/resources/app_keywords.resource
@@ -116,9 +116,7 @@ Kill App By Name
 
 Start app via GUI
     [Documentation]    Start Application via GUI and verify related process started
-    [Arguments]        ${app-vm}
-    ...                ${process_name}
-    ...                ${display_name}=""
+    [Arguments]        ${app-vm}   ${process_name}   ${display_name}
     Check that appVM is running   ${app-vm}
     Check that the application is not running   ${process_name}  1
     Switch to vm                   ${GUI_VM}  user=${USER_LOGIN}
@@ -148,34 +146,17 @@ Open app menu
 
 Close app via GUI
     [Documentation]    Close Application via GUI and verify related process stopped
-    [Arguments]        ${app-vm}
-    ...                ${process_name}
-    ...                ${close_button}=window-close.png
-    ...                ${windows_to_close}=1
-    ...                ${verify_is_killed}=true
+    [Arguments]        ${app-vm}   ${process_name}   ${close_button}   ${verify_is_killed}=True
     Switch to vm       ${app-vm}
     Check that the application was started    ${process_name}
     Switch to vm       ${GUI_VM}  user=${USER_LOGIN}
     Log To Console     Clicking the close button of the application window
     Locate and click   image  ${close_button}  0.9  iterations=25  wiggle=True
     Save Time          ${process_name}_launched    ${LAST_SCREENSHOT_TIME}
-    IF  $verify_is_killed=='true'
+    IF  ${verify_is_killed}
         Switch to vm       ${app-vm}
         ${status}          Run Keyword And Return Status  Check that the application is not running  ${process_name}  5
-        IF  "${windows_to_close}" != "1"
-            # At first launch chrome opens window for selecting account.
-            # If this window is closed the actual browser window still opens.
-            # So need to prepare to close another window in chrome test case.
-            IF  '${status}' != 'True'
-                Switch to vm        ${GUI_VM}  user=${USER_LOGIN}
-                Locate and click    image  ${close_button}  0.9  iterations=10  wiggle=True
-                Switch to vm        ${app-vm}
-                ${status}           Run Keyword And Return Status  Check that the application is not running  ${process_name}  5
-            END
-        END
-        IF  '${status}' != 'True'
-            FAIL  Failed to close the application
-        END
+        Should Be True     ${status}   Failed to close the application
     END
     # In case closing the app via GUI failed
     [Teardown]     Run Keywords   Switch to vm   ${app-vm}   AND   Kill App By Name   ${process_name}  sudo=True

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -82,8 +82,11 @@ Log out with loginctl
         Log To Console    Log out disabled. Skipping log out procedure.
         RETURN
     END
-    Switch to vm   ${GUI_VM}
-    Run Command    loginctl terminate-user ${USER_LOGIN}   sudo=True
+    Switch to vm          ${GUI_VM}
+    ${session_id}         Run Command      loginctl list-sessions --no-legend | grep seat0 | awk '{print $1}'
+    Run Command           loginctl         # For debugging
+    Should Not Be Empty   ${session_id}    No active session found for ${USER_LOGIN}
+    Run Command           loginctl terminate-session ${session_id}   sudo=True
     [Teardown]   Switch to vm   ${GUI_VM}  user=${USER_LOGIN}
 
 Type string

--- a/Robot-Framework/test-suites/gui-tests/gui_app_launch.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_app_launch.robot
@@ -23,169 +23,168 @@ Suite Teardown      Create App Launch Montage And Move Graphs
 Start App Store via GUI
     [Documentation]   Start App Store via GUI and measure launch time
     [Tags]            SP-T334  SP-T334-2
-    Start app via GUI   ${FLATPAK_VM}  cosmic-store  display_name="App Store"
+    Start app via GUI   ${FLATPAK_VM}  cosmic-store  "App Store"
     Close app via GUI   ${FLATPAK_VM}  cosmic-store  window-close-neg.png
     Save launch time    cosmic-store
 
 Start Bluetooth Settings via GUI
     [Documentation]   Start Bluetooth Settings via GUI and measure launch time
     [Tags]            SP-T204  SP-T204-2
-    Start app via GUI   ${GUI_VM}  blueman-manager-wrapped-wrapped  display_name="Bluetooth Settings"
-    Close app via GUI   ${GUI_VM}  blueman-manager-wrapped-wrapped
+    Start app via GUI   ${GUI_VM}  blueman-manager-wrapped-wrapped  "Bluetooth Settings"
+    Close app via GUI   ${GUI_VM}  blueman-manager-wrapped-wrapped  window-close.png
     Save launch time    blueman-manager-wrapped-wrapped
 
 Start COSMIC Document Reader via GUI
     [Documentation]   Start COSMIC Document Reader via GUI and measure launch time
     [Tags]            SP-T105  SP-T105-2
-    Start app via GUI   ${GUI_VM}  cosmic-reader   display_name="COSMIC Document Reader"
+    Start app via GUI   ${GUI_VM}  cosmic-reader   "COSMIC Document Reader"
     Close app via GUI   ${GUI_VM}  cosmic-reader   ghaf-close.png
     Save launch time    cosmic-reader
 
 Start COSMIC Files via GUI
     [Documentation]   Start COSMIC Files via GUI and measure launch time
     [Tags]            SP-T206  SP-T206-2
-    Start app via GUI   ${GUI_VM}  ^cosmic-files$  display_name="COSMIC Files"
+    Start app via GUI   ${GUI_VM}  ^cosmic-files$  "COSMIC Files"
     Close app via GUI   ${GUI_VM}  ^cosmic-files$  ghaf-close.png
     Save launch time    ^cosmic-files$
 
 Start COSMIC Media Player via GUI
     [Documentation]   Start COSMIC Media Player via GUI and measure launch time
     [Tags]            SP-T294  SP-T294-2
-    Start app via GUI   ${GUI_VM}  cosmic-player  display_name="COSMIC Media Player"
+    Start app via GUI   ${GUI_VM}  cosmic-player  "COSMIC Media Player"
     Close app via GUI   ${GUI_VM}  cosmic-player  ghaf-close.png
     Save launch time    cosmic-player
 
 Start COSMIC Settings via GUI
     [Documentation]   Start COSMIC Settings via GUI and measure launch time
     [Tags]            SP-T254  SP-T254-2
-    Start app via GUI   ${GUI_VM}  cosmic-settings$  display_name="COSMIC Settings"
+    Start app via GUI   ${GUI_VM}  cosmic-settings$  "COSMIC Settings"
     Close app via GUI   ${GUI_VM}  cosmic-settings$  ghaf-close.png
-    ${status}    ${message}    Run Keyword And Ignore Error    Save launch time    cosmic-settings$
-    Run Keyword If    '${status}' == 'FAIL'    SKIP    Known Issue: SSRCSP-7518 (${message})
+    Save launch time    cosmic-settings$
 
 Start COSMIC Terminal via GUI
     [Documentation]   Start COSMIC Terminal via GUI and measure launch time
     [Tags]            SP-T263  SP-T263-2
-    Start app via GUI   ${GUI_VM}  cosmic-term  display_name="COSMIC Terminal"
+    Start app via GUI   ${GUI_VM}  cosmic-term  "COSMIC Terminal"
     Close app via GUI   ${GUI_VM}  cosmic-term  ghaf-close.png
     Save launch time    cosmic-term
 
 Start COSMIC Text Editor via GUI
     [Documentation]   Start COSMIC Text Editor via GUI and measure launch time
     [Tags]            SP-T243  SP-T243-2
-    Start app via GUI   ${GUI_VM}  cosmic-edit  display_name="COSMIC Text Editor"
+    Start app via GUI   ${GUI_VM}  cosmic-edit  "COSMIC Text Editor"
     Close app via GUI   ${GUI_VM}  cosmic-edit  ghaf-close.png
     Save launch time    cosmic-edit
 
 Start Calculator via GUI
     [Documentation]   Start Calculator via GUI and measure launch time
     [Tags]            SP-T202  SP-T202-2
-    Start app via GUI   ${GUI_VM}  gnome-calculator  display_name=Calculator
+    Start app via GUI   ${GUI_VM}  gnome-calculator  Calculator
     Close app via GUI   ${GUI_VM}  gnome-calculator  window-close-neg.png
     Save launch time    gnome-calculator
 
 Start Element via GUI
     [Documentation]   Start Element via GUI and measure launch time
     [Tags]            SP-T52  SP-T52-2
-    Start app via GUI   ${COMMS_VM}  element  display_name=Element
+    Start app via GUI   ${COMMS_VM}  element  Element
     Close app via GUI   ${COMMS_VM}  element  ghaf-close.png
     Save launch time    element
 
 Start GPU Screen Recorder via GUI
     [Documentation]   Start GPU Screen Recorder via GUI and measure launch time
     [Tags]            SP-T293  SP-T293-2
-    Start app via GUI   ${GUI_VM}  gpu-screen-recorder-gtk  display_name="GPU Screen Recorder"
-    Close app via GUI   ${GUI_VM}  gpu-screen-recorder-gtk
+    Start app via GUI   ${GUI_VM}  gpu-screen-recorder-gtk  "GPU Screen Recorder"
+    Close app via GUI   ${GUI_VM}  gpu-screen-recorder-gtk  window-close.png
     Save launch time    gpu-screen-recorder-gtk
 
 Start Gala via GUI
     [Documentation]   Start Gala via GUI and measure launch time
     [Tags]            SP-T104  SP-T104-2
-    Start app via GUI   ${BUSINESS_VM}  gala  display_name=Gala
+    Start app via GUI   ${BUSINESS_VM}  gala  Gala
     Close app via GUI   ${BUSINESS_VM}  gala  ghaf-close.png
     Save launch time    gala
 
 Start Getting Started via GUI
     [Documentation]   Start 'Getting Started' via GUI and measure launch time
     [Tags]            SP-T354  SP-T354-2
-    Start app via GUI   ${CHROME_VM}  ghaf-intro  display_name="Getting Started"
-    Close app via GUI   ${CHROME_VM}  ghaf-intro  ghaf-close.png   2
+    Start app via GUI   ${CHROME_VM}  ghaf-intro  "Getting Started"
+    Close app via GUI   ${CHROME_VM}  ghaf-intro  ghaf-close.png
     Save launch time    ghaf-intro
 
 Start Ghaf Control Panel via GUI
     [Documentation]   Start Ghaf Control Panel via GUI and measure launch time
     [Tags]            SP-T205  SP-T205-2
-    Start app via GUI   ${GUI_VM}  ctrl-panel  display_name="Ghaf Control Panel"
+    Start app via GUI   ${GUI_VM}  ctrl-panel  "Ghaf Control Panel"
     Close app via GUI   ${GUI_VM}  ctrl-panel  window-close-neg.png
     Save launch time    ctrl-panel
 
 Start Google Chrome via GUI
     [Documentation]   Start Google Chrome via GUI and measure launch time
     [Tags]            SP-T92  SP-T92-2
-    Start app via GUI   ${CHROME_VM}  chrome  display_name="Google Chrome"
-    Close app via GUI   ${CHROME_VM}  chrome  ghaf-close.png   2
+    Start app via GUI   ${CHROME_VM}  chrome  "Google Chrome"
+    Close app via GUI   ${CHROME_VM}  chrome  ghaf-close.png
     Save launch time    chrome
 
 Start Microsoft 365 via GUI
     [Documentation]   Start Microsoft 365 via GUI and measure launch time
     [Tags]            SP-T178  SP-T178-2
-    Start app via GUI   ${BUSINESS_VM}  microsoft365  display_name="Microsoft 365"
+    Start app via GUI   ${BUSINESS_VM}  microsoft365  "Microsoft 365"
     Close app via GUI   ${BUSINESS_VM}  microsoft365  ghaf-close.png
     Save launch time    microsoft365
 
 Start Outlook via GUI
     [Documentation]   Start Outlook via GUI and measure launch time
     [Tags]            SP-T176  SP-T176-2
-    Start app via GUI   ${BUSINESS_VM}  outlook  display_name=Outlook
+    Start app via GUI   ${BUSINESS_VM}  outlook  Outlook
     Close app via GUI   ${BUSINESS_VM}  outlook  ghaf-close.png
     Save launch time    outlook
 
 Start Slack via GUI
     [Documentation]   Start Slack via GUI and measure launch time
     [Tags]            SP-T181  SP-T181-2
-    Start app via GUI   ${COMMS_VM}  slack  display_name=Slack
+    Start app via GUI   ${COMMS_VM}  slack  Slack
     Close app via GUI   ${COMMS_VM}  slack  ghaf-close.png
     Save launch time    slack
 
 Start Sticky Notes via GUI
     [Documentation]   Start Sticky Notes via GUI and measure launch time
     [Tags]            SP-T201  SP-T201-2
-    Start app via GUI   ${GUI_VM}  sticky-wrapped  display_name="Sticky Notes"
+    Start app via GUI   ${GUI_VM}  sticky-wrapped  "Sticky Notes"
     Close app via GUI   ${GUI_VM}  sticky-wrapped  window-close-neg.png
     Save launch time    sticky-wrapped
 
 Start Teams via GUI
     [Documentation]   Start Teams via GUI and measure launch time
     [Tags]            SP-T177  SP-T177-2
-    Start app via GUI   ${BUSINESS_VM}  teams  display_name=Teams
+    Start app via GUI   ${BUSINESS_VM}  teams  Teams
     Close app via GUI   ${BUSINESS_VM}  teams  ghaf-close.png
     Save launch time    teams
 
 Start Trusted Browser via GUI
     [Documentation]   Start Trusted Browser via GUI and measure launch time
     [Tags]            SP-T179  SP-T179-2
-    Start app via GUI   ${BUSINESS_VM}  google-chrome  display_name="Trusted Browser"
-    Close app via GUI   ${BUSINESS_VM}  google-chrome  ghaf-close.png   2
+    Start app via GUI   ${BUSINESS_VM}  google-chrome  "Trusted Browser"
+    Close app via GUI   ${BUSINESS_VM}  google-chrome  ghaf-close.png
     Save launch time    google-chrome
 
 Start Volume Control via GUI
     [Documentation]   Start Volume Control via GUI and measure launch time
     [Tags]            SP-T349  SP-T349-2
-    Start app via GUI   ${GUI_VM}  pavucontrol  display_name="Volume Control"
+    Start app via GUI   ${GUI_VM}  pavucontrol  "Volume Control"
     Close app via GUI   ${GUI_VM}  pavucontrol  window-close-neg.png
     Save launch time    pavucontrol
 
 Start VPN via GUI
     [Documentation]   Start VPN app via GUI and measure launch time
     [Tags]            SP-T200  SP-T200-2
-    Start app via GUI   ${BUSINESS_VM}  gp-gui  display_name=VPN
+    Start app via GUI   ${BUSINESS_VM}  gp-gui  VPN
     Close app via GUI   ${BUSINESS_VM}  gp-gui  ghaf-close.png
     Save launch time    gp-gui
 
 Start Zoom via GUI
     [Documentation]   Start Zoom via GUI and measure launch time
     [Tags]            SP-T237  SP-T237-2
-    Start app via GUI   ${COMMS_VM}  zoom  display_name=Zoom
+    Start app via GUI   ${COMMS_VM}  zoom  Zoom
     Close app via GUI   ${COMMS_VM}  zoom  ghaf-close.png
     Save launch time    zoom
 

--- a/Robot-Framework/test-suites/gui-tests/gui_app_store.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_app_store.robot
@@ -137,7 +137,7 @@ Kill app and Uninstall in App Store
     ${flatpak_app_id}   Get flatpak app id   ${app_name}
     Should Be Empty     ${flatpak_app_id}    App ${app_name} is still installed via flatpak (${flatpak_app_id})
     Log   ${app_name} is now uninstalled   console=True
-    Close app via GUI   ${FLATPAK_VM}  cosmic-store  ./window-close-neg.png
+    Close app via GUI   ${FLATPAK_VM}  cosmic-store  window-close-neg.png
     [Teardown]   Run Keywords   Switch to vm   ${FLATPAK_VM}
     ...    AND   Kill App By Name   cosmic-store   sudo=True
     ...    AND   Kill App By Name   ${process_name}   sudo=True

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -21,7 +21,7 @@ Create and save text file from COSMIC Text Editor via GUI
     ${doc_text}        Set Variable    test_content
     ${share_path}      Set Variable    /Shares/'Unsafe comms-vm share'/${file_name}
 
-    Start app via GUI   ${GUI_VM}  cosmic-edit  display_name="COSMIC Text Editor"
+    Start app via GUI   ${GUI_VM}  cosmic-edit  "COSMIC Text Editor"
     Locate on screen    image      ghaf-close.png
     Type string         ${doc_text}   enter_at_end=True
     Save current document from Cosmic Text Editor to Shares   ${file_name}
@@ -36,10 +36,10 @@ Copy and paste text between VMs
     [Documentation]   Copy text in COSMIC Text Editor (GUI VM) and paste it into Trusted Browser (BUSINESS VM)
     [Tags]            SP-T72
     ${clipboard_text}    Set Variable  COPYPASTE
-    Start app via GUI    ${GUI_VM}     cosmic-edit  display_name="COSMIC Text Editor"
+    Start app via GUI    ${GUI_VM}     cosmic-edit  "COSMIC Text Editor"
     Locate on screen     image         ghaf-close.png
     Copy text to clipboard    ${clipboard_text}
-    Start app via GUI   ${BUSINESS_VM}  google-chrome  display_name="Trusted Browser"
+    Start app via GUI   ${BUSINESS_VM}  google-chrome  "Trusted Browser"
     Paste clipboard text and verify     ${clipboard_text}
     [Teardown]    Run Keywords    Switch to vm    ${BUSINESS_VM}    AND    Kill App By Name   google-chrome   sudo=True
     ...           AND             Switch to vm    ${GUI_VM}  user=${USER_LOGIN}
@@ -49,7 +49,7 @@ Copy and paste text between VMs
 Open an app from the dock
     [Documentation]   Open Zoom, minimize its window, verify it is hidden, then restore it from dock and compare coordinates.
     [Tags]            SP-T79
-    Start app via GUI   ${COMMS_VM}   zoom    display_name="Zoom"
+    Start app via GUI   ${COMMS_VM}   zoom    "Zoom"
     ${zoom_window_coords}    ${zoom_anchor_coords}    Save Zoom window baseline coordinates
     ${zoom_before_x}   ${zoom_before_y}    Save Zoom icon coordinates
     Locate and click minimize window button
@@ -62,7 +62,7 @@ Open an app from the dock
 Maximize and restore window
     [Documentation]   Open Zoom, maximize its window, verify it, then restore it and compare coordinates.
     [Tags]            SP-T78
-    Start app via GUI   ${COMMS_VM}   zoom    display_name="Zoom"
+    Start app via GUI   ${COMMS_VM}   zoom    "Zoom"
     ${zoom_window_coords}    ${zoom_anchor_coords}    Save Zoom window baseline coordinates
     Locate and click maximize/restore window button
     Verify app window is maximized

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -15,7 +15,6 @@
 | 26.02.2026 | Check systemctl status in every VM (retry added for NX) | Timeout of Executing command 'systemctl list-units --plain --no-legend --no-pager '.          |
 | 11.02.2026 | Check device id                                         | SSRCSP-7997                                                                                   |
 | 11.02.2026 | Check net-vm hostname                                   | SSRCSP-7997                                                                                   |
-| 07.11.2025 | Measure time to launch COSMIC Settings                  | SSRCSP-7518                                                                                   |
 | 23.10.2025 | Save host journalctl/Verify NetVM is started            | SSRCSP-7453                                                                                   |
 | 16.09.2025 | Check systemctl status in every VM                      | [Full list of skips in the test case](/Robot-Framework/test-suites/functional-tests/vm.robot) |
 |            | Measure Hard Boot Time                                  | The searched journalctl line is sometimes (randomly) not there. Didn't find it this time      |


### PR DESCRIPTION
- Remove a workaround for multiple windows from `Close app via GUI`, Chrome has been updated and workaround is not needed anymore
- Use `terminate-session` instead of `terminate-user` to log out. This means that only the GUI session is terminated, SSH connections still continue to work. This removes the need to create a new SSH connection for the testuser right after termination, now it works with a [switch](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6324/artifact/Robot-Framework/test-suites/lenovo-x1ANDgui/log.html#s1-s1-k2-k2-k1-k2-k1-k3-k4-k3-k7-k9-k2-k8-k1-k1). Will hopefully fix the issue where the teardown fails.
- Some other cleaning to make things look nicer.

Testruns
- [Lenovo X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6324/artifact/Robot-Framework/test-suites/lenovo-x1ANDgui/report.html#totals)
- [Darter Pro storeDisk installer](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6323/artifact/Robot-Framework/test-suites/darter-proANDgui/report.html#totals)