### PR TITLE
Sudo with NOPASSWD

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -164,14 +164,18 @@ Get device state
     RETURN          ${state}
 
 Restart VM
-    [Documentation]         Try to restart VM service and verify it started
-    [Arguments]             ${vm}
+    [Documentation]         Start or restart a VM service and verify it is running.
+    ...                     Reinstall Robot sudoers after the VM is back by default.
+    ...                     Pass `${restore_sudoers}=False` only if you will re-enable sudoers yourself afterward.
+    [Arguments]             ${vm}    ${start_only}=False    ${restore_sudoers}=True
     [Setup]                 Switch to vm   ${HOST}
     Log                     Going to start ${vm}    console=True
-    Run Command             systemctl restart microvm@${vm}.service  sudo=True  timeout=120
+    ${start_commnad}        Set Variable If   ${start_only}   start   restart
+    Run Command             systemctl ${start_commnad} microvm@${vm}.service  sudo=True  timeout=120
     ${state}  ${substate}   Verify service status  service=microvm@${vm}.service  expected_state=active  expected_substate=running
     Log                     ${vm} is ${substate}    console=True
     Check if ssh is ready on vm   ${vm}
+    [Teardown]   Run Keyword If   ${restore_sudoers}   Ensure Robot sudoers is installed in all VMs    skip_boot_check=True
 
 Check VM Log on Grafana
     [Documentation]  Check that specific log entry (log line contains) from a VM is available in Grafana

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -32,22 +32,21 @@ Log in, unlock and verify
     [Arguments]       ${enable_dnd}=False
     ${logout_status}    Check if logged out   1
     IF  ${logout_status}
-        Run Command       logger --priority=user.info "ROBOT_LOG: Logging in on ${DEVICE_TYPE}, job ${JOB}"
         Log in via GUI
-        ${status}    ${output}    Run Keyword And Ignore Error    Wait Until Keyword Succeeds    60s    1s    Verify user login session
+        ${status}    ${output}    Run Keyword And Ignore Error    Wait Until Keyword Succeeds    60s    1s    Verify login session
         IF    '${status}' == 'FAIL'
             Log To Console    Login session verification failed, retrying GUI login
             Run Command       logger --priority=user.info "ROBOT_LOG: Login failed on ${DEVICE_TYPE}, job ${JOB}"
             Log in via GUI
-            Wait Until Keyword Succeeds    60s    1s    Verify user login session
+            Wait Until Keyword Succeeds    60s    1s    Verify login session
         END
-        Run Command       logger --priority=user.info "ROBOT_LOG: Login passed on ${DEVICE_TYPE}, job ${JOB}"
     ELSE
         ${lock}       Check if locked
         IF  ${lock}   Unlock
     END
 
-    Verify desktop availability   iterations=100
+    ${iterations}   Set Variable If    "${DEVICE_TYPE}" == "dell-7330"    130    100
+    Verify desktop availability   iterations=${iterations}
 
     Kill Initial Setup
     Disable automatic suspension
@@ -75,6 +74,9 @@ Log out and verify
 Log in via GUI
     [Documentation]   Log in by typing password
     Log To Console    Logging in
+    Wait Until Keyword Succeeds    60s    1s    Verify login session    greeter
+    # Sleep is needed to make sure that greeter is ready, screenshots can't be used because greeter has control of the screen
+    Sleep    5
     # Make sure that password field is active by clicking on screen
     Run ydotool command   mousemove --absolute -x 50 -y 50   sudo=True
     Click   sudo=True
@@ -143,7 +145,7 @@ Locate on screen
     ${coordinates}=        Set Variable  ${EMPTY}
     ${locate_status}=      Set Variable  FAIL
     Run Command            mkdir -p test-images
-    Log To Console         Taking a screenshot to locate ${type} ${searched_item}   console=True   no_newline=True
+    Log To Console         Taking a screenshot to locate ${type} ${searched_item}   no_newline=True
     FOR   ${i}   IN RANGE   1   ${iterations}+1
         ${screenshot_status}  ${result}     Take a screenshot
         Log To Console        ${SPACE}${i}   no_newline=True
@@ -219,21 +221,23 @@ Verify desktop availability
     Log To Console    Verifying login by trying to detect the launcher icon
     Locate on screen  image  ${APP_MENU_LAUNCHER}  0.95  ${iterations}
 
-Verify user login session
-    [Documentation]   Confirm that the user has an active login session on a seat
+Verify login session
+    [Documentation]   Confirm that the given user has an active login session on a seat
+    [Arguments]       ${session_user}=${USER_LOGIN}
+    Run Command       loginctl list-sessions   # For debugging
     ${sessions}       Run Command   loginctl list-sessions | grep seat   rc_match=skip
-    IF    $USER_LOGIN in $sessions
-        Log   Found active GUI session for ${USER_LOGIN}   console=True
+    IF    $session_user in $sessions
+        Log   Found active GUI session for ${session_user}   console=True
         RETURN
     END
-    Log     No active GUI session found for ${USER_LOGIN}   console=True
-    FAIL    User is logged out
+    Log     No active GUI session found for ${session_user}   console=True
+    FAIL    User ${session_user} is not logged in
 
 Check if logged out
     [Documentation]    Check if system is in logged out state
     [Arguments]        ${iterations}=10
     FOR   ${i}   IN RANGE  ${iterations}
-        ${status}    ${output}    Run Keyword And Ignore Error    Verify user login session
+        ${status}    ${output}    Run Keyword And Ignore Error    Verify login session
         IF    '${status}' == 'PASS'
             Log      Found active GUI session for ${USER_LOGIN}, user is logged in  console=True
         ELSE

--- a/Robot-Framework/resources/serial_keywords.resource
+++ b/Robot-Framework/resources/serial_keywords.resource
@@ -188,6 +188,7 @@ Verify shutdown via serial
 
 Run Command On Serial
     [Documentation]    Run a host command on the serial console and wait for the shell prompt.
+    ...                NOTE: Does not currently work if NOPASSWD sudo is enabled.
     [Arguments]    ${command}    ${timeout}=30    ${sudo}=${False}    ${pre_flush}=${True}
     ${opened_here}     Set Variable    ${False}
     IF    not ${UART_CAPTURE_ACTIVE}
@@ -266,6 +267,7 @@ Run Command on VM Via Serial
     SerialLibrary.Read Until    terminator=${\n}
     ${search1}         Set Variable    (yes/no/[fingerprint])?
     ${search2}         Set Variable    assword
+    ${post_auth_output}    Set Variable    ${EMPTY}
     ${status}  ${output}  Run Keyword And Ignore Error  SerialLibrary.Read Until  terminator=${search1}
     IF  $search1 in $output
         Write Data       yes${\n}
@@ -281,12 +283,15 @@ Run Command on VM Via Serial
     END
     # If the command was run with sudo expect another password prompt
     IF    ${sudo}
-        ${status}  ${output}  Run Keyword And Ignore Error  SerialLibrary.Read Until  terminator=${search2}
-        IF  $search2 in $output
+        ${status}  ${post_auth_output}  Run Keyword And Ignore Error  SerialLibrary.Read Until  terminator=${search2}
+        IF  $search2 in $post_auth_output
             Send Password Via Serial Quietly
         END
     END
     ${prompt_output}   SerialLibrary.Read Until    terminator=ghaf@${HOST}:
+    IF    $post_auth_output != '${EMPTY}' and $search2 not in $post_auth_output
+        ${prompt_output}    Catenate    SEPARATOR=    ${post_auth_output}    ${prompt_output}
+    END
     IF    ${opened_here}
         Delete All Ports
     END

--- a/Robot-Framework/resources/setup_keywords.resource
+++ b/Robot-Framework/resources/setup_keywords.resource
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***
+Library             SSHLibrary
 Resource            ../config/variables.robot
 Resource            ../resources/gui_keywords.resource
 Resource            ../resources/ssh_keywords.resource
@@ -10,7 +11,8 @@ Resource            ../resources/file_keywords.resource
 
 
 *** Variables ***
-${CONNECTION_TYPE}       ssh
+${CONNECTION_TYPE}           ssh
+${ROBOT_SUDOERS_BOOT_ID}     ${EMPTY}
 
 
 *** Keywords ***
@@ -38,6 +40,7 @@ Prepare Test Environment
     END
 
 Verify boot from expected device
+    [Setup]   Switch to vm    ${HOST}
     IF  '${JOB}' == '${DEVICE_TYPE}'
         # Avoid blocking custom local test runs
         RETURN
@@ -78,6 +81,7 @@ Save host journalctl
     OperatingSystem.File Should Exist    ${OUTPUT_DIR}/journal_${SUITE_NAME}.txt
 
 Log versions and device unique data
+    [Setup]             Switch to vm    ${HOST}
     ${ghaf_commit}      Get File Content Or Default        /persist/build_commit
     ${build_job}        Get File Content Or Default        /persist/job
 
@@ -144,7 +148,7 @@ Save login and logout icons
 Login to laptop
     [Documentation]   Log in to the laptop
     [Arguments]       ${enable_dnd}=False
-    Check if ssh is ready on vm   ${GUI_VM}    timeout=60
+    Ensure Robot sudoers is installed in all VMs
     Start ydotoold
     Switch to vm   ${GUI_VM}  user=${USER_LOGIN}
     Log in, unlock and verify   ${enable_dnd}
@@ -163,3 +167,44 @@ Is first graphical login
     ${lines}    Count lines    ${result}
     IF  ${lines} <= 1   RETURN   True
     RETURN      False
+
+Ensure Robot sudoers is installed in all VMs
+    [Arguments]     ${skip_boot_check}=False
+    Switch to vm    ${HOST}
+    ${current_boot_id}    Run Command    cat /proc/sys/kernel/random/boot_id
+    IF    '${ROBOT_SUDOERS_BOOT_ID}' == '${current_boot_id}' and not ${skip_boot_check}
+        Log    Robot sudoers already installed in this boot, skipping    console=True
+        RETURN
+    END
+
+    @{vm_list_with_host}    Get VM list    with_host=True
+    ${robot_sudoers_install_script_remote}   Set Variable   /tmp/install_robot_sudoers.sh
+    ${skipped_vms}    Create List
+
+    # Start an installation in all reachable VMs and on host.
+    FOR    ${vm}    IN    @{vm_list_with_host}
+        TRY
+            Switch to vm    ${vm}
+        EXCEPT    AS    ${switch_error}
+            Log               Skipping sudoers install in ${vm}: ${switch_error}   console=True
+            Append To List    ${skipped_vms}    ${vm}
+            CONTINUE
+        END
+        Log            Starting sudoers install in ${vm}    console=True
+        Put File       ../test-files/install_robot_sudoers.sh    ${robot_sudoers_install_script_remote}
+        Run Command    chmod 755 ${robot_sudoers_install_script_remote}
+        Start Command  ${robot_sudoers_install_script_remote}    sudo=True    sudo_password=${PASSWORD}
+    END
+    IF    $skipped_vms    Run Command  logger --priority=user.info "ROBOT_LOG: Sudoers not installed to ${skipped_vms} on ${DEVICE_TYPE}, job ${JOB}"
+    # Check that installation has finished everywhere
+    FOR    ${vm}    IN    @{vm_list_with_host}
+        IF    $vm in $skipped_vms
+            Log          Skipping sudoers install verification in ${vm} because install was skipped   console=True
+            CONTINUE
+        END
+        Switch to vm    ${vm}
+        ${install_out}    Read Command Output
+        Should Contain    ${install_out}    __ROBOT_SUDOERS_INSTALL_DONE__    Sudoers install failed in ${vm}, output: ${install_out}
+        Log               Sudoers install completed in ${vm}    console=True
+    END
+    Set Global Variable    ${ROBOT_SUDOERS_BOOT_ID}    ${current_boot_id}

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -252,10 +252,10 @@ Check if ssh is ready on vm
     ${start_time}                   Get Time	epoch
     FOR    ${i}    IN RANGE    ${timeout}
         ${status}  ${out}   Run Keyword And Ignore Error   Run Command    timeout 4 nc -zvw3 ${vm} 22  timeout=5
-        Sleep        ${PING_SPACING}
         IF   '${status}' == 'PASS'
             BREAK
         END
+        Sleep        ${PING_SPACING}
         ${diff}=    Evaluate    int(time.time()) - int(${start_time})
         IF   ${diff} > ${timeout}
             BREAK

--- a/Robot-Framework/test-files/install_robot_sudoers.sh
+++ b/Robot-Framework/test-files/install_robot_sudoers.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+set -eu
+
+target_file="${1:-/etc/sudoers}"
+tmp_prefix="/tmp/sudoers.robot"
+
+base_file="${tmp_prefix}.base"
+block_file="${tmp_prefix}.block"
+new_file="${tmp_prefix}.new"
+
+cp "$target_file" "$base_file"
+
+if grep -q "^# BEGIN ROBOT TEST SUDOERS$" "$target_file"; then
+    sed "/^# BEGIN ROBOT TEST SUDOERS$/,/^# END ROBOT TEST SUDOERS$/d" \
+        "$target_file" > "$base_file"
+fi
+
+{
+    printf "\n# BEGIN ROBOT TEST SUDOERS\n"
+    printf "ghaf ALL=(root) NOPASSWD: ALL\n"
+    printf "\n# END ROBOT TEST SUDOERS\n"
+} > "$block_file"
+
+cat "$base_file" "$block_file" > "$new_file"
+
+if command -v visudo >/dev/null 2>&1; then
+    visudo -cf "$new_file"
+elif [ -x /run/current-system/sw/bin/visudo ]; then
+    /run/current-system/sw/bin/visudo -cf "$new_file"
+else
+    echo "visudo not found" >&2
+    exit 1
+fi
+
+install -m 0440 "$new_file" "$target_file"
+printf "__ROBOT_SUDOERS_INSTALL_DONE__\n"

--- a/Robot-Framework/test-suites/gui-tests/gui_app_store.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_app_store.robot
@@ -94,6 +94,7 @@ Wait until flatpak app is installed
             RETURN
         END
         Log To Console   ${i}.  no_newline=true
+        Sleep   3
     END
     FAIL    App ${app_name} is not installed via flatpak.
     [Teardown]   Switch to vm   ${GUI_VM}  user=${USER_LOGIN}

--- a/Robot-Framework/test-suites/performance-tests/ballooning.robot
+++ b/Robot-Framework/test-suites/performance-tests/ballooning.robot
@@ -28,6 +28,8 @@ ${rebooted}               False
 # Tags removed:  lenovo-x1  darter-pro
 # Ballooning feature was turned off in ghaf by PR#1770
 
+# NOTE: "Run Command  -b <command>" does not work anymore. If this test is taken back to use that has to be fixed.
+
 Test ballooning in chrome-vm
     [Tags]                  SP-T255  ballooning_chrome_vm
     Test ballooning in VM   vm=chrome-vm   mem_quota=6144   max_inflate_ratio=3

--- a/Robot-Framework/test-suites/security-tests/firewall.robot
+++ b/Robot-Framework/test-suites/security-tests/firewall.robot
@@ -52,6 +52,7 @@ Check that internal tcp syn flooding triggers blacklisting
 Check that external ping flooding triggers blacklisting
     [Tags]            SP-T299  SP-T299-3  lenovo-x1  darter-pro  orin-agx  orin-nx  lab-only
     [Documentation]   Validate that ping flooding from the test agent to net-vm triggers firewall blacklisting.
+    [Setup]           Run Keyword If   "${SERIAL_PORT}" == "NONE"   SKIP   No serial address, skipping test
     ${ext_attacker_ip}    Get External Attacker IP
     External Ping Flood NetVM
     Verify NetVM Blacklist Contains IP Via Serial    ${ext_attacker_ip}
@@ -61,6 +62,7 @@ Check that external ping flooding triggers blacklisting
 Check that external tcp syn flooding triggers blacklisting
     [Tags]            SP-T299  SP-T299-4  lenovo-x1  darter-pro  orin-agx  orin-nx  lab-only
     [Documentation]   Validate that tcp syn probing from the test agent to net-vm triggers firewall blacklisting.
+    [Setup]           Run Keyword If   "${SERIAL_PORT}" == "NONE"   SKIP   No serial address, skipping test
     ${ext_attacker_ip}    Get External Attacker IP
     Tcp Syn Flood         ${DEVICE_IP_ADDRESS}
     Verify NetVM Blacklist Contains IP Via Serial    ${ext_attacker_ip}

--- a/Robot-Framework/test-suites/security-tests/immutability.robot
+++ b/Robot-Framework/test-suites/security-tests/immutability.robot
@@ -9,8 +9,10 @@ Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/file_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/service_keywords.resource
+Resource            ../../resources/setup_keywords.resource
 
 Suite Setup         Suite Setup
+Suite Teardown      Ensure Robot sudoers is installed in all VMs   skip_boot_check=True
 
 
 *** Test Cases ***
@@ -39,19 +41,9 @@ ${vm} is wiped after restarting
     Create file         /etc/test.txt    sudo=True
     Close Connection
     Switch to vm        ${HOST}
-    Restart VM          ${vm}
+    Restart VM          ${vm}   restore_sudoers=False
     Check Network Availability      ${vm}    expected_result=True    range=15
     Switch to vm        ${vm}
     Log To Console      Check if created file still exists
     Check file doesn't exist    /etc/test.txt    sudo=True
-    [Teardown]  Run Keyword If  "${KEYWORD STATUS}" == 'FAIL'   Start VM   ${vm}
-
-Start VM
-    [Documentation]         Try to start VM and verify it started
-    [Arguments]             ${vm}
-    Switch to vm            ${HOST}
-    Log                     Going to start ${vm}    console=True
-    Run Command             systemctl start microvm@${vm}.service  sudo=True  timeout=120
-    ${state}  ${substate}   Verify service status  service=microvm@${vm}.service  expected_state=active  expected_substate=running
-    Log                     ${vm} is ${substate}    console=True
-    Check if ssh is ready on vm   ${vm}
+    [Teardown]  Run Keyword If  "${KEYWORD STATUS}" == 'FAIL'   Restart VM   ${vm}   start_only=True   restore_sudoers=False

--- a/Robot-Framework/test-suites/security-tests/ip_spoofing.robot
+++ b/Robot-Framework/test-suites/security-tests/ip_spoofing.robot
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 *** Settings ***
+Resource            ../../resources/service_keywords.resource
+Resource            ../../resources/setup_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 Test Tags           ip-spoofing
 Test Timeout        3 minutes
@@ -43,7 +45,8 @@ Test IP spoofing
         Sleep       5
     END
     Check the result files
-    [Teardown]                      Spoofing Test Teardown
+    # Switching of IP address can make stealer VM inaccessible for further tests. Restart the stealer vm.
+    [Teardown]   Restart VM   ${stealer_vm}
 
 Prepare netcat server script
     Switch to vm                      ${server_vm}
@@ -73,7 +76,7 @@ Prepare netcat stealer script
 Launch netcat test script
     [Arguments]                       ${vm}  ${script_name}
     Switch to vm                      ${vm}
-    Run Keyword And Ignore Error      Run Command  -b ${file_path}/${script_name} ${file_path}  sudo=True  timeout=2
+    Run Keyword And Ignore Error      Run Command  sh -c "nohup ${file_path}/${script_name} ${file_path} >/tmp/${script_name}.out 2>&1 < /dev/null &"  sudo=True  timeout=2
 
 Check the result files
     Switch to vm                      ${GUI_VM}
@@ -104,11 +107,3 @@ Get Virtual Network Interface IP
         Sleep    1
     END
     FAIL    IP address not found.
-
-
-Spoofing Test Teardown
-    [Documentation]   Switching of IP address can make stealer VM inaccessible for further tests.
-    ...               Restart the stealer vm.
-    Switch to vm      ${HOST}
-    Run Command       systemctl restart microvm@${stealer_vm}.service  sudo=True
-    Close All Connections

--- a/Robot-Framework/test-suites/security-tests/vm_isolation.robot
+++ b/Robot-Framework/test-suites/security-tests/vm_isolation.robot
@@ -12,6 +12,7 @@ Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/service_keywords.resource
 
 Suite Setup         Switch to vm   ${NET_VM}
+Suite Teardown      Ensure Robot sudoers is installed in all VMs   skip_boot_check=True
 
 
 *** Test Cases ***
@@ -37,7 +38,8 @@ Stopping one VM does not affect another
     ${state}  ${substate}   Verify service status  service=microvm@${another_vm}.service  expected_state=active  expected_substate=running
     Switch to vm   ${another_vm}
     Check that the application was started    ${process_name}
-    [Teardown]    Run Keywords   Start VM   ${one_vm}   AND   Kill App in VM   ${another_vm}   ${process_name}   PASS
+    [Teardown]    Run Keywords   Restart VM   ${one_vm}   start_only=True   restore_sudoers=False
+    ...                    AND   Kill App in VM   ${another_vm}   ${process_name}   PASS
 
 Stop VM
     [Documentation]         Try to stop VM and verify it stopped
@@ -48,13 +50,3 @@ Stop VM
     Sleep    3
     ${state}  ${substate}   Verify service status  service=microvm@${vm}.service  expected_state=inactive  expected_substate=dead
     Log                     ${vm} is ${substate}    console=True
-
-Start VM
-    [Documentation]         Try to start VM and verify it started
-    [Arguments]             ${vm}
-    Switch to vm            ${HOST}
-    Log                     Going to start ${vm}    console=True
-    Run Command             systemctl start microvm@${vm}.service  sudo=True  timeout=120
-    ${state}  ${substate}   Verify service status  service=microvm@${vm}.service  expected_state=active  expected_substate=running
-    Log                     ${vm} is ${substate}    console=True
-


### PR DESCRIPTION
**Changes**

- Allow `ghaf` user to run `sudo` without password. This makes every `sudo` command about 4 seconds faster.
  - `Ensure Robot sudoers is installed in all VMs` is now called before login. It checks whether the sudoers files in the VMs have already been modified to allow passwordless `sudo`. If not, a script is executed in every VM to enable it. `Start Command` is used to execute the script simultaneously across multiple VMs.
  - Sudoers files need to be edited again every time after a reboot and after a VM has been rebooted.
  - For now Orins are excluded.
- Due to `sudo` not taking as long some timing adjustments were needed. Most notably I had to add an extra checks before `testuser` password is typed in login screen.
- `Run Command on VM Via Serial` required changes to work correctly when no password prompt is shown. The previous implementation consumed the output while waiting for a password prompt that never appeared.
- Moved `${PING_SPACING}` in `Check if ssh is ready on vm` so that it is not executed after successful `netcat`.
  - Ghaf limits `netcat` to one connection per second, but there is a separate limit for bursts. Even if there happens to be another `netcat` to the same VM right after it won't be an issue. This change saves 1 second every time a new connection is opened. It does not sound that much, but ends up saving a couple of minutes in a full regression run.

**Advantages**

- Faster

| Target     | Nightly with mainline | Nightly with this PR | Time save    | Improvement |
| ---------- | --------------------- | -------------------- | ------------ | ----------- |
| Lenovo X1  | 01:46:02.862          | 01:12:46.643         | 00:33:16.219 | 31.37%      |
| Darter Pro | 01:51:04.715          | 01:13:19.650         | 00:37:45.065 | 33.99%      |
| Dell-7330  | 00:41:14.954          | 00:19:57.027         | 00:21:17.927 | 51.63%      |

| Tag (Darter) | Nightly with mainline | Nightly with this PR | Time save    | Improvement |
| ------------ | --------------------- | -------------------- | ------------ | ----------- |
| pre-merge    | 00:05:07.451          | 00:02:37.551         | 00:02:29.900 | 48.76%      |
| bat          | 00:10:10.526          | 00:04:14.203         | 00:05:56.323 | 58.36%      |
| security     | 00:39:30.646          | 00:27:39.354         | 00:11:51.292 | 30.00%      |

**Disadvantages**

- Adds another level of complexity. For now I do not want to hide any errors. If random failures start happening, we can add `Run Keyword And Ignore Error` for `Ensure Robot sudoers is installed in all VMs`.

**Testruns**
- [Lenovo X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test/1322/artifact/Robot-Framework/test-suites/regression/report.html#totals)
- [Lenovo X1 installer](https://ci-dev.vedenemo.dev/job/ghaf-hw-test/1317/artifact/Robot-Framework/test-suites/regression/report.html#totals)
- [Darter Pro](https://ci-dev.vedenemo.dev/job/ghaf-hw-test/1323/artifact/Robot-Framework/test-suites/regression/report.html#totals)
- [Darter Pro storeDisk installer](https://ci-dev.vedenemo.dev/job/ghaf-hw-test/1325/artifact/Robot-Framework/test-suites/regression/report.html#totals)
- [Dell 7330](https://ci-dev.vedenemo.dev/job/ghaf-hw-test/1316/artifact/Robot-Framework/test-suites/regression/report.html#totals)
- [Orin AGX](https://ci-dev.vedenemo.dev/job/ghaf-hw-test/1328/artifact/Robot-Framework/test-suites/regression/report.html#totals)
- [Orin NX](https://ci-dev.vedenemo.dev/job/ghaf-hw-test/1315/artifact/Robot-Framework/test-suites/regression/report.html#totals)
- [Perfomance pipeline](https://ci-dev.vedenemo.dev/job/ghaf-nightly-perftest/316/)