### PR TITLE
Add a second attempt for login

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -32,8 +32,16 @@ Log in, unlock and verify
     [Arguments]       ${enable_dnd}=False
     ${logout_status}    Check if logged out   1
     IF  ${logout_status}
+        Run Command       logger --priority=user.info "ROBOT_LOG: Logging in on ${DEVICE_TYPE}, job ${JOB}"
         Log in via GUI
-        Wait Until Keyword Succeeds    60s    1s    Verify user login session
+        ${status}    ${output}    Run Keyword And Ignore Error    Wait Until Keyword Succeeds    60s    1s    Verify user login session
+        IF    '${status}' == 'FAIL'
+            Log To Console    Login session verification failed, retrying GUI login
+            Run Command       logger --priority=user.info "ROBOT_LOG: Login failed on ${DEVICE_TYPE}, job ${JOB}"
+            Log in via GUI
+            Wait Until Keyword Succeeds    60s    1s    Verify user login session
+        END
+        Run Command       logger --priority=user.info "ROBOT_LOG: Login passed on ${DEVICE_TYPE}, job ${JOB}"
     ELSE
         ${lock}       Check if locked
         IF  ${lock}   Unlock


### PR DESCRIPTION
- Try to login via GUI again if first attempt fails
- New approach for tracking failures: send a log to Grafana to make it easy to check for failures

[Testrun](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6342/artifact/Robot-Framework/test-suites/SP-T75-2ORSP-T186/report.html#totals) - not sure how/why but login failed in both tests and this workaround saved both of them

Grafana logs

```
1780480086908	2026-06-03T09:48:06.908Z	ROBOT_LOG: Logging in on darter-pro, job intel-laptop-debug
1780480094946	2026-06-03T09:48:14.946Z	ROBOT_LOG: Login passed on darter-pro, job intel-laptop-debug
1780480119696	2026-06-03T09:48:39.696Z	ROBOT_LOG: Logging in on darter-pro, job intel-laptop-debug
1780480186653	2026-06-03T09:49:46.653Z	ROBOT_LOG: Login failed on darter-pro, job intel-laptop-debug
1780480194913	2026-06-03T09:49:54.913Z	ROBOT_LOG: Login passed on darter-pro, job intel-laptop-debug
1780480211724	2026-06-03T09:50:11.724Z	ROBOT_LOG: Logging in on darter-pro, job intel-laptop-debug
1780480279497	2026-06-03T09:51:19.497Z	ROBOT_LOG: Login failed on darter-pro, job intel-laptop-debug
1780480287668	2026-06-03T09:51:27.668Z	ROBOT_LOG: Login passed on darter-pro, job intel-laptop-debug
```