### PR TITLE
Log screen recording output

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -368,7 +368,8 @@ Start screen recording
         Set Global Variable  ${SCREEN_SELECTED}  ${True}
     END
     Wait Until Keyword Succeeds    5x    1s    Run Command    ls -la /home/${USER_LOGIN}/Videos/${test_name}.mkv
-    [Teardown]       Run Keyword If   '${KEYWORD_STATUS}' == 'FAIL'   Timestamp last screenshot
+    [Teardown]       Run Keyword If   '${KEYWORD_STATUS}' == 'FAIL'   Run Keywords   Timestamp last screenshot
+    ...              AND   Run Command   cat /tmp/gpu-screen-recorder.log
 
 Stop screen recording
     [Arguments]      ${test_status}   ${test_name}=""

--- a/Robot-Framework/test-suites/functional-tests/vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/vm.robot
@@ -21,7 +21,6 @@ Suite Setup         VM Suite Setup
              ...    dell-7330|ghaf-host|autovt@ttyUSB0.service|SSRCSP-6667
              ...    ANY|gui-vm|plymouth-start.service|SSRCSP-7306
              ...    ANY|gui-vm|plymouth-quit.service|SSRCSP-7306
-             ...    ANY|gui-vm|setup-ghaf-user.service|SSRCSP-7234
              ...    ANY|ANY|tuned.service|SSRCSP-7717
              ...    ANY|ANY|fail2ban.service|SSRCSP-7759
              ...    ANY|ANY|journal-fss-verify.service|SSRCSP-8425
@@ -88,7 +87,7 @@ Check Device ID in every VM
     FOR  ${vm}  IN  @{VM_LIST}
         Switch to vm   ${vm}
         ${id}          Get Actual Device ID
-        Log            Device ID in ${vm}: ${id}, expected be te same as in host: ${host_device_id}     console=True
+        Log            Device ID in ${vm}: ${id}, expected to be the same as in host: ${host_device_id}     console=True
         ${result}      Run Keyword And Return Status    Should Be Equal As Strings
         ...            ${id}    ${host_device_id}    ignore_case=True
         IF    not ${result}


### PR DESCRIPTION
* Save screen recorder output if starting the recording fails
* Remove `setup-ghaf-user.service` skip, this service was removed from Ghaf in January
* Fix typos in `Check Device ID in every VM` logging

**Testruns**
- [Fail](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6357/artifact/Robot-Framework/test-suites/darter-proANDgui-apps/report.html#totals) in `Start screen recording`, output saved
- [Pass](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6358/artifact/Robot-Framework/test-suites/darter-proANDgui-apps/report.html#totals), no output