### PR TITLE
Measure latency with cyclictest

### DIFF
--- a/Robot-Framework/lib/PerformanceDataProcessing.py
+++ b/Robot-Framework/lib/PerformanceDataProcessing.py
@@ -7,9 +7,17 @@ import shutil
 import pandas
 import json
 import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
 import logging
 from robot.api.deco import keyword
 from performance_thresholds import *
+from output_parser import (
+    parse_cyclictest_histogram,
+    parse_cyclictest_histogram_overflows,
+    parse_cyclictest_results,
+    parse_cyclictest_spike_count,
+    parse_cyclictest_spikes,
+)
 from memory_plotting import (
     add_percentage_columns,
     plot_vm_memory_snapshot,
@@ -33,6 +41,34 @@ class PerformanceDataProcessing:
         self.zero_result_flag = -100
         self.low_limit = float(low_limit)
         self.default_low_limit = float(low_limit)
+
+    @staticmethod
+    def _format_latency_us(value_us):
+        if value_us >= 1000:
+            return f"{value_us / 1000.0:.3f} ms"
+        return f"{value_us} us"
+
+    @staticmethod
+    def _format_thread_counts(counts_per_thread):
+        if not counts_per_thread:
+            return "none"
+        return ', '.join(
+            f"t{thread_id}={count}"
+            for thread_id, count in enumerate(counts_per_thread)
+        )
+
+    @staticmethod
+    def _format_thread_cycles(cycles_per_thread, max_cycles_per_thread=5):
+        cycle_chunks = []
+        for thread_id in sorted(cycles_per_thread):
+            cycles = cycles_per_thread[thread_id]
+            if not cycles:
+                continue
+            shown_cycles = ','.join(str(cycle) for cycle in cycles[:max_cycles_per_thread])
+            if len(cycles) > max_cycles_per_thread:
+                shown_cycles += ',...'
+            cycle_chunks.append(f"t{thread_id}=[{shown_cycles}]")
+        return ', '.join(cycle_chunks) if cycle_chunks else "none"
 
     @keyword
     def set_custom_low_limit(self, new_value):
@@ -101,7 +137,15 @@ class PerformanceDataProcessing:
             truncated_list.append(float(f'{item:.{significant_figures}g}'))
         return truncated_list
 
-    def detect_deviation(self, data_column, baseline_start, threshold, deviations_in_row, deviations=[]):
+    def detect_deviation(
+        self,
+        data_column,
+        baseline_start,
+        threshold,
+        deviations_in_row,
+        deviations=[],
+        low_limit=None,
+    ):
         # Calculate mean and population standard deviation of the results
         # Check if last value changes more than threshold from
         #   last "normal" measurement result
@@ -111,6 +155,8 @@ class PerformanceDataProcessing:
         flag = 0
         baseline_end = 0
         last_measurement = data_column[-1]
+        if low_limit is None:
+            low_limit = self.low_limit
 
         if deviations_in_row < self.zero_result_flag + 1:
             deviations_in_row = 0
@@ -186,8 +232,8 @@ class PerformanceDataProcessing:
             upper_marginal = mean + threshold
             lower_marginal = mean - threshold
 
-            if lower_marginal < self.low_limit:
-                lower_marginal = self.low_limit
+            if lower_marginal < low_limit:
+                lower_marginal = low_limit
 
             stats = self.truncate([mean, pstd] + d + [data_column[baseline_end], data_column[baseline_start], upper_marginal, lower_marginal], 5)
 
@@ -196,10 +242,10 @@ class PerformanceDataProcessing:
             stats[0] = last_measurement
             stats[4] = last_measurement
             stats[5] = last_measurement
-            stats[6] = self.low_limit
-            stats[7] = self.low_limit
+            stats[6] = low_limit
+            stats[7] = low_limit
 
-        if last_measurement < self.low_limit:
+        if last_measurement < low_limit:
             flag = self.zero_result_flag
 
         statistics_dict = {
@@ -227,10 +273,16 @@ class PerformanceDataProcessing:
         deviations,
         new_baseline_start,
         row_index,
+        low_limit=None,
     ):
         # Update automatic baseline state and deviation counter for one measurement series.
         statistics_block = self.detect_deviation(
-            data_column, baseline_start, threshold, deviation_counter, deviations
+            data_column,
+            baseline_start,
+            threshold,
+            deviation_counter,
+            deviations,
+            low_limit,
         )
 
         flag = statistics_block['flag']
@@ -266,14 +318,24 @@ class PerformanceDataProcessing:
             deviation_counter = 0
 
         # In case there are not yet valid result history (results below low_limit) and now first valid result
-        if data_column[baseline_start] < self.low_limit and data_column[-1] > self.low_limit:
+        if low_limit is None:
+            low_limit = self.low_limit
+
+        if data_column[baseline_start] < low_limit and data_column[-1] > low_limit:
             deviation_counter = 0
             deviations = []
             baseline_start = row_index
 
         return statistics_block, baseline_start, new_baseline_start, deviation_counter, deviations
 
-    def calculate_statistics(self, test_name, data, monitored_value, threshold):
+    def calculate_statistics(
+        self,
+        test_name,
+        data,
+        monitored_value,
+        threshold,
+        low_limit_overrides=None,
+    ):
         # monitored_value: list of labels
         # threshold: dictionary or list of single value
 
@@ -322,6 +384,9 @@ class PerformanceDataProcessing:
                     indexed_statistics_row = {}
                     monitored_value_index = 0
                     for value in monitored_value:
+                        low_limit = self.low_limit
+                        if low_limit_overrides and value in low_limit_overrides:
+                            low_limit = low_limit_overrides[value]
                         # Select threshold by value name only if there are multiple thresholds
                         if len(threshold) < 2:
                             select_threshold = 0
@@ -341,6 +406,7 @@ class PerformanceDataProcessing:
                             deviations[value],
                             new_baseline_start[value],
                             row_index,
+                            low_limit,
                         )
 
                         new_statistics_row.update({value: statistics_block})
@@ -936,6 +1002,330 @@ class PerformanceDataProcessing:
         return
 
     @keyword
+    def parse_cyclictest_results_file(self, file_path):
+        with open(file_path, 'r', encoding='utf-8') as file:
+            return parse_cyclictest_results(file.read())
+
+    @keyword
+    def get_failed_cyclictest_variants(self, statistics_dict):
+        failed_variants = []
+        suffixes = (
+            '_avg_latency_ms',
+            '_overflow_count',
+        )
+
+        for key, value in statistics_dict.items():
+            if value['flag'] <= 0:
+                continue
+            variant_name = key
+            for suffix in suffixes:
+                if key.endswith(suffix):
+                    variant_name = key[:-len(suffix)]
+                    break
+            if variant_name not in failed_variants:
+                failed_variants.append(variant_name)
+
+        return failed_variants
+
+    @keyword
+    def get_cyclictest_histogram_limit(self, target, variant_name):
+        return thresholds['cyclictest'][target][f'latency_threshold_us_{variant_name}']
+
+    @keyword
+    def generate_cyclictest_histogram_plot(
+        self,
+        source_file,
+        plot_name,
+        plot_title,
+        overflow_start_us,
+    ):
+        with open(source_file, 'r', encoding='utf-8') as file:
+            output = file.read()
+
+        histogram = parse_cyclictest_histogram(output)
+        overflow_data = parse_cyclictest_histogram_overflows(output)
+        summary = parse_cyclictest_results(output)
+        bucket_width_us = 50
+        aggregated_counts = {}
+
+        for bucket_us, count in zip(histogram['buckets_us'], histogram['counts']):
+            if bucket_us < 0:
+                continue
+            range_start_us = (bucket_us // bucket_width_us) * bucket_width_us
+            aggregated_counts[range_start_us] = (
+                aggregated_counts.get(range_start_us, 0) + count
+            )
+
+        overflow_count = overflow_data['total_count']
+        if overflow_count > 0:
+            aggregated_counts[int(overflow_start_us)] = (
+                aggregated_counts.get(int(overflow_start_us), 0) + overflow_count
+            )
+
+        x_values = [bucket / 1000.0 for bucket in sorted(aggregated_counts.keys())]
+        y_values = [aggregated_counts[bucket] for bucket in sorted(aggregated_counts.keys())]
+
+        plt.figure(figsize=(20, 8))
+        plt.set_loglevel('WARNING')
+        plt.bar(x_values, y_values, width=bucket_width_us / 1000.0, align='edge', color='b')
+        plt.xlabel('Latency bucket start (ms)', fontsize=16)
+        plt.ylabel('Samples', fontsize=16)
+        plt.title(plot_title, fontsize=18, fontweight='bold')
+        plt.yscale('log', base=10)
+        plt.xlim(left=0)
+        if overflow_count > 0:
+            overflow_start_ms = int(overflow_start_us) / 1000.0
+            bucket_width_ms = bucket_width_us / 1000.0
+            overflow_end_ms = overflow_start_ms + bucket_width_ms
+            tick_positions = [
+                tick for tick in plt.xticks()[0]
+                if tick < overflow_start_ms
+            ]
+            tick_positions.extend([overflow_start_ms, overflow_end_ms])
+            tick_labels = [f"{tick:g}" for tick in tick_positions[:-2]]
+            tick_labels.extend([f">={int(overflow_start_us)} us", ""])
+            plt.xlim(left=0, right=overflow_end_ms)
+            plt.xticks(tick_positions, tick_labels)
+        plt.grid(True)
+        plt.figtext(
+            0.99,
+            0.01,
+            (
+                f"Min {summary['min_latency_ms']:.6f} ms, "
+                f"Avg {summary['avg_latency_ms']:.6f} ms, "
+                f"Max {summary['max_latency_ms']:.6f} ms, "
+                f"Overflows > {self._format_latency_us(int(overflow_start_us))}: {overflow_count}"
+            ),
+            ha='right',
+            fontsize=12,
+        )
+        plt.tight_layout()
+        plt.savefig(self.plot_dir + f'{plot_name}.png')
+        plt.close()
+
+    @keyword
+    def generate_cyclictest_spike_plot(
+        self,
+        spike_file,
+        plot_name,
+        plot_title,
+        histogram_limit_us=50000,
+    ):
+        with open(spike_file, 'r', encoding='utf-8') as file:
+            output = file.read()
+
+        spikes = parse_cyclictest_spikes(output)
+        if not spikes:
+            return False
+
+        bucket_width_us = 50
+        aggregated_counts = {}
+        for spike in spikes:
+            latency_us = spike['latency_us']
+            range_start_us = max(
+                int(histogram_limit_us),
+                (latency_us // bucket_width_us) * bucket_width_us,
+            )
+            aggregated_counts[range_start_us] = (
+                aggregated_counts.get(range_start_us, 0) + 1
+            )
+
+        x_values = [bucket / 1000.0 for bucket in sorted(aggregated_counts.keys())]
+        y_values = [aggregated_counts[bucket] for bucket in sorted(aggregated_counts.keys())]
+        histogram_limit_ms = int(histogram_limit_us) / 1000.0
+        bucket_width_ms = bucket_width_us / 1000.0
+        min_spike_us = min(spike['latency_us'] for spike in spikes)
+        max_spike_us = max(spike['latency_us'] for spike in spikes)
+        max_spike_bucket_us = max(aggregated_counts.keys())
+        # Keep the spike plot readable even when only one or a few spikes were recorded near the threshold.
+        min_plot_end_ms = histogram_limit_ms + bucket_width_ms * 10
+        max_spike_end_ms = max_spike_bucket_us / 1000.0 + bucket_width_ms
+        plot_end_ms = max(min_plot_end_ms, max_spike_end_ms)
+
+        plt.figure(figsize=(20, 8))
+        plt.set_loglevel('WARNING')
+        plt.bar(x_values, y_values, width=bucket_width_us / 1000.0, align='edge', color='darkred')
+        plt.xlabel('Spike latency bucket start (ms)', fontsize=16)
+        plt.ylabel('Samples', fontsize=16)
+        plt.title(plot_title, fontsize=18, fontweight='bold')
+        plt.yscale('log', base=10)
+        plt.xlim(left=histogram_limit_ms, right=plot_end_ms)
+        plt.grid(True)
+        plt.figtext(
+            0.99,
+            0.01,
+            (
+                f"Spike samples {len(spikes)}, "
+                f"Min spike {self._format_latency_us(min_spike_us)}, "
+                f"Max spike {self._format_latency_us(max_spike_us)}"
+            ),
+            ha='right',
+            fontsize=12,
+        )
+        plt.tight_layout()
+        plt.savefig(self.plot_dir + f'{plot_name}.png')
+        plt.close()
+        return True
+
+    @keyword
+    def get_cyclictest_histogram_overflow_count(self, histogram_file):
+        with open(histogram_file, 'r', encoding='utf-8') as file:
+            overflow_data = parse_cyclictest_histogram_overflows(file.read())
+
+        return overflow_data['total_count']
+
+    @keyword
+    def get_cyclictest_histogram_overflow_report(
+        self,
+        histogram_file,
+        overflow_start_us,
+        max_cycles_per_thread=5,
+    ):
+        with open(histogram_file, 'r', encoding='utf-8') as file:
+            overflow_data = parse_cyclictest_histogram_overflows(file.read())
+
+        limit_us = int(overflow_start_us)
+        return (
+            f"Histogram overflows > {self._format_latency_us(limit_us)}: "
+            f"{overflow_data['total_count']}"
+            f" | Per-thread: {self._format_thread_counts(overflow_data['counts_per_thread'])}"
+            f" | Cycles: {self._format_thread_cycles(overflow_data['cycles_per_thread'], int(max_cycles_per_thread))}"
+        )
+
+    @keyword
+    def get_cyclictest_spike_report(
+        self,
+        spike_file,
+        overflow_start_us,
+        max_spikes_to_show=20,
+    ):
+        with open(spike_file, 'r', encoding='utf-8') as file:
+            output = file.read()
+
+        spikes = parse_cyclictest_spikes(output)
+        count = parse_cyclictest_spike_count(output)
+
+        limit_us = int(overflow_start_us)
+        if count == 0:
+            return (
+                "Debug spike run did not report per-spike durations "
+                f"above {self._format_latency_us(limit_us)}"
+            )
+
+        durations = ', '.join(
+            self._format_latency_us(spike['latency_us'])
+            for spike in spikes[:int(max_spikes_to_show)]
+        )
+        if count > int(max_spikes_to_show):
+            durations += ', ...'
+
+        return (
+            f"Debug spike run reported {count} spike samples"
+            f" | Durations: {durations}"
+        )
+
+    @keyword
+    def read_cyclictest_latency_csv_and_plot(self, test_name):
+        data = {'commit': []}
+        metrics = ['min_latency_ms', 'avg_latency_ms', 'max_latency_ms', 'overflow_count']
+        variants = ['t1_p80', 't1_p95', 'tnproc_p80', 'tnproc_p95']
+        target = test_name.rsplit(' on ', 1)[-1]
+        monitored_values = []
+
+        for variant in variants:
+            for metric in metrics:
+                key = f'{variant}_{metric}'
+                data[key] = []
+                if metric in ('avg_latency_ms', 'overflow_count'):
+                    monitored_values.append(key)
+
+        threshold = {}
+        low_limit_overrides = {}
+        for variant in variants:
+            threshold[f'{variant}_avg_latency_ms'] = thresholds['cyclictest'][target][
+                f'latency_threshold_us_{variant}'
+            ] / 1000.0
+            threshold[f'{variant}_overflow_count'] = thresholds['cyclictest']['latency_overflow_count']
+            low_limit_overrides[f'{variant}_overflow_count'] = 0
+        return_statistics, _statistics = self.calculate_statistics(
+            test_name,
+            data,
+            monitored_values,
+            threshold,
+            low_limit_overrides,
+        )
+        for variant in variants:
+            return_statistics[f'{variant}_avg_latency_ms']['low_limit'] = self.low_limit
+            return_statistics[f'{variant}_overflow_count']['low_limit'] = 0
+
+        for key in data.keys():
+            data[key] = data[key][-40:]
+
+        plot_defs = [
+            ('min_latency_ms', 'Min latency (ms)', 'Min latency'),
+            ('avg_latency_ms', 'Avg latency (ms)', 'Avg latency'),
+            ('max_latency_ms', 'Max latency (ms)', 'Max latency'),
+            ('overflow_count', 'Overflow samples', 'Histogram overflows'),
+        ]
+        labels = {
+            't1_p80': 't1 p80',
+            't1_p95': 't1 p95',
+            'tnproc_p80': 't$(nproc) p80',
+            'tnproc_p95': 't$(nproc) p95',
+        }
+
+        for metric_key, axis_label, title in plot_defs:
+            plt.figure(figsize=(20, 10))
+            plt.set_loglevel('WARNING')
+            for variant in variants:
+                key = f'{variant}_{metric_key}'
+                plt.plot(
+                    data['commit'],
+                    data[key],
+                    marker='o',
+                    linestyle='-',
+                    label=labels[variant],
+                )
+            plt.ylabel(axis_label, fontsize=16)
+            plt.xlabel('Build Number', fontsize=16)
+            ax = plt.gca()
+            ax.tick_params(axis='y', labelsize=14)
+            plt.xticks(data['commit'], rotation=90, fontsize=10)
+            plt.grid(True)
+            plt.legend(loc='upper left')
+            if metric_key == 'overflow_count':
+                title_threshold = thresholds['cyclictest']['latency_overflow_count']
+                ax.yaxis.set_major_locator(mticker.MaxNLocator(integer=True))
+                plt.axhline(
+                    y=thresholds['cyclictest']['latency_overflow_count'],
+                    color='k',
+                    linestyle='-.',
+                    linewidth=1.5,
+                )
+            elif metric_key == 'avg_latency_ms':
+                title_threshold = 'variant specific latency_threshold_us_*'
+            elif metric_key == 'min_latency_ms':
+                title_threshold = 'not monitored'
+            else:
+                title_threshold = 'not monitored'
+            plt.title(
+                f'{title} / Threshold: {title_threshold}',
+                loc='right',
+                fontweight='bold',
+                fontsize=16,
+            )
+            plt.suptitle(
+                f'{test_name}\nBuild type: {self.build_type}, Device: {self.device}',
+                fontsize=18,
+                fontweight='bold',
+            )
+            plt.tight_layout()
+            plt.savefig(self.plot_dir + f'{self.device}_{test_name}_{metric_key}.png')
+            plt.close()
+
+        return return_statistics
+
+    @keyword
     def save_cpu_data(self, test_name, cpu_data):
         self.write_test_data_to_csv(test_name, cpu_data)
         return self.read_cpu_csv_and_plot(test_name)
@@ -1000,6 +1390,11 @@ class PerformanceDataProcessing:
 
         df.to_csv(file_path, index=False)
         return self.read_vm_memory_snapshot_csv_and_plot(test_name)
+
+    @keyword
+    def save_cyclictest_latency_data(self, test_name, latency_data):
+        self.write_test_data_to_csv(test_name, latency_data)
+        return self.read_cyclictest_latency_csv_and_plot(test_name)
 
     def read_vm_memory_snapshot_csv_and_plot(self, test_name):
         # Match other read_*_csv_and_plot methods: read CSV, analyze, plot, return last result.

--- a/Robot-Framework/lib/output_parser.py
+++ b/Robot-Framework/lib/output_parser.py
@@ -187,6 +187,136 @@ def parse_fileio_write_results(output):
     return fileio_write_data
 
 
+def _parse_cyclictest_summary_line(output, label):
+    # Summary lines look like: "# Max Latencies: 00026 00031 ..."
+    match = re.search(rf'^# {label}:\s+(.+)$', output, re.MULTILINE)
+    if not match:
+        return None
+    values = [int(value) for value in re.findall(r'\d+', match.group(1))]
+    if not values:
+        raise Exception(f"Couldn't parse cyclictest {label.lower()}")
+    return values
+
+
+def parse_cyclictest_results(output):
+    # Return cyclictest latencies in milliseconds from the final summary:
+    # - absolute minimum across threads
+    # - mean of per-thread averages
+    # - absolute maximum across threads
+    output = re.sub(r'\033\[.*?m', '', output)
+
+    min_values = _parse_cyclictest_summary_line(output, 'Min Latencies')
+    avg_values = _parse_cyclictest_summary_line(output, 'Avg Latencies')
+    max_values = _parse_cyclictest_summary_line(output, 'Max Latencies')
+
+    if not (min_values and avg_values and max_values):
+        raise Exception("Couldn't parse cyclictest results")
+
+    return {
+        'min_latency_ms': min(min_values) / 1000.0,
+        'avg_latency_ms': sum(avg_values) / len(avg_values) / 1000.0,
+        'max_latency_ms': max(max_values) / 1000.0,
+    }
+
+
+def parse_cyclictest_histogram(output):
+    output = re.sub(r'\033\[.*?m', '', output)
+    histogram_started = False
+    buckets_us = []
+    counts = []
+
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped == '# Histogram':
+            histogram_started = True
+            continue
+        if not histogram_started:
+            continue
+        if stripped.startswith('# Total:'):
+            break
+        if not stripped or stripped.startswith('#'):
+            continue
+
+        parts = stripped.split()
+        if len(parts) < 2 or not all(part.isdigit() for part in parts):
+            continue
+
+        buckets_us.append(int(parts[0]))
+        counts.append(sum(int(part) for part in parts[1:]))
+
+    if not buckets_us:
+        raise Exception("Couldn't parse cyclictest histogram")
+
+    return {
+        'buckets_us': buckets_us,
+        'counts': counts,
+    }
+
+
+def parse_cyclictest_histogram_overflows(output):
+    output = re.sub(r'\033\[.*?m', '', output)
+    overflow_counts = []
+    overflow_cycles = {}
+
+    # Example: "# Histogram Overflows: 00000 00002 00001"
+    match = re.search(r'^# Histogram Overflows:\s+(.+)$', output, re.MULTILINE)
+    if match:
+        overflow_counts = [int(value) for value in re.findall(r'\d+', match.group(1))]
+
+    in_cycle_section = False
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped == '# Histogram Overflow at cycle number:':
+            in_cycle_section = True
+            continue
+        if not in_cycle_section:
+            continue
+
+        # Example: "# Thread 2: 12345 23456"
+        thread_match = re.match(r'^# Thread\s+(\d+):\s*(.*)$', stripped)
+        if not thread_match:
+            continue
+
+        thread_id = int(thread_match.group(1))
+        overflow_cycles[thread_id] = [
+            int(value) for value in re.findall(r'\d+', thread_match.group(2))
+        ]
+
+    return {
+        'counts_per_thread': overflow_counts,
+        'total_count': sum(overflow_counts),
+        'cycles_per_thread': overflow_cycles,
+    }
+
+
+def parse_cyclictest_spikes(output):
+    output = re.sub(r'\033\[.*?m', '', output)
+    spikes = []
+    # Example: "T: 5 Spike:     424: TS:   6433102503"
+    spike_pattern = re.compile(
+        r'^T:\s*(\d+)\s+Spike:\s*(\d+):\s+TS:\s*(\d+)$',
+        re.MULTILINE,
+    )
+
+    for match in spike_pattern.finditer(output):
+        spikes.append({
+            'thread': int(match.group(1)),
+            'latency_us': int(match.group(2)),
+            'timestamp': int(match.group(3)),
+        })
+
+    return spikes
+
+
+def parse_cyclictest_spike_count(output):
+    output = re.sub(r'\033\[.*?m', '', output)
+    # Prefer the explicit summary count when available: "spikes = 9"
+    match = re.search(r'^spikes\s*=\s*(\d+)$', output, re.MULTILINE)
+    if match:
+        return int(match.group(1))
+    return len(parse_cyclictest_spikes(output))
+
+
 def parse_iperf_output(output):
     tx_pattern = r'\s(\d+(\.\d+)?) MBytes\/sec.*sender'
     rx_pattern = r'\s(\d+(\.\d+)?) MBytes\/sec.*receiver'

--- a/Robot-Framework/lib/performance_thresholds.py
+++ b/Robot-Framework/lib/performance_thresholds.py
@@ -52,6 +52,24 @@ thresholds = {
     'vm_memory_snapshot': {
         'mem_avail_pct': 20
     },
+    'cyclictest': {
+        # Same value is used both as the absolute pass/fail limit for avg latency measurement of the variant
+        # and as the cyclictest histogram limit that defines overflow counting.
+        'ghaf-host': {
+            'latency_threshold_us_t1_p80': 300,
+            'latency_threshold_us_t1_p95': 300,
+            'latency_threshold_us_tnproc_p80': 1000,
+            'latency_threshold_us_tnproc_p95': 1000,
+        },
+        'gui-vm': {
+            'latency_threshold_us_t1_p80': 4000,
+            'latency_threshold_us_t1_p95': 4000,
+            'latency_threshold_us_tnproc_p80': 8000,
+            'latency_threshold_us_tnproc_p95': 8000,
+        },
+        # The number of allowed overflows above latency_threshold_us_<variant>
+        'latency_overflow_count': 10,
+    },
 
 }
 

--- a/Robot-Framework/resources/performance_keywords.resource
+++ b/Robot-Framework/resources/performance_keywords.resource
@@ -3,6 +3,7 @@
 
 *** Settings ***
 Library             Collections
+Library             String
 
 
 *** Keywords ***
@@ -32,7 +33,9 @@ Determine Test Status
     ${msg}=                 Set Variable  ${EMPTY}
     FOR   ${i}  IN  @{keys}
         ${statistics}       Get From Dictionary      ${statistics_dict}    ${i}
-        IF  ${statistics}[measurement] < ${PERF_LOW_LIMIT}
+        ${low_limit_present}    Run Keyword And Return Status    Dictionary Should Contain Key    ${statistics}    low_limit
+        ${measurement_low_limit}    Set Variable If    ${low_limit_present}    ${statistics}[low_limit]    ${PERF_LOW_LIMIT}
+        IF  ${statistics}[measurement] < ${measurement_low_limit}
             FAIL            Measurement result is zero or too close to zero.\n\n${statistics}
         END
         IF  ${statistics}[flag] != 0
@@ -100,3 +103,20 @@ Initial Memory Check
         ${duration}       Evaluate    int(${iterations} * ${sleep_between})
         FAIL    High initial total memory not deflating within ${duration} sec.\nghaf-mem-manager service of the vm has probably failed.
     END
+
+Set power profile
+    [Documentation]     Set power profile to ${profile}
+    [Arguments]         ${profile}
+    [Setup]             Switch to vm   ${GUI_VM}
+    Log                 Setting power profile to ${profile}   console=True
+    Run Command         tuned-adm profile ${profile}   sudo=True
+    ${active_profile}   Get active power profile
+    Should Contain      ${active_profile}   ${profile}
+
+Get active power profile
+    [Documentation]     Return active power profile
+    ${output}           Run Command   tuned-adm active
+    ${parts}            Split String    ${output}    : 
+    ${active_profile}   Strip String    ${parts}[1]
+    Log                 Active power profile is ${active_profile}   console=True
+    RETURN              ${active_profile}

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -10,6 +10,8 @@ Library             ../../lib/PerformanceDataProcessing.py  ${DEVICE}  ${BUILD_I
 ...                 ${PERF_DATA_DIR}  ${CONFIG_PATH}  ${PLOT_DIR}  ${PERF_LOW_LIMIT}
 Library             Collections
 Library             DateTime
+Library             OperatingSystem
+Library             String
 Resource            ../../resources/performance_keywords.resource
 Resource            ../../resources/serial_keywords.resource
 Resource            ../../resources/setup_keywords.resource
@@ -23,6 +25,11 @@ Suite Setup         Switch to vm   ${HOST}
 *** Variables ***
 @{FAILED_VM_TESTS}
 @{IMPROVED_VM_TESTS}
+${SAVE_CYCLICTEST_HISTOGRAMS_ON_PASS}    ${True}
+${CYCLICTEST_USE_NIX_SHELL}              ${True}
+# If this limit of overflows above variant specific threshold is exceeded it triggers
+# an addittional debug cyclictest measuring more in detail the spikes over the histogram threshold.
+${CYCLICTEST_SPIKE_THRESHOLD}            5
 
 
 *** Test Cases ***
@@ -94,6 +101,28 @@ nvpmodel check test
     IF  not ("Power mode check ok: ${ExpectedNVPmode}" in $output)
         FAIL  ${output}\n\nExpected: ${ExpectedNVPmode}
     END
+
+Cyclictest latency on ghaf-host
+    [Documentation]    Run four cyclictest latency measurements on ghaf-host and track min/avg/max
+    ...                latency history across builds.
+    [Tags]             SP-T363  SP-T363-1  latency  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  orin-nx  excl-secboot
+    [Setup]           Ensure balanced power profile
+    Measure cyclictest latency on target    ${HOST}
+    [Teardown]        Run Keywords    Set default low limit
+    ...               AND             Set Global Variable    ${PERF_LOW_LIMIT}    1
+    ...               AND             Close All Connections
+    ...               AND             Switch to vm   ${HOST}
+
+Cyclictest latency on gui-vm
+    [Documentation]    Run four cyclictest latency measurements on gui-vm and track min/avg/max
+    ...                latency history across builds.
+    [Tags]             SP-T363  SP-T363-2  latency  lenovo-x1  darter-pro  dell-7330  excl-storeDisk  excl-secboot
+    [Setup]           Ensure balanced power profile
+    Measure cyclictest latency on target    ${GUI_VM}
+    [Teardown]        Run Keywords    Set default low limit
+    ...               AND             Set Global Variable    ${PERF_LOW_LIMIT}    1
+    ...               AND             Close All Connections
+    ...               AND             Switch to vm   ${HOST}
 
 CPU One thread test
     [Documentation]         Run a CPU benchmark using Sysbench with a duration of 10 seconds and a SINGLE thread.
@@ -423,6 +452,175 @@ Sysbench test in VMs
 
 
 *** Keywords ***
+
+Ensure balanced power profile
+    IF    ${IS_LAPTOP}
+        Set power profile    gui-balanced
+    END
+
+Measure cyclictest latency on target
+    [Arguments]         ${target}
+    Set custom low limit   0.000001
+    Set Global Variable    ${PERF_LOW_LIMIT}    0.000001
+    ${data_dir}         Get Data Dir
+    ${raw_dir}          Set Variable    ${data_dir}cyclictest_raw/
+    Create Directory    ${raw_dir}
+    @{variants}         Create List    t1_p80    t1_p95    tnproc_p80    tnproc_p95
+    Switch to vm        ${target}
+    &{latency_data}     Create Dictionary
+    &{cyclictest_debug_data}    Create Dictionary
+    &{cyclictest_spike_plot_data}    Create Dictionary
+
+    Run cyclictest latency variant
+    ...    ${target}
+    ...    t1_p80
+    ...    cyclictest -q -t1 -p80 -i1000 -l30000
+    ...    ${raw_dir}
+    ...    ${latency_data}
+    ...    ${cyclictest_debug_data}
+    ...    ${cyclictest_spike_plot_data}
+    Run cyclictest latency variant
+    ...    ${target}
+    ...    t1_p95
+    ...    cyclictest -q -t1 -p95 -m -i1000 -l30000
+    ...    ${raw_dir}
+    ...    ${latency_data}
+    ...    ${cyclictest_debug_data}
+    ...    ${cyclictest_spike_plot_data}
+    Run cyclictest latency variant
+    ...    ${target}
+    ...    tnproc_p80
+    ...    cyclictest -q -t$(nproc) -p80 -i1000 -l30000
+    ...    ${raw_dir}
+    ...    ${latency_data}
+    ...    ${cyclictest_debug_data}
+    ...    ${cyclictest_spike_plot_data}
+    Run cyclictest latency variant
+    ...    ${target}
+    ...    tnproc_p95
+    ...    cyclictest -q -t$(nproc) -p95 -m -i1000 -l30000
+    ...    ${raw_dir}
+    ...    ${latency_data}
+    ...    ${cyclictest_debug_data}
+    ...    ${cyclictest_spike_plot_data}
+
+    &{statistics}       Save Cyclictest Latency Data    ${TEST NAME}    ${latency_data}
+    @{failed_variants}  Get Failed Cyclictest Variants    ${statistics}
+    @{histogram_plot_names}    Create List
+    @{spike_plot_names}    Create List
+    FOR    ${variant}    IN    @{variants}
+        Log    ${variant}: ${cyclictest_debug_data}[${variant}]    console=True
+        ${save_plot}     Evaluate    ${SAVE_CYCLICTEST_HISTOGRAMS_ON_PASS} or $variant in $failed_variants
+        IF    ${save_plot}
+            ${plot_name}    Set Variable    ${DEVICE}_${TEST NAME}_${variant}_histogram
+            ${histogram_limit}    Get Cyclictest Histogram Limit    ${target}    ${variant}
+            Generate Cyclictest Histogram Plot
+            ...    ${raw_dir}${DEVICE}_${TEST NAME}_${variant}.txt
+            ...    ${plot_name}
+            ...    ${TEST NAME} ${variant} histogram
+            ...    ${histogram_limit}
+            Append To List    ${histogram_plot_names}    ${plot_name}
+        END
+        ${spike_plot_generated}    Get From Dictionary    ${cyclictest_spike_plot_data}    ${variant}
+        IF    ${spike_plot_generated}
+            ${spike_plot_name}    Set Variable    ${DEVICE}_${TEST NAME}_${variant}_spike_histogram
+            Append To List    ${spike_plot_names}    ${spike_plot_name}
+        END
+    END
+
+    Log
+    ...    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_min_latency_ms.png" alt="Min latency plot" width="1200">
+    ...    HTML
+    Log
+    ...    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_avg_latency_ms.png" alt="Avg latency plot" width="1200">
+    ...    HTML
+    Log
+    ...    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_max_latency_ms.png" alt="Max latency plot" width="1200">
+    ...    HTML
+    Log
+    ...    <img src="${REL_PLOT_DIR}${DEVICE}_${TEST NAME}_overflow_count.png" alt="Overflow count plot" width="1200">
+    ...    HTML
+    FOR    ${plot_name}    IN    @{histogram_plot_names}
+        Log
+        ...    <img src="${REL_PLOT_DIR}${plot_name}.png" alt="${plot_name}" width="1200">
+        ...    HTML
+    END
+    FOR    ${plot_name}    IN    @{spike_plot_names}
+        Log
+        ...    <img src="${REL_PLOT_DIR}${plot_name}.png" alt="${plot_name}" width="1200">
+        ...    HTML
+    END
+    Determine Test Status    ${statistics}  inverted=1
+
+Run cyclictest latency variant
+    [Arguments]         ${target}    ${variant_name}    ${command}    ${raw_dir}    ${latency_data}    ${cyclictest_debug_data}    ${cyclictest_spike_plot_data}
+    ${remote_output}    Set Variable    /tmp/cyclictest_${target}_${variant_name}.txt
+    ${local_output}     Set Variable    ${raw_dir}${DEVICE}_${TEST NAME}_${variant_name}.txt
+    ${histogram_limit}    Get Cyclictest Histogram Limit    ${target}    ${variant_name}
+    IF    ${CYCLICTEST_USE_NIX_SHELL}
+        ${histogram_command}    Set Variable
+        ...    nix-shell -p rt-tests --run "${command} --histogram=${histogram_limit}"
+    ELSE
+        ${histogram_command}    Set Variable    ${command} --histogram=${histogram_limit}
+    END
+    Log To Console      Running cyclictest variant ${variant_name} on ${target}
+    Run Command
+    ...    sh -lc '${histogram_command} > ${remote_output} 2>&1'
+    ...    sudo=True
+    ...    timeout=300
+    Run Command         chmod 644 ${remote_output}    sudo=True
+    SSHLibrary.Get File    ${remote_output}    ${local_output}
+    &{result}           Parse Cyclictest Results File    ${local_output}
+    Set To Dictionary   ${latency_data}    ${variant_name}_min_latency_ms=${result}[min_latency_ms]
+    Set To Dictionary   ${latency_data}    ${variant_name}_avg_latency_ms=${result}[avg_latency_ms]
+    Set To Dictionary   ${latency_data}    ${variant_name}_max_latency_ms=${result}[max_latency_ms]
+    ${overflow_count}    Get Cyclictest Histogram Overflow Count    ${local_output}
+    Set To Dictionary   ${latency_data}    ${variant_name}_overflow_count=${overflow_count}
+    ${debug_report}    Get Cyclictest Histogram Overflow Report
+    ...    ${local_output}
+    ...    ${histogram_limit}
+    Set To Dictionary    ${cyclictest_spike_plot_data}    ${variant_name}=${False}
+    # Histogram can save latency values only up to histogram limit, the rest are logged as number of overflows
+    # Here further measurement for studying overflows is triggered in case the overflow is significant
+    IF    ${overflow_count} > ${CYCLICTEST_SPIKE_THRESHOLD}
+        ${remote_spike_output}    Set Variable    /tmp/cyclictest_${target}_${variant_name}_spike.txt
+        ${local_spike_output}     Set Variable    ${raw_dir}${DEVICE}_${TEST NAME}_${variant_name}_spike.txt
+        IF    ${CYCLICTEST_USE_NIX_SHELL}
+            ${spike_command}    Set Variable
+            ...    nix-shell -p rt-tests --run "${command} --spike=${histogram_limit}"
+        ELSE
+            ${spike_command}    Set Variable    ${command} --spike=${histogram_limit}
+        END
+        Log To Console      Running cyclictest spike debug for ${variant_name} on ${target}
+        Run Command
+        ...    sh -lc '${spike_command} > ${remote_spike_output} 2>&1'
+        ...    sudo=True
+        ...    timeout=300
+        Run Command         chmod 644 ${remote_spike_output}    sudo=True
+        SSHLibrary.Get File    ${remote_spike_output}    ${local_spike_output}
+        ${spike_report}    Get Cyclictest Spike Report
+        ...    ${local_spike_output}
+        ...    ${histogram_limit}
+        ${spike_plot_name}    Set Variable    ${DEVICE}_${TEST NAME}_${variant_name}_spike_histogram
+        ${spike_plot_generated}    Generate Cyclictest Spike Plot
+        ...    ${local_spike_output}
+        ...    ${spike_plot_name}
+        ...    ${TEST NAME} ${variant_name} spike histogram
+        ...    ${histogram_limit}
+        Set To Dictionary    ${cyclictest_spike_plot_data}    ${variant_name}=${spike_plot_generated}
+        ${debug_report}    Catenate
+        ...    SEPARATOR= | 
+        ...    ${debug_report}
+        ...    ${spike_report}
+        Run Command         rm -f ${remote_spike_output}    sudo=True
+    ELSE
+        ${debug_report}    Catenate
+        ...    SEPARATOR= | 
+        ...    ${debug_report}
+        ...    Spike debug skipped; threshold is > ${CYCLICTEST_SPIKE_THRESHOLD} overflows.
+    END
+    Set To Dictionary    ${cyclictest_debug_data}    ${variant_name}=${debug_report}
+    Run Command         rm -f ${remote_output}    sudo=True
 
 Save cpu results
     [Arguments]        ${test}=cpu  ${host}=ghaf_host

--- a/Robot-Framework/test-suites/performance-tests/power_profiles.robot
+++ b/Robot-Framework/test-suites/performance-tests/power_profiles.robot
@@ -8,6 +8,7 @@ Test Tags           power-profiles  lenovo-x1  lab-only
 Resource            ../../resources/gui_keywords.resource
 Resource            ../../resources/gui-vm_keywords.resource
 Resource            ../../resources/measurement_keywords.resource
+Resource            ../../resources/performance_keywords.resource
 Resource            ../../resources/setup_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/common_keywords.resource
@@ -75,20 +76,3 @@ Measure power consumption of a power profile
     ${average_power}     Calculate average power over interval   ${BUILD_ID}   ${starttime}   ${endtime}
     Log                  Average power with ${profile} was ${average_power}   console=True
     RETURN               ${average_power}
-
-Set power profile
-    [Documentation]     Set power profile to ${profile}
-    [Arguments]         ${profile}
-    [Setup]             Switch to vm   ${GUI_VM}
-    Log                 Setting power profile to ${profile}   console=True
-    Run Command         tuned-adm profile ${profile}   sudo=True
-    ${active_profile}   Get active power profile
-    Should Contain      ${active_profile}   ${profile}
-
-Get active power profile
-    [Documentation]     Return active power profile
-    ${output}           Run Command   tuned-adm active
-    ${parts}            Split String    ${output}    : 
-    ${active_profile}   Strip String    ${parts}[1]
-    Log                 Active power profile is ${active_profile}   console=True
-    RETURN              ${active_profile}


### PR DESCRIPTION
- Run 4 different cyclictest measurement variants in ghaf-host and gui-vm (for laptops).
- Set variant specific absolute thresholds for average latency measurements.
- Set threshold for number of overflows exceeding the variant specific threshold.
- Plot the results: absolute min_latency, avg_latency, absolute max_latency, histogram of each 4 variant
- Trigger additional debug spike measurement run if CYCLICTEST_SPIKE_THRESHOLD (currently set to 5) is exceeded.
- Currently set the overflow count pass/fails criteria to 10.
- Had to make some changes to handling of low limit to allow 0 result in case of overflow count

**Test runs**

Dell-7330
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6472/

Orin-NX
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6474/

Lenovo-X1
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6486/

Orin-AGX
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6482/

Darter-Pro
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6497/
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6498/
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6499/ (latency thresholds temporarily divided by 10 to demonstrate overflows and debug spike measurements)