### PR TITLE
Fix app keywords, add Fingerprints app tests

### DIFF
--- a/Robot-Framework/resources/app_keywords.resource
+++ b/Robot-Framework/resources/app_keywords.resource
@@ -26,7 +26,7 @@ Start application in VM
 
     IF    '${app-vm}' not in ${RUNNING_VMS} or ${always_check_vm}   Check that appVM is running   ${app-vm}
     Switch to vm   ${app-vm}
-    Check that the application is not running   ${process_name}  1
+    Check that the application is not running   ${process_name}  1   before_launch_check=True
     
     Switch to vm   ${GUI_VM}  user=${USER_LOGIN}
     Start application   ${app_name}     params_string=${params_string}
@@ -51,8 +51,8 @@ Start application
 Check that the application was started
     [Arguments]    ${process_name}  ${range}=2
     FOR   ${i}   IN RANGE  ${range}
-        ${status}  Check if process is running   ${process_name}
-        IF    ${status}
+        ${is_running}  Is process running   ${process_name}
+        IF    ${is_running}
             Log    ${process_name} is running    console=True
             RETURN
         END
@@ -61,14 +61,17 @@ Check that the application was started
     FAIL   ${process_name} is not running after ${range} seconds
 
 Check that the application is not running
-    [Arguments]    ${process_name}  ${range}=2
+    [Arguments]    ${process_name}  ${range}=2   ${before_launch_check}=False
     FOR   ${i}   IN RANGE  ${range}
-        ${status}  Check if process is running   ${process_name}
-        IF    not ${status}
+        ${is_running}  Is process running   ${process_name}
+        IF    not ${is_running}
             Log    ${process_name} is not running    console=True
             RETURN
         END
         Sleep   1
+    END
+    IF    ${before_launch_check}
+        FAIL   ${process_name} is already running before it was launched
     END
     FAIL   ${process_name} is still running after ${range} seconds
 
@@ -118,7 +121,7 @@ Start app via GUI
     [Documentation]    Start Application via GUI and verify related process started
     [Arguments]        ${app-vm}   ${process_name}   ${display_name}
     Check that appVM is running   ${app-vm}
-    Check that the application is not running   ${process_name}  1
+    Check that the application is not running   ${process_name}  1  before_launch_check=True
     Switch to vm                   ${GUI_VM}  user=${USER_LOGIN}
 
     Open app menu

--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -70,28 +70,31 @@ Get VM list
     IF    ${with_host}    Append To List   ${vm_list}   ${HOST}
     RETURN    @{vm_list}
 
-Check if process is running
+Is process running
     [Arguments]    ${process_name}
-    ${status}  ${output}   Run Keyword And Ignore Error   Run Command    pgrep -f "${process_name}" -a
-    RETURN   '${status}' == 'PASS'
+    ${running}   Run Keyword And Return Status   Run Command    pgrep -f "${process_name}" -a
+    RETURN   ${running}
+
+Check that process is not running
+    [Arguments]    ${process_name}
+    ${is_running}   Is process running   ${process_name}
+    Should Not Be True   ${is_running}   Process ${process_name} is still running
 
 Kill process by name
     [Arguments]   ${process_name}   ${sudo}=True   ${require_exists}=${True}   ${signal}=TERM   ${fallback_signal}=KILL
     IF    ${require_exists}
-        ${was_running}   Check if process is running   ${process_name}
-        IF    not ${was_running}   FAIL   Process ${process_name} is not running
+        ${is_running}   Is process running   ${process_name}
+        Should Be True   ${is_running}   Process ${process_name} is not running
     END
     Log   Killing process ${process_name} with signal ${signal} (fallback: ${fallback_signal})   console=True
     # A = ignore pkill process (ancestor), e = display what is killed, f = use full process name to kill
     Run Command    pkill -${signal} -Aef "${process_name}"  sudo=${sudo}  return=rc  rc_match=skip  timeout=15
-    ${still_running}   Wait Until Keyword Succeeds   5x   1s   Check if process is running   ${process_name}
-    IF  ${still_running}
+    ${stopped}   Run Keyword And Return Status   Wait Until Keyword Succeeds   5x   1s   Check that process is not running   ${process_name}
+    IF  not ${stopped}
         Log   Process ${process_name} still running after signal ${signal}, retrying with ${fallback_signal}   console=True
         Run Command    pkill -${fallback_signal} -Aef "${process_name}"  sudo=${sudo}  return=rc  rc_match=skip  timeout=15
-        ${still_running}   Wait Until Keyword Succeeds   5x   1s   Check if process is running   ${process_name}
-        IF  ${still_running}
-            FAIL   Process ${process_name} is still running after ${signal} and ${fallback_signal}
-        END
+        ${stopped}   Run Keyword And Return Status   Wait Until Keyword Succeeds   5x   1s   Check that process is not running   ${process_name}
+        Should Be True   ${stopped}   Process ${process_name} is still running after ${signal} and ${fallback_signal}
     END
 
 Save Time

--- a/Robot-Framework/test-suites/functional-tests/apps.robot
+++ b/Robot-Framework/test-suites/functional-tests/apps.robot
@@ -62,6 +62,11 @@ Start Element
     [Tags]            SP-T52  SP-T52-1
     Start application in VM   Element   ${COMMS_VM}   element
 
+Start Fingerprints
+    [Documentation]   Start Fingerprints and verify process started
+    [Tags]            SP-T364  SP-T364-1
+    Start application in VM   Fingerprints   ${GUI_VM}   fingwit
+
 Start GPU Screen Recorder
     [Documentation]   Start GPU Screen Recorder and verify process started
     [Tags]            SP-T293  SP-T293-1

--- a/Robot-Framework/test-suites/gui-tests/gui_app_launch.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_app_launch.robot
@@ -90,6 +90,13 @@ Start Element via GUI
     Close app via GUI   ${COMMS_VM}  element  ghaf-close.png
     Save launch time    element
 
+Start Fingerprints via GUI
+    [Documentation]   Start Fingerprints via GUI and measure launch time
+    [Tags]            SP-T364  SP-T364-2
+    Start app via GUI   ${GUI_VM}  fingwit  Fingerprints
+    Close app via GUI   ${GUI_VM}  fingwit  window-close.png
+    Save launch time    fingwit
+
 Start GPU Screen Recorder via GUI
     [Documentation]   Start GPU Screen Recorder via GUI and measure launch time
     [Tags]            SP-T293  SP-T293-2


### PR DESCRIPTION
* Fix error message about app running before it was launched
  * Old error message: `${process_name} is still running after ${range} seconds`
  * New error message: `${process_name} is already running before it was launched`
* Fix checks about process still running in `Kill process by name`. `Wait Until Keyword Succeeds` did not work as intended because `Check if process is running` never failed.
* Add app tests for the new Fingerprints app (https://github.com/tiiuae/ghaf/pull/1983)

[Darter Pro](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6451/artifact/Robot-Framework/test-suites/darter-proANDappsORdarter-proANDguiNOTstoreDisk-only/report.html#totals) - apps and gui
[Dell 7330](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6453/artifact/Robot-Framework/test-suites/dell-7330ANDapps/report.html#totals) - apps