### PR TITLE
Skips for orin-nx

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -16,6 +16,7 @@ ${TEST_WIFI_SSID}         ${EMPTY}
 ${TEST_WIFI_PSWD}         ${EMPTY}
 ${DEVICE_TYPE}            ${EMPTY}
 ${JOB}                    ${EMPTY}
+${NATIVE_BUILD}           ${True}
 ${FLEETDM_ENROLL_SECRET}  ${EMPTY}
 ${FLEETDM_API_TOKEN}      ${EMPTY}
 ${USER_LOGIN}             ${EMPTY}
@@ -138,8 +139,17 @@ Set Variables
             Set Global Variable    ${JOB}    ${DEVICE_TYPE}
         END
     END
+    Set Native Build Variable
 
     Set Global Variable  ${GRAFANA_LOGS}    https://loki.ghaflogs.vedenemo.dev
+
+Set Native Build Variable
+    ${cross_compiled}    Run Keyword And Return Status    Should Contain    ${JOB}    from-x86
+    IF    ${cross_compiled}
+        Set Global Variable    ${NATIVE_BUILD}    ${False}
+    ELSE
+        Set Global Variable    ${NATIVE_BUILD}    ${True}
+    END
 
 Read Config
     [Arguments]  ${file_path}

--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -178,6 +178,8 @@ Break the system
 *** Keywords ***
 
 Test Teardown
+    Run Keyword If    "${DEVICE_TYPE}" == "orin-nx"
+    ...    Run Keyword If Test Failed    Skip    Known issue: SSRCSP-8585, orin-nx fails ssh on some boots
     IF  ${IS_AVAILABLE}
         IF  "${CONNECTION_TYPE}" == "ssh"
             Run Keyword If Test Failed    Run Keyword And Ignore Error    ssh_keywords.Save log

--- a/Robot-Framework/test-suites/functional-tests/__init__.robot
+++ b/Robot-Framework/test-suites/functional-tests/__init__.robot
@@ -7,6 +7,22 @@ Test Tags           regression
 
 Resource            ../../resources/setup_keywords.resource
 
-Suite Setup         Prepare Test Environment
-Suite Teardown      Clean Up Test Environment
+Suite Setup         Functional Tests Suite Setup
+Suite Teardown      Functional Tests Suite Teardown
 Test Timeout        10 minutes
+
+
+*** Variables ***
+${SUITE_SETUP_STATUS}    NOT_RUN
+
+
+*** Keywords ***
+
+Functional Tests Suite Setup
+    ${status}=            Run Keyword And Return Status    Prepare Test Environment
+    Set Suite Variable    ${SUITE_SETUP_STATUS}    ${status}
+    Run Keyword If        not ${status}    FAIL    Suite setup failed
+
+Functional Tests Suite Teardown
+    Clean Up Test Environment
+    Run Keyword If    "${DEVICE_TYPE}" == "orin-nx" and not ${SUITE_SETUP_STATUS}    Skip    Known issue: SSRCSP-8585, orin-nx suite setup may fail due to SSH

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -3,7 +3,9 @@
 ## Active SKIPS
 
 | DATE SET   | TEST CASE                                               | TICKET / Additional Data.                                                                     |
-| ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+|------------|---------------------------------------------------------| --------------------------------------------------------------------------------------------- |
+| 11.06.2026 | Verify booting after restart by power (orin-nx)         | SSRCSP-8585                                                                                   |
+| 11.06.2026 | functional-tests (orin-nx)                              | SSRCSP-8585                                                                                   |
 | 29.05.2026 | Check Grafana log forwarding after disconnected state   | SSRCSP-8525                                                                                   |
 | 25.05.2026 | Reboot from power menu                                  | SSRCSP-8490                                                                                   |
 | 22.05.2026 | Check logging rate (Dell)                               | SSRCSP-8481                                                                                   |


### PR DESCRIPTION
Add skips because of a bug failing pre-merge runs. SSRCSP-8585

Although native / cross-compiled separation was not needed after all, I leave the related keyword in variables.robot.

Test run with cross-compiled orin-nx image from last nightly-pipeline
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6487/
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6490/ (x86 in job)
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6491/ (native / cross-compiled check removed form Skips, finally the ssh failed at this boot)

Test run with native orin-agx image from last nightly-pipeline
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6488/
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6489/ (x86 in job)
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6492/ (native / cross-compiled check removed form Skips)