### PR TITLE
Add more tests to pre-merge and bat

### DIFF
--- a/Robot-Framework/lib/ParseMeasurementData.py
+++ b/Robot-Framework/lib/ParseMeasurementData.py
@@ -175,6 +175,9 @@ class ParseMeasurementData:
             logging.warning("No measurement history data to plot for %s/%s", test_name, metric_name)
             return
 
+        # Keep the history file intact, but only plot the most recent samples.
+        data = data.tail(100)
+
         value_columns = [column for column in data.columns if column not in {"build_id", "unit"}]
         if not value_columns:
             logging.warning("No measurement columns found to plot for %s/%s", test_name, metric_name)

--- a/Robot-Framework/test-suites/functional-tests/__init__.robot
+++ b/Robot-Framework/test-suites/functional-tests/__init__.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       Functional tests
-Test Tags           regression
+Test Tags           regression  functional
 
 Resource            ../../resources/setup_keywords.resource
 

--- a/Robot-Framework/test-suites/functional-tests/camera.robot
+++ b/Robot-Framework/test-suites/functional-tests/camera.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       Testing camera application
-Test Tags           camera  bat  lenovo-x1  darter-pro  dell-7330
+Test Tags           camera  pre-merge  bat  lenovo-x1  darter-pro  dell-7330
 
 Library             Collections
 Library             OperatingSystem

--- a/Robot-Framework/test-suites/functional-tests/files.robot
+++ b/Robot-Framework/test-suites/functional-tests/files.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       Testing launching files
-Test Tags           files  lenovo-x1  darter-pro  dell-7330
+Test Tags           files  bat  lenovo-x1  darter-pro  dell-7330
 
 Resource            ../../resources/app_keywords.resource
 Resource            ../../resources/file_keywords.resource
@@ -17,7 +17,7 @@ ${OUTPUT_FILE}   /tmp/out.log
 
 Open PDF from chrome-vm
     [Documentation]    Open PDF file from Chrome VM and check that Ghaf Isolated Document Viewer started
-    [Tags]             SP-T131  SP-T131-1  pre-merge  bat
+    [Tags]             SP-T131  SP-T131-1  pre-merge
     Open PDF from app-vm    ${CHROME_VM}
 
 Open PDF from comms-vm
@@ -37,7 +37,7 @@ Open PDF from gui-vm
 
 Open image with Oculante
     [Documentation]    Open PNG image in the Gui VM and check that Oculante app is started and opens the image
-    [Tags]             SP-T197  pre-merge  bat
+    [Tags]             SP-T197  pre-merge
     Switch to vm       ${GUI_VM}  user=${USER_LOGIN}
 
     Run Command        WAYLAND_DISPLAY=wayland-1 grim ./screenshot.png   timeout=5
@@ -50,7 +50,7 @@ Open image with Oculante
 
 Open text file with Cosmic Text Editor
     [Documentation]    Open text file and check that Cosmic Text Editor app is started
-    [Tags]             SP-T262  pre-merge  bat
+    [Tags]             SP-T262  pre-merge
     Switch to vm       ${GUI_VM}  user=${USER_LOGIN}
     Create text file   test    /tmp/test_text.txt
     Open file to gui-vm with XDG handler    /tmp/test_text.txt

--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -3,33 +3,19 @@
 
 *** Settings ***
 Documentation       Testing Gui-vm
-Test Tags           gui-vm
+Test Tags           gui-vm  pre-merge  lenovo-x1  darter-pro  dell-7330  fmo
 
-Resource            ../../resources/app_keywords.resource
 Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/service_keywords.resource
 
-Test Setup          Switch to vm    ${GUI_VM}  user=${USER_LOGIN}
-
 
 *** Test Cases ***
 
-Start Falcon AI
-    [Documentation]   Start Falcon AI and verify process started
-    [Tags]            SP-T223  falcon_ai
-    Get Falcon LLM Name
-    Start application  "Falcon AI"
-    Wait Until Falcon Download Complete
-    Check that the application was started    alpaca    range=20
-
-    ${answer}  Ask the question     2+2=? Return just the number.
-    Should Be Equal As Integers     ${answer}   4
-    [Teardown]  Kill App in VM   ${GUI_VM}   alpaca
-
 Check user systemctl status
     [Documentation]   Verify systemctl status --user is running
-    [Tags]            SP-T260  systemctl  pre-merge  bat  lenovo-x1  darter-pro  dell-7330  fmo
+    [Tags]            SP-T260  systemctl
+    [Setup]           Switch to vm    ${GUI_VM}  user=${USER_LOGIN}
     [Teardown]        Set Test Message    append=${True}  separator=\n    message=${found_known_issues_message}
     Set Test Variable   ${found_known_issues_message}   ${EMPTY}
 
@@ -49,49 +35,3 @@ Check user systemctl status
     IF    ${filtered_failed_units}
         Check systemctl status for known issues  ${DEVICE_TYPE}  ${GUI_VM}  ${known_issues}  ${filtered_failed_units}   user=True
     END
-
-
-*** Keywords ***
-
-Get Falcon LLM Name
-    ${output}            Run Command    cat '/run/current-system/sw/share/applications/com.jeffser.Alpaca.desktop'
-    ${line}              Get Lines Containing String  ${output}  Exec=
-    ${path}              Set Variable  ${line[5:]}
-    ${llm_name_raw}      Run Command  cat ${path} | grep LLM_NAME | head -n 1
-    # LLM_NAME="falcon3:10b" -> falcon3:10b
-    ${tmp}               Fetch From Right  ${llm_name_raw}  =
-    ${LLM_NAME}          Set Variable  ${tmp[1:-1]}
-    Set Suite Variable  ${LLM_NAME}
-
-Wait Until Falcon Download Complete
-    [Setup]             Switch to vm    ${GUI_VM}
-    [Timeout]           10 minutes
-    ${downloaded}       Set Variable    0
-    ${stop_flag}        Set Variable    0
-    Log To Console      Logging progression of downloaded model files
-    FOR  ${i}  IN RANGE   60
-        ${output}          Run Command  ollama list
-        ${download_done}   Run Keyword And Return Status  Should Contain   ${output}  ${LLM_NAME}
-        IF  ${download_done}  BREAK
-        Sleep  6
-        ${downloaded_new}  Run Command    du -s /var/lib/private/ollama/models/ | awk '{print $1}'  sudo=True
-        Log                ${downloaded_new} KB    console=True
-        IF  ${downloaded_new} > ${downloaded}
-            ${stop_flag}        Set Variable    0
-            ${downloaded}       Set Variable   ${downloaded_new}
-        ELSE
-            ${stop_flag}        Evaluate       ${stop_flag}+1
-        END
-        IF  ${stop_flag} > 9
-            FAIL                Download of ollama AI model stopped for more than 100 sec without completing.
-        END
-    END
-    [Teardown]          Switch to vm    ${GUI_VM}  user=${USER_LOGIN}
-
-Ask the question
-    [Arguments]      ${question}
-    Log              Asking AI: ${question}  console=True
-    Run Command      script -q -c 'ollama run falcon3:10b "${question}" > result.txt'   timeout=60
-    ${answer}        Run Command   cat result.txt
-    Log              The answer is: ${answer}  console=True
-    RETURN           ${answer}

--- a/Robot-Framework/test-suites/functional-tests/logging.robot
+++ b/Robot-Framework/test-suites/functional-tests/logging.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       Testing logging
-Test Tags           logging  bat  lenovo-x1  darter-pro  dell-7330
+Test Tags           logging  pre-merge  bat  lenovo-x1  darter-pro  dell-7330
 
 Library             DateTime
 Library             OperatingSystem
@@ -25,7 +25,7 @@ ${TEST_LOG}           log_check_${BUILD_ID}
 
 Logging service is running in all VMs
     [Documentation]    Check that logging service is running in every VM
-    [Tags]             SP-T333  SP-T333-1  pre-merge
+    [Tags]             SP-T333  SP-T333-1
     ${failed_vms}      Create List
     FOR  ${vm}  IN  @{VM_LIST}
         Switch to vm   ${vm}
@@ -45,14 +45,14 @@ Logging service is running in all VMs
 
 Alloy and stunnel services are running in admin-vm
     [Documentation]    Verify that admin-vm runs alloy and stunnel services required for log collection and forwarding
-    [Tags]             SP-T333  SP-T333-2  pre-merge
+    [Tags]             SP-T333  SP-T333-2
     Switch to vm   ${ADMIN_VM}
     Run Keyword And Continue On Failure   Verify service status  range=5  service=alloy.service    expected_state=active  expected_substate=running
     Run Keyword And Continue On Failure   Verify service status  range=5  service=stunnel.service  expected_state=active  expected_substate=running
 
 Check Grafana logs
     [Documentation]  Check that all virtual machines are sending logs to Grafana
-    [Tags]           SP-T172  pre-merge
+    [Tags]           SP-T172
     Check Network Availability    8.8.8.8   limit_freq=${False}
     Switch to vm       ${ADMIN_VM}
     ${id}              Get Actual Device ID
@@ -76,7 +76,7 @@ Check Grafana logs
 
 Check logging rate
     [Documentation]    Check that host or vms are not creating too much logs
-    [Tags]             SP-T359  log_rate  pre-merge  orin-agx  orin-agx-64  orin-nx
+    [Tags]             SP-T359  log_rate  orin-agx  orin-agx-64  orin-nx
 
     ${check_interval}          Set Variable   100
     ${entry_limit}             Set Variable   500

--- a/Robot-Framework/test-suites/functional-tests/net-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/net-vm.robot
@@ -45,7 +45,7 @@ Wifi passthrough into NetVM
 
 Ethernet passthrough into NetVM
     [Documentation]     Verify that ethernet connection works inside netvm and internet is available
-    [Tags]              SP-T62  SP-T62-1  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  lab-only
+    [Tags]              SP-T62  SP-T62-1  pre-merge  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  lab-only
     [Setup]             Switch to vm   ${NET_VM}
     Check Network Availability   8.8.8.8   limit_freq=${False}   interface=eth
 
@@ -58,7 +58,7 @@ Verify NetVM PCI device passthrough
 Check net-vm hostname
     [Documentation]    Compare actual net-vm hostname with expected one from the config file,
     ...                It should never change.
-    [Tags]             SP-352  SP-352-1  pre-merge  bat  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  orin-nx  lab-only
+    [Tags]             SP-352  SP-352-1  pre-merge  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  orin-nx  lab-only
     Switch to vm       ${NET_VM}
     Log                Comparing actual net-vm hostname ${NETVM_NAME} and expected ${STATIC_NETVM_NAME}     console=True
     Should Be Equal As Strings   ${NETVM_NAME}    ${STATIC_NETVM_NAME}    ignore_case=True
@@ -68,7 +68,7 @@ Check net-vm hostname
 Verify native ethernet is present and in the same network as USB ethernet
     [Documentation]    Verify that native ethernet exists, both interfaces have IPs,
     ...                and belong to the same /24 subnet.
-    [Tags]             SP-T62  SP-T62-2  darter-pro  lab-only
+    [Tags]             SP-T62  SP-T62-2  pre-merge  darter-pro  lab-only
     ${usb_eth}         Get Interface name   usb-eth
     ${usb_ip}          Get VM IP            ${usb_eth}
     ${native_eth}      Get Interface name   native-eth

--- a/Robot-Framework/test-suites/functional-tests/shares.robot
+++ b/Robot-Framework/test-suites/functional-tests/shares.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       Testing files sharing among VMs
-Test Tags           SP-T198  shares  lenovo-x1  darter-pro  dell-7330
+Test Tags           SP-T198  shares  bat  lenovo-x1  darter-pro  dell-7330
 
 Resource            ../../resources/file_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
@@ -19,7 +19,7 @@ File sharing from Chrome-VM to Business-VM
     ${CHROME_VM}    ${BUSINESS_VM}
 
 File sharing from Chrome-VM to Comms-VM
-    [Tags]          SP-T198-2  pre-merge  bat
+    [Tags]          SP-T198-2  pre-merge
     ${CHROME_VM}    ${COMMS_VM}
 
 File sharing from Comms-VM to Business-VM

--- a/Robot-Framework/test-suites/functional-tests/vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/vm.robot
@@ -43,7 +43,7 @@ ${found_known_issues_message}=
 
 Check internet connection in every VM
     [Documentation]    Pings google from every vm.
-    [Tags]             SP-T257   orin-agx  orin-agx-64  orin-nx
+    [Tags]             SP-T257  orin-agx  orin-agx-64  orin-nx
     ${failed_vms}=    Create List
     FOR  ${vm}  IN  @{VM_LIST_WITH_HOST}
         Switch to vm     ${vm}

--- a/Robot-Framework/test-suites/gui-tests/__init__.robot
+++ b/Robot-Framework/test-suites/gui-tests/__init__.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       GUI tests
-Test Tags           regression    gui
+Test Tags           regression  gui
 
 Resource            ../../resources/gui_keywords.resource
 Resource            ../../resources/setup_keywords.resource

--- a/Robot-Framework/test-suites/security-tests/access_control.robot
+++ b/Robot-Framework/test-suites/security-tests/access_control.robot
@@ -3,7 +3,7 @@
 
 *** Settings ***
 Documentation       Verify access rights and isolation across memory zones, virtual machines, and system resources
-Test Tags           access-control  lenovo-x1  darter-pro  dell-7330
+Test Tags           access-control  bat  lenovo-x1  darter-pro  dell-7330
 
 Resource            ../../resources/ssh_keywords.resource
 

--- a/Robot-Framework/test-suites/security-tests/firewall.robot
+++ b/Robot-Framework/test-suites/security-tests/firewall.robot
@@ -50,8 +50,8 @@ Check that internal tcp syn flooding triggers blacklisting
     [Teardown]      Run Keyword If Test Failed    Blacklist Teardown
 
 Check that external ping flooding triggers blacklisting
-    [Tags]            SP-T299  SP-T299-3  lenovo-x1  darter-pro  orin-agx  orin-nx  lab-only
     [Documentation]   Validate that ping flooding from the test agent to net-vm triggers firewall blacklisting.
+    [Tags]            SP-T299  SP-T299-3  lenovo-x1  darter-pro  orin-agx  orin-nx  lab-only
     [Setup]           Run Keyword If   "${SERIAL_PORT}" == "NONE"   SKIP   No serial address, skipping test
     ${ext_attacker_ip}    Get External Attacker IP
     External Ping Flood NetVM
@@ -60,8 +60,8 @@ Check that external ping flooding triggers blacklisting
     [Teardown]      Run Keyword If Test Failed    Blacklist Teardown
 
 Check that external tcp syn flooding triggers blacklisting
-    [Tags]            SP-T299  SP-T299-4  lenovo-x1  darter-pro  orin-agx  orin-nx  lab-only
     [Documentation]   Validate that tcp syn probing from the test agent to net-vm triggers firewall blacklisting.
+    [Tags]            SP-T299  SP-T299-4  lenovo-x1  darter-pro  orin-agx  orin-nx  lab-only
     [Setup]           Run Keyword If   "${SERIAL_PORT}" == "NONE"   SKIP   No serial address, skipping test
     ${ext_attacker_ip}    Get External Attacker IP
     Tcp Syn Flood         ${DEVICE_IP_ADDRESS}
@@ -70,8 +70,8 @@ Check that external tcp syn flooding triggers blacklisting
     [Teardown]      Run Keyword If Test Failed    Blacklist Teardown
 
 Check VM firewall policy
-    [Tags]               SP-T361  lenovo-x1  darter-pro  dell-7330
     [Documentation]      Check that blocked pages can not be accessed, policy only applies to chrome-vm
+    [Tags]               SP-T361  bat  lenovo-x1  darter-pro  dell-7330
     ${since_last_boot}   Get Time Since Last Boot
     Switch to vm         ${CHROME_VM}
     # Policy can take up to 5 minutes to update

--- a/Robot-Framework/test-suites/security-tests/killswitch.robot
+++ b/Robot-Framework/test-suites/security-tests/killswitch.robot
@@ -19,7 +19,7 @@ ${AUDIO_DIR}    ${OUTPUT_DIR}/outputs/audio-temp
 
 Killswitch disconnects camera
     [Documentation]  Check that camera works, then block it using killswitch and verify that it doesn't work
-    [Tags]           SP-T275  SP-T275-1
+    [Tags]           SP-T275  SP-T275-1  bat
     Check camera     expected=True
     Set device state  blocked    cam
     Check camera     expected=False
@@ -27,7 +27,7 @@ Killswitch disconnects camera
 
 Killswitch disconnects microphone
     [Documentation]  Check that microphone works, then block it using killswitch and verify that it doesn't work
-    [Tags]           SP-T275  SP-T275-2
+    [Tags]           SP-T275  SP-T275-2  bat
     Record Audio And Verify   ${BUSINESS_VM}
     Set device state  blocked    mic
     Record Audio And Verify   ${BUSINESS_VM}    expected_duration=0

--- a/Robot-Framework/test-suites/security-tests/logging.robot
+++ b/Robot-Framework/test-suites/security-tests/logging.robot
@@ -19,7 +19,7 @@ Suite Setup         Logging Setup
 
 Wifi password is not revealed in Grafana
     [Documentation]  Check that logs in Grafana don't contain wifi password
-    [Tags]           SP-T328  SP-T328-1  lab-only
+    [Tags]           SP-T328  SP-T328-1  bat  lab-only
     Configure wifi   ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Sleep   3        # Time for needed data to be logged
     Is password revealed in Grafana    ${TEST_WIFI_SSID}    ${TEST_WIFI_PSWD}
@@ -27,7 +27,7 @@ Wifi password is not revealed in Grafana
 
 User password is not revealed in Grafana
     [Documentation]  Check that logs in Grafana don't contain user's password
-    [Tags]           SP-T328  SP-T328-2
+    [Tags]           SP-T328  SP-T328-2  bat
     Is password revealed in Grafana    ${USER_LOGIN}    ${USER_PASSWORD}
 
 Check Grafana log forwarding after disconnected state

--- a/Robot-Framework/test-suites/security-tests/network.robot
+++ b/Robot-Framework/test-suites/security-tests/network.robot
@@ -28,7 +28,7 @@ Account lockout after failed login
 
 Check OpenSSL3 is Available In Nix Store
     [Documentation]  Connect to GUI-VM and check that OpenSSL3 is available in NixStore.
-    [Tags]           SP-T295  lenovo-x1  darter-pro   dell-7330
+    [Tags]           SP-T295  lenovo-x1  darter-pro  dell-7330
     Switch to vm     ${GUI_VM}
     ${output}        Run Command    ls /nix/store | grep openssl-3    rc_match=skip
     Should Not Be Empty    ${output}    msg=Found no openssl in Nix Store

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -29,7 +29,6 @@
 
 | DATE SET   | TEST CASE                                  | TICKET / Additional Data.                                                              |
 | ---------- | ------------------------------------------ | -------------------------------------------------------------------------------------- |
-| 04.05.2026 | Start Falcon AI and verify process started | Falcon is no longer included in the default image (Ghaf#1944)                          |
 | 24.04.2026 | Rebuild tests removed from regression      | Rebuild tests do not work properly with signed images                                  |
 | 27.02.2026 | Measure Soft Boot Time (Darter Pro)        | Test removed because the Enter finger causes inaccuracy to the result                  |
 | 20.02.2026 | Test ballooning in chrome-vm / business-vm | Ballooning feature was turned off in ghaf by PR#1770                                   |

--- a/pkgs/tag-helper/organize_robot_tags.py
+++ b/pkgs/tag-helper/organize_robot_tags.py
@@ -4,7 +4,7 @@ import re
 TAGS_RE = re.compile(r"^(\s*(?:\[Tags\]|Test Tags)\s+)(.+)$")
 
 TAG_PRIORITY = ["pre-merge", "bat", "regression",   # Test set tags from smallest to biggest
-                "gui", "performance", "security", "suspension", "update",  # Test suite tags in an alphabetical order (there should be only one of these for each test)
+                "functional", "gui", "performance", "security", "suspension", "update",  # Test suite tags in an alphabetical order (there should be only one of these for each test)
                 "lenovo-x1", "darter-pro", "dell-7330", "orin-agx", "orin-agx-64", "orin-nx", # Device tags
                 "installer-only", "excl-installer", "storeDisk-only", "excl-storeDisk", "secboot-only", "excl-secboot",  # Image type tags
                 "lab-only", "fmo"]  # Other important tags
@@ -37,9 +37,10 @@ def process_file(path):
         prefix, tag_str = match.groups()
         tags = tag_str.split()
         ordered = sorted(tags, key=tag_priority)
+        normalized = prefix + "  ".join(ordered)
 
-        if tags != ordered:
-            lines[i] = prefix + "  ".join(ordered)
+        if line != normalized:
+            lines[i] = normalized
             changed = True
 
     if changed:


### PR DESCRIPTION
- Add more tests to pre-merge and bat now that tests are running faster. On Darter Pro the number of tests changes as follows (execution times in brackets):
  - Pre-merge:  51 tests (04:04) ->56 tests (04:26)
  - Bat: 64 tests (05:43) -> 80 tests (07:32)
- Remove Falcon test, it was removed from Ghaf some time ago.
- Update organize_robot_tags.py script and run it to normalize the tag order.
- Limit data points in logging rate graphs to 100 (for comparison: [mainline](https://ci-prod.vedenemo.dev/job/ghaf-hw-test/25816/artifact/Robot-Framework/test-suites/regression/OrinAGX1_Check%20logging%20rate__log_entries.png) vs. [this PR](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2101/artifact/Robot-Framework/test-suites/orin-agxANDpre-merge/OrinAGX1_Check%20logging%20rate__log_entries.png))

**Testruns**
- [Pre-merge](https://ci-dev.vedenemo.dev/job/ghaf-pre-merge-manual/303/)
- [Main](https://ci-dev.vedenemo.dev/job/ghaf-main/309/)