### PR TITLE
Update log and memory limits, small bugfixes

### DIFF
--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -225,7 +225,7 @@ Check that device is suspended
 
 Reboot Orin if ssh connection dropped
     ${ssh_available}  Run Keyword And Return Status    Run Command    ls  timeout=5
-    IF  not ${ssh_available}
+    IF  not ${ssh_available} and "orin" in "${DEVICE_TYPE}"
         Reboot Orin
         Close All Connections
         Check If Device Is Up

--- a/Robot-Framework/resources/wifi_keywords.resource
+++ b/Robot-Framework/resources/wifi_keywords.resource
@@ -39,7 +39,7 @@ Turn ON WiFi
 Scan for Wifi
     [Arguments]         ${SSID}
     Switch to vm        ${NET_VM}
-    Log                 Scanning for ${SSID}
+    Log                 Scanning for ${SSID}   console=True
     ${output}           Run Command   nmcli dev wifi list --rescan yes   sudo=True
     Should Contain      ${output}   ${SSID}
 

--- a/Robot-Framework/test-suites/functional-tests/logging.robot
+++ b/Robot-Framework/test-suites/functional-tests/logging.robot
@@ -46,15 +46,17 @@ Logging service is running in all VMs
 Alloy and stunnel services are running in admin-vm
     [Documentation]    Verify that admin-vm runs alloy and stunnel services required for log collection and forwarding
     [Tags]             SP-T333  SP-T333-2
+    [Timeout]          2 minutes
     Switch to vm   ${ADMIN_VM}
     Run Keyword And Continue On Failure   Verify service status  range=5  service=alloy.service    expected_state=active  expected_substate=running
     Run Keyword And Continue On Failure   Verify service status  range=5  service=stunnel.service  expected_state=active  expected_substate=running
+    [Teardown]         Reboot Orin if ssh connection dropped
 
 Check Grafana logs
     [Documentation]  Check that all virtual machines are sending logs to Grafana
     [Tags]           SP-T172
-    Check Network Availability    8.8.8.8   limit_freq=${False}
     Switch to vm       ${ADMIN_VM}
+    Check Network Availability    8.8.8.8   limit_freq=${False}
     ${id}              Get Actual Device ID
     Run Keyword And Continue On Failure   Create logs in all VMs
     Sleep              5
@@ -79,9 +81,9 @@ Check logging rate
     [Tags]             SP-T359  log_rate
 
     ${check_interval}          Set Variable   100
-    ${entry_limit}             Set Variable   500
+    ${entry_limit}             Set Variable   400
     ${dell_host_entry_limit}   Set Variable   1000   # Known Issue: SSRCSP-8481
-    ${orin_entry_limit}        Set Variable   2000
+    ${orin_entry_limit}        Set Variable   1000
     ${bytes_per_entry}         Set Variable   200
 
     &{spam_metrics}       Create Dictionary

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -41,7 +41,8 @@ Record memory usage test
 VM memory usage snapshot
     [Documentation]    Log current memory usage (available/total) and swap usage (free/total) in every VM and ghaf-host and plot it across builds.
     [Tags]             SP-T360  memory_usage  lenovo-x1  darter-pro  dell-7330  orin-agx  orin-agx-64  orin-nx
-    ${low_mem_limit}   Set variable    3.0
+    ${low_mem_limit}       Set Variable    10
+    ${low_swap_limit}      Set Variable    50
     @{vms}         Get VM list    with_host=True
     &{mem_data}    Create Dictionary
     FOR    ${vm}    IN    @{vms}
@@ -54,9 +55,13 @@ VM memory usage snapshot
         ${swap_free_mib}     Set Variable    ${vals}[2]
         ${swap_total_mib}    Set Variable    ${vals}[3]
         ${mem_avail_pct}     Evaluate    (float($mem_avail_mib) / float($mem_total_mib)) * 100 if float($mem_total_mib) > 0 else 0
+        ${swap_free_pct}     Evaluate    (float($swap_free_mib) / float($swap_total_mib)) * 100 if float($swap_total_mib) > 0 else 0
         ${pct_str}           Evaluate    f"{float($mem_avail_pct):.2f}%"
         IF    ${mem_avail_pct} < ${low_mem_limit}
             Run Keyword And Continue On Failure    FAIL    ${vm} available memory is below ${low_mem_limit}% of the total memory
+        END
+        IF    ${swap_free_pct} < ${low_swap_limit}
+            Run Keyword And Continue On Failure    FAIL    ${vm} swap free is below ${low_swap_limit}% of the total swap
         END
         Log    Memory in ${vm}: avail ${mem_avail_mib}/${mem_total_mib} MiB, swap free ${swap_free_mib}/${swap_total_mib} MiB    console=True
         Set To Dictionary    ${mem_data}    mem_avail_mib__${vm}=${mem_avail_mib}
@@ -74,6 +79,7 @@ VM memory usage snapshot
 
     [Teardown]      Run Keywords    Close All Connections
     ...             AND             Switch to vm   ${HOST}
+    ...             AND             Run Keyword If Test Failed    Run Keyword If    "${DEVICE_TYPE}" == "dell-7330"    SKIP    Low memory target has less memory available
 
 nvpmodel check test
     [Documentation]     If power mode changed it would probably have an effect on performance test results.

--- a/Robot-Framework/test-suites/security-tests/killswitch.robot
+++ b/Robot-Framework/test-suites/security-tests/killswitch.robot
@@ -46,7 +46,7 @@ Killswitch disconnects WLAN
     Check Network Availability    8.8.8.8     expected_result=True    limit_freq=${False}    interface=eth
     Set device state   unblocked    net
     Remove Wifi configuration       ${TEST_WIFI_SSID}
-    Scan for Wifi                   ${TEST_WIFI_SSID}
+    Wait Until Keyword Succeeds     10x   1s   Scan for Wifi   ${TEST_WIFI_SSID}
     Configure wifi                  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Get wifi IP
     [Teardown]       WLAN teardown

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -3,7 +3,8 @@
 ## Active SKIPS
 
 | DATE SET   | TEST CASE                                               | TICKET / Additional Data.                                                                     |
-|------------|---------------------------------------------------------| --------------------------------------------------------------------------------------------- |
+| ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| 15.06.2026 | VM memory usage snapshot (Dell)                         | Dell has less memory than other targets                                                       |
 | 11.06.2026 | Verify booting after restart by power (orin-nx)         | SSRCSP-8585                                                                                   |
 | 11.06.2026 | functional-tests (orin-nx)                              | SSRCSP-8585                                                                                   |
 | 29.05.2026 | Check Grafana log forwarding after disconnected state   | SSRCSP-8525                                                                                   |


### PR DESCRIPTION
* Decrease limits in `Check logging rate`, this is a follow-up for https://github.com/tiiuae/ci-test-automation/pull/846
* Increase the limit for minimum free memory in `VM memory usage snapshot` and add a separate limit for swap. There were changes to Ghaf last week that freed memory. Dell-7330 is skipped in case it fails, low-memory-target does not have as much memory and I did not want to spend time adding a separate limit for it.
* Add iterations for scanning for wifi after killswitch. Locally images connect back to wifi automatically.
* Add a reboot to the teardown of `Alloy and stunnel services are running in admin-vm` in case the connection dropped on Orin. This test is old but it was added for Orins last week. Orin NX [timed out](https://ci-prod.vedenemo.dev/job/ghaf-hw-test/25986/artifact/Robot-Framework/test-suites/bat/log.html#s1-s1-s2-t2) in main pipeline while running this test. We might also need a skip if the issue repeats.

**Testruns**
- Darter storeDisk [pre-mergeANDkillswitch](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6543/artifact/Robot-Framework/test-suites/darter-proANDpre-mergeORloggingORkillswitch/report.html#totals)
- Darter storeDisk [performance](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6550/artifact/Robot-Framework/test-suites/darter-proANDperformanceNOTSP-T61-9/report.html#totals)
- Orin NX [Alloy and stunnel services are running in admin-vm](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6551/artifact/Robot-Framework/test-suites/orin-nxANDbat/log.html#s1-s1-s2-t2) with connection drop
- (Limits for `Check logging rate` and `VM memory usage snapshot` checked from prod runs)