### PR TITLE
Ignore BT config in case of error

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -53,10 +53,10 @@ Set Variables
         ${config}=     Read Config    ${CONFIG_PATH}/test_config.json
         Set Global Variable  ${SERIAL_PORT}        ${config['addresses']['${DEVICE}']['serial_port']}
         Set Global Variable  ${RELAY_SERIAL_PORT}  ${config['addresses']['relay_serial_port']}
-        Set Global Variable  ${BT_SERIAL_PORT}     ${config['addresses']['bluetooth_serial_port']}
-        Set Global Variable  ${BT_BOARD_NAME}      ${config['addresses']['bluetooth_name']}
         Set Global Variable  ${DEVICE_IP_ADDRESS}  ${config['addresses']['${DEVICE}']['device_ip_address']}
         Set Global Variable  ${THREADS_NUMBER}     ${config['addresses']['${DEVICE}']['threads']}
+        Run Keyword And Ignore Error    Set Global Variable  ${BT_SERIAL_PORT}     ${config['addresses']['bluetooth_serial_port']}
+        Run Keyword And Ignore Error    Set Global Variable  ${BT_BOARD_NAME}      ${config['addresses']['bluetooth_name']}
         Run Keyword And Ignore Error    Set Global Variable  ${STATIC_DEVICE_ID}   ${config['addresses']['${DEVICE}']['device_id']}
         Run Keyword And Ignore Error    Set Global Variable  ${STATIC_NETVM_NAME}  ${config['addresses']['${DEVICE}']['netvm_hostname']}
         Run Keyword And Ignore Error    Set Global Variable  ${SOCKET_IP_ADDRESS}  ${config['addresses']['${DEVICE}']['socket_ip_address']}


### PR DESCRIPTION
prod2 does not have BT board, and also local testruns should support ignoring this configuration, as far as it is lab-only

[OrinNX](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6574/console)

[LenovoX1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6575/)