### PR TITLE
Remove skip from log forwarding after reboot

### DIFF
--- a/Robot-Framework/test-suites/security-tests/logging.robot
+++ b/Robot-Framework/test-suites/security-tests/logging.robot
@@ -59,9 +59,8 @@ Check Grafana log forwarding after disconnected state
     ELSE
         Soft Reboot Device And Connect   vm=${HOST}
     END
-    Wait Until Keyword Succeeds  60s  5s  Check VM Log on Grafana     ${id}   ${ADMIN_VM}   5m   ${True}   logtest1_${BUILD_ID}
+    Wait Until Keyword Succeeds  90s  5s  Check VM Log on Grafana     ${id}   ${ADMIN_VM}   5m   ${True}   logtest1_${BUILD_ID}
     Log To Console               Checked that log is forwarded after clearing the iptables rule by reboot
-    [Teardown]      Run Keyword If Test Failed   SKIP   Known Issue: SSRCSP-8525
 
 *** Keywords ***
 

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -7,7 +7,6 @@
 | 15.06.2026 | VM memory usage snapshot (Dell)                         | Dell has less memory than other targets                                                       |
 | 11.06.2026 | Verify booting after restart by power (orin-nx)         | SSRCSP-8585                                                                                   |
 | 11.06.2026 | functional-tests (orin-nx)                              | SSRCSP-8585                                                                                   |
-| 29.05.2026 | Check Grafana log forwarding after disconnected state   | SSRCSP-8525                                                                                   |
 | 25.05.2026 | Reboot from power menu                                  | SSRCSP-8490                                                                                   |
 | 22.05.2026 | Check logging rate (Dell)                               | SSRCSP-8481                                                                                   |
 | 13.05.2026 | Validate Forward Secure Sealing                         | SSRCSP-8425                                                                                   |


### PR DESCRIPTION
To be merged after https://github.com/tiiuae/ghaf/pull/1995

- Remove skip from `Check Grafana log forwarding after disconnected state`
- Extend the search time because Orins are slower at sending logs. This test was added for Orins while the skip was already in place so it has not been tested before.

[Orin-NX](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6598/artifact/Robot-Framework/test-suites/orin-nxANDlogging/report.html#totals)
[Darter Pro](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6599/artifact/Robot-Framework/test-suites/darter-proANDsecurityANDlogging/report.html#totals)