### PR TITLE
Refactor Check If Device Up

### DIFF
--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -141,11 +141,11 @@ Connect After Reboot
         WHILE    True    limit=120 seconds
             Log              Pressing Enter    console=True
             Press Button     ${SWITCH_BOT}-Enter
-            Run Keyword And Ignore Error    Check If Device Is Up    range=5
+            Check If Device Is Up   retry=5x
             IF   ${IS_AVAILABLE} == True and "${CONNECTION_TYPE}" == "ssh"   BREAK
         END
     ELSE
-        Check If Device Is Up         range=60
+        Check If Device Is Up         retry=60x
     END
     
     IF    ${IS_AVAILABLE} == False
@@ -160,7 +160,7 @@ Connect After Reboot
 Wake up device
     Log To Console    Pressing the power button...
     Press Button      ${SWITCH_BOT}-ON
-    Check If Device Is Up    range=30
+    Check If Device Is Up    retry=30x
     IF    ${IS_AVAILABLE} == False
         FAIL             The device did suspend but failed to wake up
     ELSE IF  "${CONNECTION_TYPE}" == "serial"
@@ -213,15 +213,6 @@ Verify shutdown via network
     END
     ${diff}    Evaluate    int(time.time()) - int(${start_time})
     Fail       Device at ${DEVICE_IP_ADDRESS} still responds after ${diff} seconds.
-
-Check that device is suspended
-    ${device_not_available}  Run Keyword And Return Status  Wait Until Keyword Succeeds  15s  2s  Check If Ping Fails
-    IF  ${device_not_available} == True
-        Log To Console  Device is suspended
-    ELSE
-        Log To Console  Device is available
-        FAIL    Device failed to suspend.
-    END
 
 Reboot Orin if ssh connection dropped
     ${ssh_available}  Run Keyword And Return Status    Run Command    ls  timeout=5

--- a/Robot-Framework/resources/serial_keywords.resource
+++ b/Robot-Framework/resources/serial_keywords.resource
@@ -64,10 +64,10 @@ Check Serial Connection
 
     ${serial_status}=   Open Serial Port
     Should Not Be Equal    ${serial_status}    False    msg=Serial port is not available
-    Wait Until Keyword Succeeds    ${range}    1s    Check For Text Is In Serial Port    text=ghaf
+    Wait Until Keyword Succeeds    ${range}    1s    Check For Text In Serial Port    text=ghaf
     Delete All Ports
 
-Check For Text Is In Serial Port
+Check For Text In Serial Port
     [Arguments]    ${text}
     Write Data     ${\n}
     ${output}      SerialLibrary.Read Until

--- a/Robot-Framework/resources/serial_keywords.resource
+++ b/Robot-Framework/resources/serial_keywords.resource
@@ -57,29 +57,33 @@ Turn Relay On
 
 Check Serial Connection
     [Documentation]    Check if device is available by serial
-    [Arguments]        ${range}=30
+    [Arguments]        ${range}=30x
     Log To Console     Trying to connect via serial...
-    ${serial_status}   Open Serial Port
-    IF   ${serial_status}==False
-        Log       Serial port is not available      console=True
-        RETURN    False
-    END
-    FOR    ${i}    IN RANGE    ${range}
-        Write Data     ${\n}
-        ${output}      SerialLibrary.Read Until
-        ${status}      Run Keyword And Return Status    Should contain    ${output}    ghaf
-        IF    ${status}    BREAK
-        Sleep   1
-    END
+    Should Not Be True     ${UART_CAPTURE_ACTIVE}       msg=UART capture is active, can't check serial, data on the port could be lost.
+    Should Not Be Equal    ${SERIAL_PORT}      NONE     msg=There is no address for serial connection
+
+    ${serial_status}=   Open Serial Port
+    Should Not Be Equal    ${serial_status}    False    msg=Serial port is not available
+    Wait Until Keyword Succeeds    ${range}    1s    Check For Text Is In Serial Port    text=ghaf
     Delete All Ports
-    Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
-    IF  ${status}
-        Log To Console       Device is available via serial
-        Set Global Variable  ${CONNECTION_TYPE}    serial
-        Set Global Variable  ${IS_AVAILABLE}       True
-    ELSE
-        Log To Console       Device is not available via serial
+
+Check For Text Is In Serial Port
+    [Arguments]    ${text}
+    Write Data     ${\n}
+    ${output}      SerialLibrary.Read Until
+    Should contain    ${output}    ${text}
+
+Try To Check Serial On Device
+    [Arguments]    ${range}=30x
+    ${serial_status}=      Set variable    ${False}
+    TRY
+        Check Serial Connection     range=${range}
+        ${serial_status}=    Set Variable   ${True}
+        Log    Device is available via Serial Port.     console=True
+    EXCEPT   AS    ${exc}
+        Log    Device is not available via serial, failed with an exception:\n ${exc}!      console=True
     END
+    RETURN    ${serial_status}
 
 Log In To Ghaf OS
     [Documentation]       Log in with ${LOGIN} and ${PASSWORD}

--- a/Robot-Framework/resources/setup_keywords.resource
+++ b/Robot-Framework/resources/setup_keywords.resource
@@ -20,7 +20,7 @@ ${ROBOT_SUDOERS_BOOT_ID}     ${EMPTY}
 Prepare Test Environment
     [Arguments]   ${enable_dnd}=False
     [Timeout]     5 minutes
-    Check If Device Is Up    range=5
+    Check If Device Is Up    retry=5x
     IF    ${IS_AVAILABLE} == False
         FAIL    The device is not available via SSH or serial.
     ELSE IF  "${CONNECTION_TYPE}" == "serial"

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -19,21 +19,25 @@ ${NETVM_SYNTAX}     ghaf-[0-9]{10}
 
 
 *** Keywords ***
-
 Ping Host
-    [Arguments]        ${hostname}  ${timeout}=${PING_SPACING}  ${allow_fail}=${False}
     [Documentation]    Ping the given hostname once and return boolean result
+    [Arguments]        ${hostname}  ${timeout}=${PING_SPACING}
     ${ping_output}=    Run Process   ping ${hostname} -c 1 -W ${timeout}   shell=True
-    ${ping_success}    Run Keyword And Return Status    Should Contain    ${ping_output.stdout}    1 received
-    IF  ${allow_fail} and not ${ping_success}
-        FAIL
-    END
-    Return From Keyword    ${ping_success}
+    ${received}=       Evaluate    '1 received' in $ping_output.stdout
+    RETURN    ${received}
 
-Check If Ping Fails
-    [Documentation]  Check that ping is not getting response from host
-    ${result}  Run Process  ping  ${DEVICE_IP_ADDRESS}  -c1  timeout=1s
-    Should Not Be Equal   ${result.rc}  ${0}
+Verify Ping Host
+    [Arguments]    ${hostname}    ${expected_status}=${True}   ${timeout}=${PING_SPACING}    ${console_log}=${False}
+    ${received_status}=    Ping Host            hostname=${hostname}    timeout=${timeout}
+    Run Keyword If         ${console_log}       Log      Ping ${hostname}... Status: ${received_status}     console=True
+    Should Be Equal        ${received_status}   ${expected_status}
+
+Wait For Device Going Offline
+    [Arguments]    ${hostname}   ${timeout}=15s     ${ping_timeout}=${PING_SPACING}
+    ${log_message}=     Set Variable      Device failed to go offline: still pingable after ${timeout}.
+    Wait Until Keyword Succeeds    ${timeout}  2s  Verify Ping Host     hostname=${hostname}    expected_status=${False}    timeout=${ping_timeout}
+    ${log_message}=     Set Variable      Device is not pingable: offline.
+    [Teardown]    Log     ${log_message}    console=True
 
 Get Ethernet Interface By Type
     [Documentation]    Returns ethernet interface filtered by usb or non-usb.
@@ -116,48 +120,44 @@ Check Network Availability
     FAIL    Expected availability of ${host}: ${expected_result}, in fact: ${availability}
 
 Check If Device Is Up
-    [Arguments]    ${range}=50    ${timeout}=500
-    ${start_time}=    Get Time	epoch
-    ${ping}    Set Variable    ${False}
-    Set Global Variable        ${IS_AVAILABLE}       False
-    FOR    ${i}    IN RANGE    ${range}
-        ${elapsed}    Evaluate    int(time.time()) - int(${start_time})
-        IF    ${elapsed} >= ${timeout}
-            BREAK
-        END
-        Log         Ping ${DEVICE_IP_ADDRESS}...    console=True
-        Run Keyword If    ${UART_CAPTURE_ACTIVE}    Drain Serial Output    save_output=${True}
-        ${ping}=    Ping Host   ${DEVICE_IP_ADDRESS}
-        Sleep       ${PING_SPACING}
-        IF    ${ping}
-            Log To Console    Ping ${DEVICE_IP_ADDRESS} successful
-            BREAK
-        END
+    [Arguments]    ${retry}=500s
+    ${ssh_status}=       Try To Check Ssh On Device  retry=${retry}  interval=${PING_SPACING}s
+    ${serial_status}=    Run Keyword If   not ${ssh_status}    Try To Check Serial On Device    range=3x
+
+    Set Global Device Availability Variables     ${ssh_status}   ${serial_status}
+
+Try To Check Ssh On Device
+    [Arguments]    ${retry}   ${interval}
+    ${ssh_status}=      Set variable    ${False}
+    TRY
+        Wait Until Keyword Succeeds     ${retry}    ${interval}
+        ...      Run keywords
+        ...         Run Keyword If      ${UART_CAPTURE_ACTIVE}           Drain Serial Output    save_output=${True}  AND
+        ...         Verify Ping Host    ${DEVICE_IP_ADDRESS}             console_log=${True}
+
+        Wait Until Ssh Is Ready On Device   ${DEVICE_IP_ADDRESS}
+
+        ${ssh_status}=      Set Variable    ${True}
+        Log    Device is available via SSH    console=True
+    EXCEPT   AS    ${exc}
+        Log    Device is not available via SSH, failed with an exception:\n ${exc}!     console=True
     END
+    RETURN    ${ssh_status}
 
-    IF    ${ping}
-        ${port_22_is_available}     Check if ssh is ready on device
-        IF  ${port_22_is_available}
-            Set Global Variable    ${CONNECTION_TYPE}    ssh
-            Set Global Variable    ${IS_AVAILABLE}       True
-        ELSE
-            Set Global Variable    ${IS_AVAILABLE}       False
-        END
-    END
+Set Global Device Availability Variables
+    [Arguments]    ${ssh_status}    ${serial_status}
+    IF    ${ssh_status}
+        Set Global Variable        ${IS_AVAILABLE}       True
+        Set Global Variable        ${CONNECTION_TYPE}    ssh
+    ELSE IF    ${serial_status}
+        Set Global Variable        ${IS_AVAILABLE}       True
+        Set Global Variable        ${CONNECTION_TYPE}    serial
+        Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
+    ELSE
+        Set Global Variable        ${IS_AVAILABLE}       False
+        Set Global Variable        ${CONNECTION_TYPE}    ${None}
 
-    ${diff}=    Evaluate    int(time.time()) - int(${start_time})
-
-    IF  ${IS_AVAILABLE}    Log    Device woke up after ${diff} sec.    console=True
-
-    IF  ${IS_AVAILABLE} == False
-        Log To Console    Device is not available via SSH, waited for ${diff} sec!
-        IF  ${UART_CAPTURE_ACTIVE}
-            Log To Console    UART capture is active, leaving serial recovery for teardown.
-        ELSE IF  "${SERIAL_PORT}" == "NONE"
-            Log To Console    There is no address for serial connection
-        ELSE
-            Check Serial Connection    range=3
-        END
+        Log    Device is not available neither via ssh nor serial    console=True
     END
 
 Login with timeout
@@ -263,30 +263,35 @@ Check if ssh is ready on vm
     END
     IF   '${status}' == 'FAIL'    FAIL    Port 22 of ${vm} is not ready after ${timeout}
 
-Check if ssh is ready on device
-    [Arguments]    ${timeout}=50
-    ${is_ready}    Set Variable    False
-    ${start_time}  Get Time	epoch
-    FOR    ${i}    IN RANGE    ${timeout}
-        ${rc}  	${output}	 Run And Return Rc And Output   nc -zvw3 ${DEVICE_IP_ADDRESS} 22
-        ${status}    Run Keyword And Return Status
-        ...          Should Be Equal As Integers	${rc}	0
-        Sleep        ${PING_SPACING}
-        IF  ${status}
-            Log To Console   ${output}
-            ${is_ready} =  Set Variable    True
-            BREAK
-        END
-        ${diff}=    Evaluate    int(time.time()) - int(${start_time})
-        IF   ${diff} > ${timeout}
-            BREAK
-        END
-    END
-    IF   ${is_ready} == False
-        Log To Console  Port 22 (ssh) of ${DEVICE} is not ready after ${timeout}
+Get Ssh Status
+    [Arguments]    ${ip_address}
+    ${rc}  	${output}	 Run And Return Rc And Output   nc -zvw3 ${ip_address} 22
+    IF    ${rc} == 0
+        RETURN    ${True}   ${output}
+    ELSE
+        RETURN    ${False}  ${output}
     END
 
-    RETURN  ${is_ready}
+Check Ssh Status
+    [Arguments]    ${ip_address}    ${connection_succeeded}=${True}
+    ${rc}  	${output}	 Run And Return Rc And Output   nc -zvw3 ${ip_address} 22
+    IF    ${rc} == 0
+        ${connected}    Set Variable    ${True}
+    ELSE
+        ${connected}    Set Variable    ${False}
+    END
+    Should Be Equal     ${connected}    ${connection_succeeded}
+    RETURN    ${output}
+
+Wait Until Ssh Is Ready On Device
+    [Arguments]    ${ip_address}    ${timeout}=50s
+    [Timeout]    ${timeout}
+    ${is_ready}    Set Variable    ${False}
+    ${output}=    Wait Until Keyword Succeeds    ${timeout}   ${PING_SPACING}    Check Ssh Status    ip_address=${ip_address}
+    ${is_ready}    Set Variable    ${True}
+    Log   ${output}     console=True
+    [Teardown]    Run Keyword If    not ${is_ready}
+    ...                             Log  Port 22 (ssh) of ${ip_address} is not ready after ${timeout}   console=True
 
 Switch to vm
     [Arguments]         ${hostname}   ${user}=ghaf   ${timeout}=60

--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -31,11 +31,11 @@ Verify booting after restart by power
     Reboot Orin
     Start UART Log Capture
 
-    Check If Device Is Up   timeout=140
+    Check If Device Is Up   retry=140s
     IF      "${DEVICE_TYPE}" == "orin-nx" and ${IS_AVAILABLE} == False
             Log                     message=Orin-nx failed to start, rebooting via relay one more time...    level=WARN
             Reboot Orin
-            Check If Device Is Up   timeout=140
+            Check If Device Is Up   retry=140s
     END
 
     IF    ${IS_AVAILABLE} == False
@@ -62,14 +62,14 @@ Verify booting laptop
     Reboot Laptop      verify_shutdown=False
     Start UART Log Capture
     IF    "installer" in "${JOB}"
-        Check If Device Is Up    range=240    timeout=490
+        Check If Device Is Up    retry=490s
     ELSE
-        Check If Device Is Up    timeout=110
+        Check If Device Is Up    retry=110s
     END
     IF    ${IS_AVAILABLE} == False
         Log To Console    Turning device on again...
         Turn Laptop On
-        Check If Device Is Up    timeout=110
+        Check If Device Is Up    retry=110s
     END
     IF    ${IS_AVAILABLE} == False
         FAIL    The device did not start
@@ -96,12 +96,8 @@ Turn OFF Device
     ELSE
         Turn Off Power
     END
-    ${device_not_available}  Run Keyword And Return Status  Wait Until Keyword Succeeds  30s  2s  Check If Ping Fails
-    IF  ${device_not_available} == True
-        Log To Console    Device is down
-    ELSE
-        Log To Console    Device is UP after the end of the test.
-    END
+
+    Wait For Device Going Offline    hostname=${DEVICE_IP_ADDRESS}    timeout=30s
 
 Turn ON Device
     [Documentation]   Turn on device
@@ -147,7 +143,7 @@ Wipe installed Ghaf from internal memory
     [Tags]            wiping  lenovo-x1  darter-pro
     Log To Console    ${\n}Turning device on...
     Turn Laptop On
-    Check If Device Is Up   range=60
+    Check If Device Is Up   retry=60x
     Run Keyword If    ${IS_AVAILABLE} == False   FAIL    The device did not start
 
     IF  "${CONNECTION_TYPE}" == "ssh"
@@ -160,10 +156,10 @@ Wipe installed Ghaf from internal memory
 Break the system
     [Documentation]   Wipe boot partition
     [Tags]            break  darter-pro
-    Check If Device Is Up    range=5
+    Check If Device Is Up    retry=5x
     IF    ${IS_AVAILABLE} == False
         Turn Laptop On
-        Check If Device Is Up    range=240
+        Check If Device Is Up    retry=240x
         IF    ${IS_AVAILABLE} == False
             FAIL    Darter is not available, Wiping is not possible, requires manual maintenance.
         END

--- a/Robot-Framework/test-suites/gui-tests/gui_power.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power.robot
@@ -179,7 +179,7 @@ Confirm suspension and wake up the device
     [Documentation]   Check that the device is suspended.
     ...               Wake up by pressing the power button for 1 sec.
     ...               Check that the device is awake and unlock.
-    Check that device is suspended
+    Wait For Device Going Offline    ${DEVICE_IP_ADDRESS}
 
     Log To Console      Letting the device stay suspended for 30 sec
     Wait                30

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -46,7 +46,7 @@ Automatic suspension
 
     Wait                     610
 
-    Check that device is suspended
+    Wait For Device Going Offline   ${DEVICE_IP_ADDRESS}
 
     Wait                     60
     Set timestamp            suspend_start

--- a/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
+++ b/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
@@ -159,7 +159,7 @@ Run Nixos Rebuild
                 END
             END
             # Ensure that the device is still alive
-            Wait Until Keyword Succeeds  15s  3s  Ping Host  ${DEVICE_IP_ADDRESS}  allow_fail=${True}
+            Wait Until Keyword Succeeds  15s  3s  Verify Ping Host  ${DEVICE_IP_ADDRESS}  expected_status=${True}
             Sleep                   10
             Log To Console          .   no_newline=true
         ELSE


### PR DESCRIPTION
### Goal
Reduce complexity of the `Check If Device Is Up` keyword.

### Main logic
I was trying to not reinvent the wheel, so I saved the way we check if device is up:
1. Check if device is pingable and SSH is UP
2. If variable ${UART_CAPTURE_ACTIVE} is False Check if Serial is UP, otherwise skip
3. Results of the checks are written to the global variables ${IS_AVAILABLE} and ${CONNECTION_TYPE} 

### Main things that were done:
1. Reduced the quantity of nested keywords, where it's possible, e.q. IF-THEN+FAIL -> Should Be
2. Replaced loops+time measuring with Wait Until Keyword Succeeds
3. Chunked code into keywords with readable names and logic like: 
      A. `KW that gives state` -> 
      B. `KW that checks state given by A` ->
      C. `KW that wait for the check B is passed`
4. Unified arguments  of the `Check If Device Is Up` keyword ${range} and ${timeout} to one ${retry}. It's the same as the WUKS has, and basically just passes argument to WUKS
5. Separated setting global variables from the main code of keyword. If laptop is available or not is not a constant thing and could change during the test run, that's why `${IS_AVAILABLE}` is always used with running `Check If Device Is Up` keyword, because you need to verify current value and install it before using it. Basically it works like returning value from the keyword, but with opportunity to forget to install proper value with `Check If Device Is Up`. It's one of the reason why using global variables outside case of storing constants is a [well-know anti-pattern
](https://stackoverflow.com/questions/18635136/why-are-global-variables-considered-bad-practice-node-js). I think we should reduce using it, it's not a huge problem yet, but of course it's not a goal of this task. Here I just separated it to make its removal easier in the future.

### Runs
|  | SSH + | SSH - |
| :----------- |:--------------:| :-------------:|
| **Serial +** | [ + +, all regression on darter](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6557/artifact/Robot-Framework/test-suites/darter-proANDregression/log.html)             | - +: [${UART_CAPTURE_ACTIVE} is False](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6578/artifact/Robot-Framework/test-suites/SP-T351-1/log.html#s1-s1-k1-k1-k1-k1-k2)                                           , [ ${UART_CAPTURE_ACTIVE} is True](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6569/artifact/Robot-Framework/test-suites/relaybootANDdarter-pro/log.html#s1-s1-s1-t1-k5-k3-k2-k1-k2-k1-k3) |
| **Serial -**      | [+ - ](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6579/artifact/Robot-Framework/test-suites/SP-T351-1/log.html#s1-s1-k1-k1-k1-k1-k1)           | [- -](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6571/artifact/Robot-Framework/test-suites/relaybootANDdarter-pro/log.html#s1-s1-s1-t1-k5-k3-k2-k1-k2-k2)   |


### Found issues
Check Serial never runs on the boot tests because of the ${UART_CAPTURE_ACTIVE} flag set to True
But check serial still could work if device passes boot test and after that reboots in the main section