### PR TITLE
Skip shutdown if it takes 25-35 seconds

### DIFF
--- a/Robot-Framework/test-suites/gui-tests/gui_power.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power.robot
@@ -89,7 +89,11 @@ Shutdown from power menu
     Turn Laptop On and Connect
     Login to laptop   enable_dnd=True
 
-    Should Not Be True    ${elapsed} > ${max_elapsed}    msg=Shutdown took too long: ${elapsed} seconds (expected < ${max_elapsed})
+    IF    ${elapsed} > 35
+        FAIL    Shutdown took too long: ${elapsed} seconds (expected <= ${max_elapsed})
+    ELSE IF    ${elapsed} > ${max_elapsed}
+        SKIP    Known issue: SSRCSP-8613 (Shutdown took too long: ${elapsed} seconds (expected <= ${max_elapsed}))
+    END
 
 Log out and log in from power menu
     [Documentation]   Logout via GUI power menu icon and verify logged out state.

--- a/Robot-Framework/test-suites/security-tests/logging.robot
+++ b/Robot-Framework/test-suites/security-tests/logging.robot
@@ -59,7 +59,7 @@ Check Grafana log forwarding after disconnected state
     ELSE
         Soft Reboot Device And Connect   vm=${HOST}
     END
-    Wait Until Keyword Succeeds  90s  5s  Check VM Log on Grafana     ${id}   ${ADMIN_VM}   5m   ${True}   logtest1_${BUILD_ID}
+    Wait Until Keyword Succeeds  120s  5s  Check VM Log on Grafana     ${id}   ${ADMIN_VM}   5m   ${True}   logtest1_${BUILD_ID}
     Log To Console               Checked that log is forwarded after clearing the iptables rule by reboot
 
 *** Keywords ***

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -4,6 +4,7 @@
 
 | DATE SET   | TEST CASE                                               | TICKET / Additional Data.                                                                     |
 | ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| 18.06.2026 | Shutdown from power menu (25-35 seconds)                | SSRCSP-8613                                                                                   |
 | 15.06.2026 | VM memory usage snapshot (Dell)                         | Dell has less memory than other targets                                                       |
 | 11.06.2026 | Verify booting after restart by power (orin-nx)         | SSRCSP-8585                                                                                   |
 | 11.06.2026 | functional-tests (orin-nx)                              | SSRCSP-8585                                                                                   |


### PR DESCRIPTION
- New skip for shutdown due to https://jira.tii.ae/browse/SSRCSP-8613. `Shutdown from power menu` is skipped if it takes 25-35 seconds and fails if it takes longer than that.
- Extend log search after reboot in `Check Grafana log forwarding after disconnected state`. Orin-NX was too slow last night.

[Gui power tests on Darter](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6622/artifact/Robot-Framework/test-suites/darter-proANDgui-power/report.html#totals)