### PR TITLE
Set RTC device explicitly on Lenovo X1

### DIFF
--- a/Robot-Framework/test-suites/security-tests/timesync.robot
+++ b/Robot-Framework/test-suites/security-tests/timesync.robot
@@ -114,9 +114,11 @@ Set RTC time
     ${original_time}      Get Time	epoch
     Set Test Variable     ${original_time}  ${original_time}
     Log To Console        Setting time ${time}
-    Run Command     hwclock --set --date="${time}"  sudo=True
+    Run Command     hwclock --set --date="${time}" --verbose  sudo=True
     Sleep    3
-    Run Command     hwclock -s  sudo=True
+    # Workaround for SSRCSP-8622
+    ${extra_flag}   Set Variable If   "${DEVICE_TYPE}" == "lenovo-x1" or "${DEVICE_TYPE}" == "x1-sec-boot"   -f /dev/rtc1   ${EMPTY}
+    Run Command     hwclock -s --verbose ${extra_flag}  sudo=True
     Run Command     timedatectl -a
 
 Check time was changed
@@ -151,7 +153,7 @@ Compare local and universal time
 
 Set RTC from system clock
     [Documentation]   Set the Hardware Clock from the System Clock
-    Run Command       hwclock -w  sudo=True
+    Run Command       hwclock -w --verbose  sudo=True
     Run Command       timedatectl -a
 
 Set system time


### PR DESCRIPTION
To be merged after https://github.com/tiiuae/ghaf/pull/1999

- June bump (https://github.com/tiiuae/ghaf/pull/1999) changes Ghaf so that `hwclock` defaults to a wrong RTC device on Lenovo X1. As a workaround set the RTC device explicitly when setting system time from hardware clock. Bug number to be added once PR is merged and bug has been created.
- Enable verbose logging for `hwclock`.

**Testruns**
- [Lenovo X1](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2138/artifact/Robot-Framework/test-suites/lenovo-x1ANDtimesync/report.html#totals)
- [Darter Pro](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6655/artifact/Robot-Framework/test-suites/darter-proANDtimesync/report.html#totals)
- [Dell 7330](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6652/artifact/Robot-Framework/test-suites/dell-7330ANDtimesync/report.html#totals)
- [Orin AGX](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6650/artifact/Robot-Framework/test-suites/orin-agxANDtimesync/report.html#totals)
- [Orin NX](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6653/artifact/Robot-Framework/test-suites/orin-nxANDtimesync/report.html#totals)