### PR TITLE
Add skips for storeDisk image

### DIFF
--- a/Robot-Framework/test-suites/gui-tests/gui_power.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power.robot
@@ -68,6 +68,8 @@ Reboot from power menu
     Log               Reboot took ${elapsed} seconds   console=True
 
     Should Not Be True    ${elapsed} > ${reboot_limit}    msg=Reboot took too long: ${elapsed} seconds (expected < ${reboot_limit})
+    [Teardown]    Run Keywords   GUI Power Test Teardown   AND
+    ...           Run Keyword If Test Failed    Run Keyword If   "storeDisk" in "${JOB}" and "took too long" in $TEST_MESSAGE   SKIP    Known Issue: SSRCSP-8621
 
 Shutdown from power menu
     [Documentation]   Shutdown the device via GUI power menu shutdown icon.
@@ -94,6 +96,8 @@ Shutdown from power menu
     ELSE IF    ${elapsed} > ${max_elapsed}
         SKIP    Known issue: SSRCSP-8613 (Shutdown took too long: ${elapsed} seconds (expected <= ${max_elapsed}))
     END
+    [Teardown]    Run Keywords   GUI Power Test Teardown   AND
+    ...           Run Keyword If Test Failed    Run Keyword If   "storeDisk" in "${JOB}" and "took too long" in $TEST_MESSAGE   SKIP    Known Issue: SSRCSP-8621
 
 Log out and log in from power menu
     [Documentation]   Logout via GUI power menu icon and verify logged out state.

--- a/Robot-Framework/test-suites/security-tests/persistence.robot
+++ b/Robot-Framework/test-suites/security-tests/persistence.robot
@@ -52,6 +52,8 @@ Verify brightness persisted
     [Tags]    SP-T326  SP-T326-1
     ${brightness}     Get screen brightness
     Should Be Equal   ${EXPECTED_BRIGHTNESS}  ${brightness}
+    [Teardown]    Run Keyword If Test Failed    Run Keywords    Log persistence setup errors
+    ...    AND    Run Keyword If    "storeDisk" in "${JOB}"     SKIP   Known Issue: SSRCSP-8623
 
 Verify volume persisted
     [Tags]    SP-T326  SP-T326-2

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -4,6 +4,8 @@
 
 | DATE SET   | TEST CASE                                               | TICKET / Additional Data.                                                                     |
 | ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| 22.06.2026 | Verify brightness persisted (storeDisk)                 | SSRCSP-8623                                                                                   |
+| 22.06.2026 | Shutdown & Reboot from power menu (storeDisk)           | SSRCSP-8621                                                                                   |
 | 18.06.2026 | Shutdown from power menu (25-35 seconds)                | SSRCSP-8613                                                                                   |
 | 15.06.2026 | VM memory usage snapshot (Dell)                         | Dell has less memory than other targets                                                       |
 | 11.06.2026 | Verify booting after restart by power (orin-nx)         | SSRCSP-8585                                                                                   |


### PR DESCRIPTION
To be merged after https://github.com/tiiuae/ghaf/pull/1999

Add skips for storeDisk image
-  `Shutdown from power menu` and `Reboot from power menu` if they take too long
- `Verify brightness persisted` if it fails

[Testrun ](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6659/artifact/Robot-Framework/test-suites/darter-proANDgui-powerORpersistence/report.html#totals)