### PR TITLE
Skip boot teardown after diagnostics

### DIFF
--- a/Robot-Framework/resources/serial_keywords.resource
+++ b/Robot-Framework/resources/serial_keywords.resource
@@ -72,6 +72,7 @@ Check Serial Connection
         Sleep   1
     END
     Delete All Ports
+    Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
     IF  ${status}
         Log To Console       Device is available via serial
         Set Global Variable  ${CONNECTION_TYPE}    serial
@@ -126,11 +127,16 @@ Verify init.scope status via serial
     END
     ${diff}=    Evaluate    int(time.time()) - int(${start_time})
     FAIL    init.scope is not running after ${diff} sec! Status is ${status}
-    [Teardown]       Delete All Ports
+    [Teardown]    Run Keywords    Delete All Ports    AND
+    ...           Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
 
 Connect via serial
     [Arguments]         ${timeout}=1.0
-    ${status}           Open Serial Port    timeout=${timeout}
+    IF  not ${UART_CAPTURE_ACTIVE}
+        ${status}           Open Serial Port    timeout=${timeout}
+    ELSE
+        ${status}    Set Variable    ${True}
+    END
     IF    ${status}
         ${status}   Run Keyword And Return Status    Log In To Ghaf OS
     END
@@ -151,7 +157,8 @@ Save log
         Write Advanced Testlog    journalctl.txt     ${output}
         Log  ${output}
     END
-    [Teardown]           Delete All Ports
+    [Teardown]    Run Keywords    Delete All Ports    AND
+    ...           Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
 
 Get ethernet IP address
     ${status}            Connect via serial
@@ -163,7 +170,8 @@ Get ethernet IP address
     ELSE
         FAIL     There is no serial connection. Couldn't get IP address.
     END
-    [Teardown]           Delete All Ports
+    [Teardown]    Run Keywords    Delete All Ports    AND
+    ...           Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
 
 Verify shutdown via serial
     [Documentation]   Reading serial port and expects 'System Power Off' text.
@@ -185,7 +193,8 @@ Verify shutdown via serial
     END
     ${time}           BuiltIn.Get Time   epoch
     RETURN            ${time}
-    [Teardown]        Delete All Ports
+    [Teardown]    Run Keywords    Delete All Ports    AND
+    ...           Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
 
 Run Command On Serial
     [Documentation]    Run a host command on the serial console and wait for the shell prompt.
@@ -217,6 +226,7 @@ Run Command On Serial
     ${output}    SerialLibrary.Read Until    terminator=ghaf@${HOST}:
     IF    ${opened_here}
         Delete All Ports
+        Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
     END
     ${clean_output}    Normalize Serial Output    ${output}
     ${lower_output}    Convert To Lowercase    ${clean_output}
@@ -295,6 +305,7 @@ Run Command on VM Via Serial
     END
     IF    ${opened_here}
         Delete All Ports
+        Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
     END
     ${clean_output}    Normalize Serial Output    ${prompt_output}
     Log                ${clean_output}

--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -83,6 +83,7 @@ Verify booting laptop
     ELSE IF  "${CONNECTION_TYPE}" == "serial"
         Verify init.scope status via serial
     END
+
     [Teardown]   Test Teardown
 
 Turn OFF Device
@@ -179,18 +180,18 @@ Break the system
 *** Keywords ***
 
 Test Teardown
-    Run Keyword If    "${DEVICE_TYPE}" == "orin-nx"
-    ...    Run Keyword If Test Failed    Skip    Known issue: SSRCSP-8585, orin-nx fails ssh on some boots
-    IF  ${IS_AVAILABLE}
+    IF  ${IS_AVAILABLE} and ${IS_LAPTOP}
         IF  "${CONNECTION_TYPE}" == "ssh"
             Run Keyword If Test Failed    Run Keyword And Ignore Error    ssh_keywords.Save log
         ELSE IF  "${CONNECTION_TYPE}" == "serial"
-            Run Keyword If Test Failed    Run Keyword And Ignore Error    ssh_keywords.Save log
+            Run Keyword If Test Failed    Run Keyword And Ignore Error    serial_keywords.Save log
         END
     END
     IF  not ${IS_LAPTOP}
-        Run Keyword If Test Failed    Collect Failure Diagnostics Via Serial
+        Run Keyword If Test Failed    Run Keyword And Ignore Error    Collect Failure Diagnostics Via Serial
     END
+    Run Keyword If    "${DEVICE_TYPE}" == "orin-nx"
+    ...    Run Keyword If Test Failed    Skip    Known issue: SSRCSP-8585, orin-nx fails ssh on some boots
     IF    ${UART_CAPTURE_ACTIVE} and not ${SAVE_BOOT_LOGS_ON_PASS}
         Run Keyword If Test Passed    OperatingSystem.Remove File    ${UART_CAPTURE_FILE}
     END
@@ -198,6 +199,7 @@ Test Teardown
 Teardown
     Close All Connections
     Delete All Ports
+    Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
     Close Relay Board Connection
 
 Run ghaf-installer

--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -76,7 +76,8 @@ Check serial connection
         Sleep   1
     END
     IF    ${status} == False   Fail  Device is not available via serial port, used port: ${SERIAL_PORT}
-    [Teardown]  Delete All Ports
+    [Teardown]    Run Keywords    Delete All Ports    AND
+    ...           Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
 
 Check storage size
     [Documentation]  Check that there is enough persistent storage available


### PR DESCRIPTION
Allow collection of diagnostics for orin-nx in teardown if boot test failed instead of skipping in the beginning of teardown.

Don't apply 'Save log' to Orins because we expect 'Collect Failure Diagnostics Via Serial' to do the same and more.

Fix bug:
Use 'serial_keywords.Save log' when connection type is "serial".

Fix issue with 'Connect via serial' failing if serial port was already open.

Boot test on Orin NX (ssh happened to fail on this run)
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6682/

Boot test on Lenovo-X1 (with forced `Set Global Variable    ${CONNECTION_TYPE} serial` and `FAIL`):
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6684/
Another run after also fixing an issue with `Connect via serial` if serial port is already open (UART capture active): 
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6685/