### PR TITLE
Add more logging for Grafana test

### DIFF
--- a/Robot-Framework/resources/service_keywords.resource
+++ b/Robot-Framework/resources/service_keywords.resource
@@ -196,6 +196,7 @@ Check systemctl status for known issues
             Append To List    ${new_issues}    ${failing_service}
         END
     END
+    Run Command  logger --priority=user.info "ROBOT_LOG (systemctl status): Known failed services ${old_issues} failed on ${DEVICE_TYPE}, job ${JOB}"
     IF   ${new_issues} != []
         Fail    Unexpected failed services in ${vm}: ${new_issues}, known failed services: ${old_issues}
     ELSE

--- a/Robot-Framework/test-suites/functional-tests/logging.robot
+++ b/Robot-Framework/test-suites/functional-tests/logging.robot
@@ -63,6 +63,7 @@ Check Grafana logs
     ${failed_vms_check_1}   Check Logs Are Available   ${id}  since=3m  word=${TEST_LOG}
     ${check_status}         Run Keyword And Return Status    Should Be Empty   ${failed_vms_check_1}
     IF  not ${check_status}
+        Run Keyword And Ignore Error   Save logging logs from VMs    ${failed_vms_check_1}
         ${since_boot}  Get Time Since Last Boot
         ${failed_vms_check_2}   Check Logs Are available   ${id}   since=${since_boot}s
         ${check_status}         Run Keyword And Return Status    Should Be Empty   ${failed_vms_check_2}
@@ -200,11 +201,24 @@ Check Logs Are Available
     RETURN  ${failed_vms}
 
 Create logs in all VMs
-    [Documentation]    Create new SSH connection to all VMs to make sure there are recent logs
-    Close All Connections
+    [Documentation]    Create a logger log in all VMs
     FOR  ${vm}  IN  @{VM_LIST}
         Switch to vm   ${vm}
         Run Command  logger --priority=user.info "${TEST_LOG}"
         ${out}   Run Command    journalctl --since "1 minute ago" | grep "${TEST_LOG}"
         Run Keyword And Continue On Failure   Should Contain  ${out}   ${TEST_LOG}   Log was not created in ${vm}
+    END
+
+Save logging logs from VMs
+    [Arguments]    ${failed_vms}
+    FOR    ${vm}    IN    @{failed_vms}
+        Switch to vm    ${vm}
+        IF    '${vm}' == '${ADMIN_VM}'
+            ${service}    Set Variable    systemd-journal-remote.service
+        ELSE
+            ${service}    Set Variable    systemd-journal-upload.service
+        END
+        Log    Collecting journalctl output from ${vm}    console=True
+        Run Command    journalctl -b -u ${service}
+        Run Command    journalctl -b
     END

--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -60,8 +60,10 @@ VM memory usage snapshot
         IF    ${mem_avail_pct} < ${low_mem_limit}
             Run Keyword And Continue On Failure    FAIL    ${vm} available memory is below ${low_mem_limit}% of the total memory
         END
-        IF    ${swap_free_pct} < ${low_swap_limit}
+        IF    ${swap_free_pct} < ${low_swap_limit} and not ("orin" in "${DEVICE_TYPE}" and "${vm}" == "${HOST}")
             Run Keyword And Continue On Failure    FAIL    ${vm} swap free is below ${low_swap_limit}% of the total swap
+        ELSE IF    "orin" in "${DEVICE_TYPE}" and "${vm}" == "${HOST}"
+            Log    Skipping swap threshold check for ${HOST} because it has no swap on Orin targets    console=True
         END
         Log    Memory in ${vm}: avail ${mem_avail_mib}/${mem_total_mib} MiB, swap free ${swap_free_mib}/${swap_total_mib} MiB    console=True
         Set To Dictionary    ${mem_data}    mem_avail_mib__${vm}=${mem_avail_mib}


### PR DESCRIPTION
- Save journalctl logs from VMs where logging has stopped ([testrun of this](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6679/artifact/Robot-Framework/test-suites/SP-T172/log.html#s1-s1-s1-t1-k7-k1-k1))
- Log known failed services to Grafana to make it easier to keep track of services that are still failing, for example
`ROBOT_LOG (systemctl status): Known failed services ['journal-fss-verify.service'] failed on darter-pro, job darter-pro`
- Exclude Orin ghaf-host from the swap limit check, Orins don't have swap enabled on host

**Testruns**
- [Darter Pro](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6688/artifact/Robot-Framework/test-suites/darter-proANDpre-mergeORmemory_usage/report.html#totals) pre-merge and memory_usage (with a failed known service)
- [Orin AGX ](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6673/artifact/Robot-Framework/test-suites/memory_usageORorin-agxANDsystemctl/log.html#s1-s2-s1-t1)memory_usage