### PR TITLE
Add parsing and pinging gateway

### DIFF
--- a/Robot-Framework/resources/wifi_keywords.resource
+++ b/Robot-Framework/resources/wifi_keywords.resource
@@ -64,6 +64,18 @@ Get wifi IP
     END
     IF   ${status} == False    FAIL    NetVM hasn't gotten an IP
 
+Get gateway
+    [Documentation]     Parse route table and return gateway for the default route of selected interface type
+    [Arguments]         ${interface}=wifi
+    ${if_name}          Get Interface name   ${interface}
+    ${output}           Run Command          route -n
+    ${pattern}          Set Variable         (?m)^0\\.0\\.0\\.0\\s+(\\S+)\\s+.*\\s${if_name}\\s*$
+    @{matches}          Get Regexp Matches   ${output}    ${pattern}    1
+    Should Not Be Empty    ${matches}    Could not find gateway for interface ${if_name} in route table
+    ${gateway}          Get From List        ${matches}    0
+    Log                 ${interface} gateway is ${gateway}    console=True
+    RETURN              ${gateway}
+
 Verify nmcli device status
     [Documentation]    Check state of the interface in the output of `nmcli device status`
     ...                and compare with expected: connected | disconnected | absent

--- a/Robot-Framework/test-suites/functional-tests/net-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/net-vm.robot
@@ -35,12 +35,14 @@ Wifi passthrough into NetVM
     Turn OFF WiFi       ${TEST_WIFI_SSID}
     Sleep               1
     ${pass_status}    ${output}   Run Keyword And Ignore Error    Get wifi IP
-        IF    $pass_status=='PASS'
-            FAIL    Expected: no IP address on wifi interface after turning wifi off.
-        END
+    IF    $pass_status=='PASS'
+        FAIL    Expected: no IP address on wifi interface after turning wifi off.
+    END
     Turn ON WiFi        ${TEST_WIFI_SSID}
     Get wifi IP
-    Check Network Availability   8.8.8.8   limit_freq=${False}   interface=wifi
+    ${gateway}          Get gateway    wifi
+    Check Network Availability   ${gateway}   range=20   limit_freq=${False}   interface=wifi
+    Check Network Availability   8.8.8.8      range=20   limit_freq=${False}   interface=wifi
     [Teardown]          Run Keywords  Remove Wifi configuration  ${TEST_WIFI_SSID}  AND  Close All Connections
 
 Ethernet passthrough into NetVM

--- a/Robot-Framework/test-suites/security-tests/killswitch.robot
+++ b/Robot-Framework/test-suites/security-tests/killswitch.robot
@@ -38,12 +38,13 @@ Killswitch disconnects WLAN
     [Tags]           SP-T304  lab-only
     [Setup]          WLAN setup
     Verify nmcli device status    ${wifi_if}  connected
-    Check Network Availability    8.8.8.8     expected_result=True    limit_freq=${False}    interface=${wifi_if}
+    ${gateway}     Get gateway    wifi
+    Check Network Availability    ${gateway}     expected_result=True    limit_freq=${False}    interface=${wifi_if}
     Set device state   blocked    net
     Switch to vm       ${NET_VM}
     Verify nmcli device status    ${wifi_if}  absent
-    Check Network Availability    8.8.8.8     expected_result=False   limit_freq=${False}    interface=${wifi_if}
-    Check Network Availability    8.8.8.8     expected_result=True    limit_freq=${False}    interface=eth
+    Check Network Availability    ${gateway}     expected_result=False   limit_freq=${False}
+    Check Network Availability    8.8.8.8        expected_result=True    limit_freq=${False}    interface=eth
     Set device state   unblocked    net
     Remove Wifi configuration       ${TEST_WIFI_SSID}
     Wait Until Keyword Succeeds     10x   1s   Scan for Wifi   ${TEST_WIFI_SSID}


### PR DESCRIPTION
- Now in 'Wifi passthrough into NetVM' ping also gateway and the internet with increased amount of iterations.
- In 'Killswitch disconnects WLAN' ping only gateway

[Darter DEV](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6712/)
[Darter PROD](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2162/) all passed