### PR TITLE
Remove 25-35 second shutdown skip

### DIFF
--- a/Robot-Framework/test-suites/gui-tests/gui_power.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power.robot
@@ -91,11 +91,7 @@ Shutdown from power menu
     Turn Laptop On and Connect
     Login to laptop   enable_dnd=True
 
-    IF    ${elapsed} > 35
-        FAIL    Shutdown took too long: ${elapsed} seconds (expected <= ${max_elapsed})
-    ELSE IF    ${elapsed} > ${max_elapsed}
-        SKIP    Known issue: SSRCSP-8613 (Shutdown took too long: ${elapsed} seconds (expected <= ${max_elapsed}))
-    END
+    Should Not Be True    ${elapsed} > ${max_elapsed}    msg=Shutdown took too long: ${elapsed} seconds (expected < ${max_elapsed})
     [Teardown]    Run Keywords   GUI Power Test Teardown   AND
     ...           Run Keyword If Test Failed    Run Keyword If   "storeDisk" in "${JOB}" and "took too long" in $TEST_MESSAGE   SKIP    Known Issue: SSRCSP-8621
 

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -6,7 +6,6 @@
 | ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | 22.06.2026 | Verify brightness persisted (storeDisk)                 | SSRCSP-8623                                                                                   |
 | 22.06.2026 | Shutdown & Reboot from power menu (storeDisk)           | SSRCSP-8621                                                                                   |
-| 18.06.2026 | Shutdown from power menu (25-35 seconds)                | SSRCSP-8613                                                                                   |
 | 15.06.2026 | VM memory usage snapshot (Dell)                         | Dell has less memory than other targets                                                       |
 | 11.06.2026 | Verify booting after restart by power (orin-nx)         | SSRCSP-8585                                                                                   |
 | 11.06.2026 | functional-tests (orin-nx)                              | SSRCSP-8585                                                                                   |


### PR DESCRIPTION
Issue was fixed https://github.com/tiiuae/ghaf/pull/2003

Shutdown times from last nightly run
- `intel-laptop-debug`
  - Lenovo X1: `Shutdown took 20 seconds`
  - Secure Boot X1: `Shutdown took 20 seconds`
  - Darter Pro: `Shutdown took 19 seconds`
- `intel-laptop-debug-installer`
  - Lenovo X1: `Shutdown took 20 seconds`
- `intel-laptop-storeDisk-debug-installer`
  - Darter Pro: `Shutdown took 39 seconds` (this one still has a separate skip)

[Testrun](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6719/artifact/Robot-Framework/test-suites/gui-power/report.html#totals)
