### PR TITLE
Add a test for GUI lockout after failed login

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -33,13 +33,7 @@ Log in, unlock and verify
     ${logout_status}    Check if logged out   1
     IF  ${logout_status}
         Log in via GUI
-        ${status}    ${output}    Run Keyword And Ignore Error    Wait Until Keyword Succeeds    60s    1s    Verify login session
-        IF    '${status}' == 'FAIL'
-            Log To Console    Login session verification failed, retrying GUI login
-            Run Command       logger --priority=user.info "ROBOT_LOG: Login failed on ${DEVICE_TYPE}, job ${JOB}"
-            Log in via GUI
-            Wait Until Keyword Succeeds    60s    1s    Verify login session
-        END
+        Wait Until Keyword Succeeds    10s    1s    Verify login session
     ELSE
         ${lock}       Check if locked
         IF  ${lock}   Unlock
@@ -73,16 +67,17 @@ Log out and verify
 
 Log in via GUI
     [Documentation]   Log in by typing password
+    [Arguments]       ${password}=${USER_PASSWORD}   ${sleep_seconds}=5
     Log To Console    Logging in
     Wait Until Keyword Succeeds    60s    1s    Verify login session    greeter
     # Sleep is needed to make sure that greeter is ready, screenshots can't be used because greeter has control of the screen
-    Sleep    5
+    Sleep    ${sleep_seconds}
     # Make sure that password field is active by clicking on screen
     Run ydotool command   mousemove --absolute -x 50 -y 50   sudo=True
     Click   sudo=True
 
     IF  "${DEVICE_TYPE}" == "dell-7330"    Sleep  5
-    Confidential password write  ${USER_PASSWORD}
+    Confidential password write  ${password}
 
 Log out with loginctl
     [Documentation]   Log out from the laptop
@@ -326,9 +321,7 @@ Confidential password write
     Sleep            0.5
     ${output} 	     SSHLibrary.Read
     Write            printf '%s' "$PASSWD" | YDOTOOL_SOCKET=${YDOTOOL_SOCKET} ydotool type -f -
-    Sleep            3
-    ${output} 	     SSHLibrary.Read
-    Should Contain 	 ${output}    ${LOGIN}@
+    ${output}        SSHLibrary.Read Until    ${LOGIN}@
     Write            unset PASSWD
     Set Log Level    INFO
     Press Key(s)     ENTER   True
@@ -411,7 +404,7 @@ Kill Initial Setup
     ${status}   ${output}   Run Keyword And Ignore Error   Check file exists   .config/cosmic-initial-setup-done
     IF   $status == 'FAIL'
         # Wait for the initial setup to start
-        Run Keyword and Ignore Error     Check that the application was started   cosmic-initial-setup   range=15
+        Run Keyword and Ignore Error     Check that the application was started   cosmic-initial-setup   range=5
         # Wait until Ghaf theme is applied, this does not happen if initial setup is killed too fast
         Wait Until Keyword Succeeds   10s   0.5s   Check file exists   .config/cosmic/com.system76.CosmicTheme*
         Sleep    1

--- a/Robot-Framework/test-suites/gui-tests/gui_security.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_security.robot
@@ -39,6 +39,23 @@ Check Access List In Trusted Browser
     https://hcm22.sapsf.com                 text_to_find=SAP SuccessFactors
     https://jira.atlassian.com              text_to_find=Jira Software
 
+Account lockout after failed GUI login
+    [Documentation]     Try to login to the device with a wrong password for several times, then check that user account is locked.
+    ...                 Remove account from the lock list and log back in with the correct password.
+    [Tags]              SP-T267  lenovo-x1  darter-pro
+    Log out and verify
+    Check faillock entry count    0
+    # Account is locked after wrong password is given 5 times
+    FOR   ${i}   IN RANGE   1   6
+        Log              Typing wrong password (iteration #${i})   console=True
+        Log in via GUI   password=wrong_password   sleep_seconds=1
+        Wait Until Keyword Succeeds    10x    1s    Check faillock entry count    ${i}
+    END
+    Log     Trying to login with correct password   console=True
+    Run Keyword And Expect Error     *    Log in, unlock and verify
+    [Teardown]       Run keywords    Unlock account and login
+    ...                       AND    Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
+
 *** Keywords ***
 
 Check Access List In Trusted Browser Template
@@ -55,3 +72,21 @@ Check Access List In Trusted Browser Template
 
     [Teardown]    Run keywords      Switch to vm           ${BUSINESS_VM}    AND
     ...                             Kill process by name   google-chrome
+
+Unlock account and login
+    [Documentation]  Unlock the user account and log back in
+    [Setup]          Switch to vm     ${GUI_VM}
+    Run Command      faillock --user ${USER_LOGIN} --reset   sudo=True
+    Switch to vm     ${GUI_VM}  user=${USER_LOGIN}
+    # First login after unlocking the account fails
+    Log in via GUI   password=reset_login   sleep_seconds=1
+    Log in, unlock and verify
+
+Check faillock entry count
+    [Documentation]    Verify that the current faillock entry count matches ${expected_count}
+    [Arguments]        ${expected_count}
+    [Setup]       Switch to vm    ${GUI_VM}
+    ${count}      Run Command    faillock --user ${USER_LOGIN} | grep -c '^[0-9]'    sudo=True    rc_match=skip
+    Should Be Equal As Integers    ${count}    ${expected_count}
+    Log           Wrong password detected ${expected_count} times    console=True
+    [Teardown]    Switch to vm    ${GUI_VM}    user=${USER_LOGIN}

--- a/Robot-Framework/test-suites/security-tests/network.robot
+++ b/Robot-Framework/test-suites/security-tests/network.robot
@@ -14,7 +14,7 @@ Resource            ../../resources/security_blacklist_keywords.resource
 
 *** Test Cases ***
 
-Account lockout after failed login
+Account lockout after failed SSH login
     [Documentation]  Try to connect from the external test agent to the device with a wrong password for several times, then check that
     ...              test agent's ip is blacklisted in net-vm and it is not possible to connect even with correct password.
     ...              Remove IP from blacklist via serial and verify SSH connectivity is restored.


### PR DESCRIPTION
Add a GUI version for `Account lockout after failed login`. Test tries to use wrong password 5 times in a row when logging in via GUI and then checks that the account is locked.

Screen recording does not work on the login screen so no video of this test. This could cause issues if the test is flaky, but in my local testing it has been very stable.

[Lenovo X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6749/artifact/Robot-Framework/test-suites/lenovo-x1ANDguiNOTstoreDisk-only/report.html#totals)
[Darter Pro](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6750/artifact/Robot-Framework/test-suites/darter-proANDguiNOTstoreDisk-only/report.html#totals) (`Port already exists.` failed in the nightly too)