### PR TITLE
Prevent failures due to open serial port

### DIFF
--- a/Robot-Framework/resources/serial_keywords.resource
+++ b/Robot-Framework/resources/serial_keywords.resource
@@ -14,18 +14,31 @@ Resource            ../resources/device_control.resource
 
 *** Keywords ***
 
+Add Configured Serial Port
+    [Arguments]   ${timeout}=2.0
+    Add Port      ${SERIAL_PORT}
+    ...           baudrate=115200
+    ...           bytesize=8
+    ...           parity=N
+    ...           stopbits=1
+    ...           timeout=${timeout}
+
 Open Serial Port
     [Arguments]   ${timeout}=2.0
+    IF  "${SERIAL_PORT}" == "NONE"
+        RETURN  False
+    END
     TRY
-        Add Port      ${SERIAL_PORT}
-        ...           baudrate=115200
-        ...           bytesize=8
-        ...           parity=N
-        ...           stopbits=1
-        ...           timeout=${timeout}
-        Log           Opened serial port ${SERIAL_PORT}     console=True
+        Add Configured Serial Port    ${timeout}
+        Log       Opened serial port ${SERIAL_PORT}     console=True
         RETURN    True
-    EXCEPT   	SerialException: [Errno 2] could not open port ${SERIAL_PORT}: [Errno 2] No such file or directory: '${SERIAL_PORT}'
+    EXCEPT    *Port already*    type=GLOB
+        Log       Serial port ${SERIAL_PORT} was left open by an earlier step. Resetting serial ports and retrying.    console=True
+        Delete All Ports
+        Add Configured Serial Port    ${timeout}
+        Log       Opened serial port ${SERIAL_PORT} after resetting stale serial state     console=True
+        RETURN    True
+    EXCEPT    *No such file or directory*    type=GLOB
         RETURN    False
     END
 
@@ -65,7 +78,8 @@ Check Serial Connection
     ${serial_status}=   Open Serial Port
     Should Not Be Equal    ${serial_status}    False    msg=Serial port is not available
     Wait Until Keyword Succeeds    ${range}    1s    Check For Text In Serial Port    text=ghaf
-    Delete All Ports
+    [Teardown]    Run Keywords    Delete All Ports    AND
+    ...           Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
 
 Check For Text In Serial Port
     [Arguments]    ${text}

--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -106,11 +106,9 @@ Check Secure Boot is enabled
 *** Keywords ***
 
 Serial setup
-    IF  "${SERIAL_PORT}" == "NONE"
-        Skip    There is no address for serial connection
-    ELSE
-        ${status}   Open Serial Port
-        IF    ${status}==False    SKIP    Serial Port is not available
+    ${status}   Open Serial Port
+    IF  ${status}==False
+        SKIP    Serial Port is not available
     END
 
 Verify Ghaf Version Format


### PR DESCRIPTION
There has been some occasions where `Check Serial Connection` fails before reaching its trailing `Delete All Ports`. This has caused following `Open Serial Port` to hit stale SerialLibrary serial port state causing failures: "Port already exists."

Fixing this by:
- Ensure by teardown that ports are always deleted in `Check Serial Connection`.
- Handle already open serial port gracefully in `Open Serial Port`.

Regression tests:

darter-pro
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6757/

orin-agx-64
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6758/