### PR TITLE
Refactor device control keywords

### DIFF
--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -67,19 +67,6 @@ Turn Laptop On
         Press Button      ${SWITCH_BOT}-Enter
     END
 
-Turn Laptop On and Connect
-    Log To Console     ${\n}Booting the device by pressing the power button
-    Turn Laptop On
-    Check If Device Is Up
-    IF    ${IS_AVAILABLE} == False
-        FAIL    The device did not start
-    ELSE IF  "${CONNECTION_TYPE}" == "serial"
-        FAIL    The device is available only via serial, but tests require SSH.
-    ELSE
-        Log To Console  The device started
-    END
-    Switch to vm    ${NET_VM}
-
 Soft Reboot Device And Connect
     [Documentation]  Reboot device from ${vm} and connect after the reboot
     [Arguments]      ${vm}=${HOST}
@@ -94,9 +81,18 @@ Soft Reboot Device And Connect
         FAIL    Soft reboot failed.
     END
 
+Hard Reboot Device And Connect
+    [Arguments]     ${verify_shutdown}=True
+    IF  ${IS_LAPTOP}
+        Reboot Laptop    verify_shutdown=${verify_shutdown}
+    ELSE
+        Reboot Orin
+    END
+    Connect After Reboot
+
 Collect Logs After Failed Soft Reboot
     [Arguments]    ${since}
-    Check If Device Is Up
+    Check If Device Is Up   retry=5x
     IF    ${IS_AVAILABLE}
         IF  "${CONNECTION_TYPE}" == "ssh"
             Run Keyword And Continue On Failure    ssh_keywords.Save log   ${HOST}    ${since}
@@ -144,30 +140,16 @@ Connect After Reboot
             Check If Device Is Up   retry=5x
             IF   ${IS_AVAILABLE} == True and "${CONNECTION_TYPE}" == "ssh"   BREAK
         END
+        Check If Device Is Available   retry=5x    action=reboot
     ELSE
-        Check If Device Is Up         retry=60x
-    END
-    
-    IF    ${IS_AVAILABLE} == False
-        FAIL                      The device did shut down but didn't start in reboot.
-    ELSE IF  "${CONNECTION_TYPE}" == "serial"
-        FAIL    The device is available only via serial, but tests require SSH.
-    ELSE
-        Log To Console            Device started
-        Switch to vm    ${NET_VM}
+        Check If Device Is Available   retry=60s   action=reboot
     END
 
 Wake up device
+    [Documentation]   Wake up a laptop that was suspended
     Log To Console    Pressing the power button...
     Press Button      ${SWITCH_BOT}-ON
-    Check If Device Is Up    retry=30x
-    IF    ${IS_AVAILABLE} == False
-        FAIL             The device did suspend but failed to wake up
-    ELSE IF  "${CONNECTION_TYPE}" == "serial"
-        FAIL    The device is available only via serial, but tests require SSH.
-    ELSE
-        Log To Console   Device successfully woke up after suspend
-    END
+    Check If Device Is Available    retry=30s   action=suspend
 
 Wait Until Device Is Down
     [Arguments]    ${power_off}=${False}
@@ -217,8 +199,5 @@ Verify shutdown via network
 Reboot Orin if ssh connection dropped
     ${ssh_available}  Run Keyword And Return Status    Run Command    ls  timeout=5
     IF  not ${ssh_available} and "orin" in "${DEVICE_TYPE}"
-        Reboot Orin
-        Close All Connections
-        Check If Device Is Up
-        Switch to vm                ${NET_VM}   timeout=120
+        Hard Reboot Device And Connect
     END

--- a/Robot-Framework/resources/serial_keywords.resource
+++ b/Robot-Framework/resources/serial_keywords.resource
@@ -360,7 +360,7 @@ Drain Serial Output
         IF    ${elapsed} >= ${max_seconds}
             BREAK
         END
-        ${status}    ${output}    Run Keyword And Ignore Error    SerialLibrary.Read Until    terminator=${\n}
+        ${status}    ${output}    Run Keyword And Ignore Error    SerialLibrary.Read All Data
         IF    '${status}' != 'PASS'
             BREAK
         END

--- a/Robot-Framework/resources/setup_keywords.resource
+++ b/Robot-Framework/resources/setup_keywords.resource
@@ -20,14 +20,7 @@ ${ROBOT_SUDOERS_BOOT_ID}     ${EMPTY}
 Prepare Test Environment
     [Arguments]   ${enable_dnd}=False
     [Timeout]     5 minutes
-    Check If Device Is Up    retry=5x
-    IF    ${IS_AVAILABLE} == False
-        FAIL    The device is not available via SSH or serial.
-    ELSE IF  "${CONNECTION_TYPE}" == "serial"
-        FAIL    The device is available only via serial, but tests require SSH.
-    END
-    Close All Connections
-    Switch to vm          ${HOST}
+    Check If Device Is Available
     ${timestamp}          Run Command    date '+%Y-%m-%d %H:%M:%S'
     Set Suite Variable    ${SUITE_START_TIME}   ${timestamp}
 

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -120,11 +120,24 @@ Check Network Availability
     FAIL    Expected availability of ${host}: ${expected_result}, in fact: ${availability}
 
 Check If Device Is Up
-    [Arguments]    ${retry}=500s
+    [Arguments]    ${retry}=100s
     ${ssh_status}=       Try To Check Ssh On Device  retry=${retry}  interval=${PING_SPACING}s
     ${serial_status}=    Run Keyword If   not ${ssh_status}    Try To Check Serial On Device    range=3x
 
     Set Global Device Availability Variables     ${ssh_status}   ${serial_status}
+
+Check If Device Is Available
+    [Arguments]     ${retry}=5x   ${action}=${EMPTY}
+    Check If Device Is Up    retry=${retry}
+    ${extra_log}    Set Variable If   '${action}'!='${EMPTY}'   after ${action}    for tests
+    IF    ${IS_AVAILABLE} == False
+        FAIL    The device is not available via SSH or serial ${extra_log}.
+    ELSE IF  "${CONNECTION_TYPE}" == "serial"
+        FAIL    The device is available only via serial ${extra_log}, but SSH is required.
+    ELSE
+        Log To Console   Device is available ${extra_log}.
+    END
+    Switch to vm     ${NET_VM}
 
 Try To Check Ssh On Device
     [Arguments]    ${retry}   ${interval}

--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -122,11 +122,11 @@ Run installer
     [Documentation]   Reboot laptop and run installer, will not turn off after test, boot test is required after this
     [Tags]            installer  lenovo-x1  darter-pro
     Reboot Laptop     verify_shutdown=False
-    Check If Device Is Up
+    Check If Device Is Up   retry=100s
     IF    ${IS_AVAILABLE} == False
         Log To Console    Turning device on again...
         Turn Laptop On
-        Check If Device Is Up
+        Check If Device Is Up   retry=100s
     END
     Run Keyword If    ${IS_AVAILABLE} == False   FAIL    The device did not start
 
@@ -143,7 +143,7 @@ Wipe installed Ghaf from internal memory
     [Tags]            wiping  lenovo-x1  darter-pro
     Log To Console    ${\n}Turning device on...
     Turn Laptop On
-    Check If Device Is Up   retry=60x
+    Check If Device Is Up   retry=60s
     Run Keyword If    ${IS_AVAILABLE} == False   FAIL    The device did not start
 
     IF  "${CONNECTION_TYPE}" == "ssh"
@@ -159,7 +159,7 @@ Break the system
     Check If Device Is Up    retry=5x
     IF    ${IS_AVAILABLE} == False
         Turn Laptop On
-        Check If Device Is Up    retry=240x
+        Check If Device Is Up    retry=240s
         IF    ${IS_AVAILABLE} == False
             FAIL    Darter is not available, Wiping is not possible, requires manual maintenance.
         END

--- a/Robot-Framework/test-suites/gui-tests/gui_power.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power.robot
@@ -88,7 +88,8 @@ Shutdown from power menu
     ELSE
         Wait          10
     END
-    Turn Laptop On and Connect
+    Turn Laptop On
+    Connect After Reboot
     Login to laptop   enable_dnd=True
 
     Should Not Be True    ${elapsed} > ${max_elapsed}    msg=Shutdown took too long: ${elapsed} seconds (expected < ${max_elapsed})
@@ -136,8 +137,7 @@ GUI Power Test Teardown
     ${needs_reboot_recovery}    Evaluate
     ...    ($TEST_STATUS == 'FAIL' and 'took too long' not in $TEST_MESSAGE) or ($TEST_STATUS == 'SKIP' and 'SSRCSP-8490' in $TEST_MESSAGE)
     IF  ${needs_reboot_recovery}
-        Reboot Laptop
-        Connect After Reboot
+        Hard Reboot Device And Connect
         IF    ${IS_AVAILABLE}
             ssh_keywords.Save log   ${GUI_VM}  ${gui_power_log_since}
             ssh_keywords.Save log   ${HOST}    ${gui_power_log_since}

--- a/Robot-Framework/test-suites/performance-tests/ballooning.robot
+++ b/Robot-Framework/test-suites/performance-tests/ballooning.robot
@@ -182,9 +182,8 @@ Plot ballooning
     Log   <img src="${REL_PLOT_DIR}mem_ballooning_${id}.png" alt="Power plot" width="1200">    HTML
 
 Procedure After Timeout
-    Reboot Laptop
     ${rebooted}     Set Variable  True
-    Check If Device Is Up
+    Hard Reboot Device And Connect
     Login to laptop
 
 Clean Test Files

--- a/Robot-Framework/test-suites/performance-tests/boot_time.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time.robot
@@ -18,6 +18,7 @@ Resource            ../../resources/ssh_keywords.resource
 Variables           ../../lib/performance_thresholds.py
 
 Suite Teardown      Close All Connections
+Test Teardown       Boot Time Test Teardown
 
 *** Variables ***
 ${PING_TIMEOUT}     180
@@ -31,21 +32,18 @@ Measure Soft Boot Time
     [Tags]           SP-T187  SP-T187-1  lenovo-x1  dell-7330
     Soft Reboot Device
     Get Boot times
-    [Teardown]                    Boot Time Test Teardown
 
 Measure Hard Boot Time
     [Documentation]  Measure how long it takes to device to boot up with hard reboot
     [Tags]           SP-T182  SP-T182-1  lenovo-x1  darter-pro  dell-7330  lab-only
     Reboot Laptop
     Get Boot times                plot_name=Hard Boot Times
-    [Teardown]                    Boot Time Test Teardown
 
 Measure Orin Soft Boot Time
     [Documentation]  Measure how long it takes to device to boot up with soft reboot
     [Tags]           SP-T187  SP-T187-2  orin-agx  orin-agx-64  orin-nx
     Soft Reboot Device
     Get Time To Ping
-    [Teardown]                    Orin Boot Time Test Teardown
 
 Measure Orin Hard Boot Time
     [Documentation]  Measure how long it takes to device to boot up with hard reboot
@@ -58,7 +56,6 @@ Measure Orin Hard Boot Time
     Log To Console                Booting the device by switching the power on
     Turn On Power
     Get Time To Ping              plot_name=Hard Boot Times
-    [Teardown]                    Orin Boot Time Test Teardown
 
 
 *** Keywords ***
@@ -150,15 +147,12 @@ Log Journal To Debug
 
 Boot Time Test Teardown
     Run Keyword If Test Failed   Failed Boot Time Test Teardown
-    Login to laptop
+    IF   ${IS_LAPTOP}    Login to laptop
 
 Failed Boot Time Test Teardown
-    Reboot Laptop
-    Connect After Reboot
-    Switch to vm          ${HOST}
-    Log Journal To Debug  boot=-1
+    Hard Reboot Device And Connect
+    IF   ${IS_LAPTOP}
+        Switch to vm          ${HOST}
+        Log Journal To Debug  boot=-1
+    END
 
-Orin Boot Time Test Teardown
-    Run Keyword If Test Failed  Reboot Orin
-    Run Keyword If Test Failed  Check If Device Is Up
-    Switch to vm                ${NET_VM}   timeout=120

--- a/Robot-Framework/test-suites/security-tests/firewall.robot
+++ b/Robot-Framework/test-suites/security-tests/firewall.robot
@@ -244,11 +244,5 @@ Tcp Syn Flood
     END
 
 Blacklist Teardown
-    IF  $IS_LAPTOP == 'True'
-        Reboot Laptop
-    ELSE
-        Reboot Orin
-    END
-    Close All Connections
-    Connect After Reboot
+    Hard Reboot Device And Connect
     Run Keyword If    $IS_LAPTOP == 'True'    Login to laptop

--- a/Robot-Framework/test-suites/security-tests/network.robot
+++ b/Robot-Framework/test-suites/security-tests/network.robot
@@ -68,8 +68,7 @@ Account lockout teardown
     ${soft_reboot_ok}    Run Keyword And Return Status    Soft Reboot Device And Connect
     IF    not ${soft_reboot_ok}
         Log    Soft reboot did not recover device access, falling back to hard reboot.    console=True
-        Reboot Laptop      verify_shutdown=False
-        Check If Device Is Up
+        Hard Reboot Device And Connect   verify_shutdown=False
     END
     Verify External Connectivity Restored    SSH
     Login to laptop

--- a/Robot-Framework/test-suites/security-tests/persistence.robot
+++ b/Robot-Framework/test-suites/security-tests/persistence.robot
@@ -81,8 +81,7 @@ Persistence Suite Setup
 
 Persistence Suite Teardown
     IF  $SUITE_STATUS=='FAIL'
-        Reboot Laptop
-        Connect After Reboot
+        Hard Reboot Device And Connect
         Login to laptop
     END
     Set values   ORIGINAL

--- a/Robot-Framework/test-suites/suspension-test/suspension.robot
+++ b/Robot-Framework/test-suites/suspension-test/suspension.robot
@@ -105,8 +105,7 @@ Test teardown
     IF  $TEST_STATUS=='PASS'
         Log out from laptop
     ELSE
-        Reboot Laptop
-        Connect After Reboot
+        Hard Reboot Device And Connect
     END
     Switch to vm   ${GUI_VM}   user=${USER_LOGIN}
     Save screen recording   ${TEST_STATUS}   ${TEST_NAME} 

--- a/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
+++ b/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
@@ -225,13 +225,7 @@ Remove Ghaf Repository
 Rebuild Teardown
     Set Client Configuration      timeout=10
     IF  ${setup_skipped} or '${PREV_TEST_STATUS}'=='FAIL'
-        IF  ${IS_LAPTOP}
-            Reboot Laptop
-        ELSE
-            Reboot Orin
-        END
-        Close All Connections
-        Connect After Reboot
+        Hard Reboot Device And Connect
         IF  not ${IS_AVAILABLE}
             Log To Console    Connecting the device after boot failed. Rebuild may have left ghaf unbootable.\nStopping Teardown execution.
             RETURN


### PR DESCRIPTION
**Few bugfixes**

* Every iteration of `Check If Device Is Up` took 6 seconds during boot if UART capture was active (`Read Until terminator=${\n}` inside `Drain Serial Output` timed out on laptops every time). Replaced with `SerialLibrary.Read All Data` which won't wait unnecessarily.
* If first boot failed when booting to installer, the boot took over 8 minutes before it timed out and tried again. Now there is a 100 second time limit.

**Other changes**

* Add a new keyword `Hard Reboot Device And Connect` to keep the reboot logic inside device_control.keywords. This keyword supports both laptops and Orins. We already have `Soft Reboot Device And Connect` which works with all devices.
* Add a new keyword `Check If Device Is Available`. It handles the `Check If Device Is Up` output after a reboot, resume from suspend and before tests start. Previously nearly identical logic was duplicated across multiple keywords.
* Change all long `Check If Device Is Up` timeouts to use seconds. Due to the complexity of the keyword the length of one iteration can vary significantly.

**Note**: Tested with https://github.com/tiiuae/ci-test-automation/pull/872

**Testruns - regression**

* [Darter Pro](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6761/artifact/Robot-Framework/test-suites/darter-proANDregressionNOTstoreDisk-onlyNOTinstaller-only/report.html#totals)
* [Darter Pro storeDisk Installer](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6762/artifact/Robot-Framework/test-suites/darter-proANDregressionNOTexcl-storeDiskNOTexcl-installer/report.html#totals)
* [Lenovo X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6769/artifact/Robot-Framework/test-suites/lenovo-x1ANDregressionNOTsecboot-onlyNOTinstaller-only/report.html#totals)
* [Orin AGX 64](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6768/artifact/Robot-Framework/test-suites/orin-agx-64ANDregression/report.html#totals)
* [Orin NX](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6773/artifact/Robot-Framework/test-suites/orin-nxANDregression/report.html#totals)


**Testruns - performance**

* [Darter Pro](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6771/artifact/Robot-Framework/test-suites/darter-proANDperformance/report.html#totals)
* [Lenovo X1 Installer](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6778/artifact/Robot-Framework/test-suites/lenovo-x1ANDperformance/report.html#totals)
* [Orin AGX 64](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6770/artifact/Robot-Framework/test-suites/orin-agx-64ANDperformance/report.html#totals)
* [Orin NX](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6777/artifact/Robot-Framework/test-suites/orin-nxANDperformance/report.html#totals) (this is the best run I could get, at least the boot tests worked)