### PR TITLE
Refactor app keywords

### DIFF
--- a/Robot-Framework/resources/app_keywords.resource
+++ b/Robot-Framework/resources/app_keywords.resource
@@ -25,13 +25,10 @@ Start application in VM
     Set Test Variable    ${TEST_PROCESS_NAME}   ${process_name}
 
     IF    '${app-vm}' not in ${RUNNING_VMS} or ${always_check_vm}   Check that appVM is running   ${app-vm}
-    Switch to vm   ${app-vm}
-    Check that the application is not running   ${process_name}  1   before_launch_check=True
-    
-    Switch to vm   ${GUI_VM}  user=${USER_LOGIN}
-    Start application   ${app_name}     params_string=${params_string}
-    IF   '${app-vm}' != '${GUI_VM}'   Switch to vm   ${app-vm}
-    Check that the application was started    ${process_name}  5
+    Check that App is not running in VM    ${app-vm}   ${process_name}   range=1   before_launch_check=True
+
+    Start application   ${app_name}    params_string=${params_string}
+    Check that App is running in VM    ${app-vm}   ${process_name}   range=5
 
 Check that appVM is running
     [Arguments]    ${app-vm}
@@ -45,122 +42,90 @@ Check that appVM is running
 
 Start application
     [Arguments]      ${app_name}    ${params_string}=${EMPTY}
+    [Setup]    Switch to vm   ${GUI_VM}  user=${USER_LOGIN}
     Log    Starting ${app_name}   console=True
     Run Command  nohup sh -c 'ghaf-open ${app_name} ${params_string}' > ${APP_OUTPUT_FILE} 2>&1 &
 
-Check that the application was started
-    [Arguments]    ${process_name}  ${range}=2
-    FOR   ${i}   IN RANGE  ${range}
-        ${is_running}  Is process running   ${process_name}
-        IF    ${is_running}
-            Log    ${process_name} is running    console=True
-            RETURN
-        END
-        Sleep   1
-    END
-    FAIL   ${process_name} is not running after ${range} seconds
+Check that App is running in VM
+    [Arguments]    ${app-vm}   ${process_name}   ${range}=2
+    ${user}        Set Variable If   '${app-vm}' == '${GUI_VM}'   ${USER_LOGIN}   ghaf
+    Switch to vm   ${app-vm}   user=${user}
+    Wait Until Keyword Succeeds    ${range}x    1s   Check that process is running   ${process_name}
 
-Check that the application is not running
-    [Arguments]    ${process_name}  ${range}=2   ${before_launch_check}=False
-    FOR   ${i}   IN RANGE  ${range}
-        ${is_running}  Is process running   ${process_name}
-        IF    not ${is_running}
-            Log    ${process_name} is not running    console=True
-            RETURN
-        END
-        Sleep   1
-    END
-    IF    ${before_launch_check}
-        FAIL   ${process_name} is already running before it was launched
-    END
-    FAIL   ${process_name} is still running after ${range} seconds
+Check that App is not running in VM
+    [Arguments]   ${app-vm}   ${process_name}   ${range}=2   ${before_launch_check}=False
+    ${user}              Set Variable If   '${app-vm}' == '${GUI_VM}'   ${USER_LOGIN}   ghaf
+    Switch to vm         ${app-vm}   user=${user}
+    ${error_message}     Set Variable If      ${before_launch_check}   already running    still running
+    Wait Until Keyword Succeeds    ${range}x    1s    Check that process is not running    ${process_name}    ${error_message}
 
 Log and remove app output
-    [Documentation]    Specify the VM from which the app was started and the user (the owner of the file)
-    [Arguments]   ${file}    ${app-vm}    ${user}=ghaf
-    Switch to vm  ${app-vm}    ${user}
+    [Documentation]    Save app output from ${GUI_VM} and remove the output file.
+    [Arguments]   ${file}
+    Switch to vm  ${GUI_VM}  user=${USER_LOGIN}
     Run Command   cat ${file}
     Remove file   ${file}
 
 Log app vm journalctl
-    [Documentation]    Specify the VM where the App is actually running
+    [Documentation]    Log journalctl from ${app-vm}, specify the VM where the App is actually running.
     [Arguments]   ${app-vm}
     Switch to vm  ${app-vm}
     Run Command   journalctl -b
 
-Kill App Process And Save Logs
-    [Documentation]    Kill all running process and log apps output and journalctl
-    ...                app_start_vm - the VM from which the app was started
-    ...                user - by what user the app was started
-    ...                log_file - the name of the file which was defined in the app's starting command
-    ...                process_name - the name of the app process that will be killed
-    ...                app_running_vm - the VM where the App is actually running
-    ...                status - the status of the test executed
-    [Arguments]        ${app_start_vm}   ${user}   ${log_file}  ${process_name}  ${app_running_vm}  ${status}=${TEST_STATUS}
-    IF   '${app_running_vm}' == '${GUI_VM}'
-        Switch to vm   ${GUI_VM}  user=${USER_LOGIN}
-        Kill process by name    ${process_name}   sudo=False
-    ELSE
-        Switch to vm            ${app_running_vm}
-        Kill process by name    ${process_name}
-    END
-    Log and remove app output   ${log_file}  ${app_start_vm}   user=${user}
-    IF  '${status}'=='FAIL'   Log app vm journalctl  ${app_running_vm}
-
 Kill App in VM
-    [Documentation]   Use after "Start application in VM", call this keyword from the test teardown.
-    [Arguments]   ${app-vm}   ${process_name}   ${status}=${TEST_STATUS}
-    Kill App Process And Save Logs    ${GUI_VM}  ${USER_LOGIN}  ${APP_OUTPUT_FILE}  ${process_name}  ${app-vm}  ${status}
+    [Documentation]   Connects to ${app-vm} and kills process ${process_name}.
+    ...    Use after "Start application in VM", call this keyword from the test teardown.
+    [Arguments]   ${app-vm}   ${process_name}   ${log_file}=None   ${status}=${TEST_STATUS}   ${require_exists}=True
+    ${user}      Set Variable If      '${app-vm}' == '${GUI_VM}'     ${USER_LOGIN}   ghaf
+    ${sudo}      Set Variable If      '${user}' == '${USER_LOGIN}'   False           True
 
-Kill App By Name
-    [Arguments]     ${process_name}   ${sudo}=False
-    ${pass_status}   ${output}    Run Keyword And Ignore Error   Check that the application was started   ${process_name}   1
-    IF  $pass_status=='PASS'      Kill process by name   ${process_name}   ${sudo}
+    Switch to vm            ${app-vm}         user=${user}
+    Kill process by name    ${process_name}   sudo=${sudo}   require_exists=${require_exists}
+
+    IF  '${log_file}' != 'None'   Log and remove app output   ${log_file}
+    IF  '${status}'=='FAIL'       Log app vm journalctl       ${app-vm}
 
 Start app via GUI
     [Documentation]    Start Application via GUI and verify related process started
     [Arguments]        ${app-vm}   ${process_name}   ${display_name}
-    Check that appVM is running   ${app-vm}
-    Check that the application is not running   ${process_name}  1  before_launch_check=True
-    Switch to vm                   ${GUI_VM}  user=${USER_LOGIN}
+    Check that appVM is running           ${app-vm}
+    Check that App is not running in VM   ${app-vm}   ${process_name}   range=1   before_launch_check=True
 
     Open app menu
     Type string     ${display_name}  enter_at_end=True
     Save time       ${process_name}_start
 
-    Switch to vm    ${app-vm}
-    Check that the application was started    ${process_name}  10
+    Check that App is running in VM   ${app-vm}   ${process_name}   range=10
 
     [Teardown]    Run Keywords    Switch to vm    ${GUI_VM}  user=${USER_LOGIN}
     ...           AND             Move cursor to corner
 
 Open app menu
-    [Documentation]    Check if app menu is open and if not open it
-    # Searches for app menu magnifying glass to identify if app menu is open
-    Log To Console     Checking that app menu is not already open
-    ${status}   ${output}      Run Keyword And Ignore Error   Locate on screen  image  search-neg.png  0.90  1  expected_result=FAIL
-    IF  '${status}' == 'PASS'
-        Log To Console    App menu is already open
-    ELSE
-        Log To Console    Opening app menu
+    [Documentation]   Open app menu from the app menu icon
+    [Setup]           Switch to vm   ${GUI_VM}  user=${USER_LOGIN}
+    Log To Console    Opening app menu
+    Locate and click  image  ${APP_MENU_LAUNCHER}  0.95  10
+    TRY
+        # Search for app menu magnifying glass to identify that the app menu is open
+        Wait Until Keyword Succeeds    5x    1s    Verify Image On The Screen   search-neg.png  confidence=0.90
+    EXCEPT
+        Log To Console    App menu did not open, trying again (it might have already been open)
         Locate and click  image  ${APP_MENU_LAUNCHER}  0.95  10
-        Locate on screen  image  search-neg.png  0.90  10
+        Wait Until Keyword Succeeds    5x    1s    Verify Image On The Screen   search-neg.png  confidence=0.90
     END
 
 Close app via GUI
     [Documentation]    Close Application via GUI and verify related process stopped
     [Arguments]        ${app-vm}   ${process_name}   ${close_button}   ${verify_is_killed}=True
-    Switch to vm       ${app-vm}
-    Check that the application was started    ${process_name}
+    Check that App is running in VM    ${app-vm}   ${process_name}   range=5
     Switch to vm       ${GUI_VM}  user=${USER_LOGIN}
     Log To Console     Clicking the close button of the application window
     Locate and click   image  ${close_button}  0.9  iterations=25  wiggle=True
     Save Time          ${process_name}_launched    ${LAST_SCREENSHOT_TIME}
     IF  ${verify_is_killed}
-        Switch to vm       ${app-vm}
-        ${status}          Run Keyword And Return Status  Check that the application is not running  ${process_name}  5
+        ${status}          Run Keyword And Return Status  Check that App is not running in VM    ${app-vm}   ${process_name}   range=5
         Should Be True     ${status}   Failed to close the application
     END
     # In case closing the app via GUI failed
-    [Teardown]     Run Keywords   Switch to vm   ${app-vm}   AND   Kill App By Name   ${process_name}  sudo=True
+    [Teardown]     Run Keywords   Kill App in VM   ${app-vm}   ${process_name}   status=${KEYWORD_STATUS}   require_exists=False
     ...            AND   Switch to vm   ${GUI_VM}  user=${USER_LOGIN}   AND   Move cursor to corner

--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -75,17 +75,21 @@ Is process running
     ${running}   Run Keyword And Return Status   Run Command    pgrep -f "${process_name}" -a
     RETURN   ${running}
 
+Check that process is running
+    [Arguments]      ${process_name}
+    ${is_running}    Is process running   ${process_name}
+    Should Be True   ${is_running}    Process ${process_name} is not running
+    Log              Process ${process_name} is running    console=True
+
 Check that process is not running
-    [Arguments]    ${process_name}
-    ${is_running}   Is process running   ${process_name}
-    Should Not Be True   ${is_running}   Process ${process_name} is still running
+    [Arguments]          ${process_name}   ${error_message}=still running
+    ${is_running}        Is process running   ${process_name}
+    Should Not Be True   ${is_running}        Process ${process_name} is ${error_message}
+    Log                  Process ${process_name} is not running    console=True
 
 Kill process by name
     [Arguments]   ${process_name}   ${sudo}=True   ${require_exists}=${True}   ${signal}=TERM   ${fallback_signal}=KILL
-    IF    ${require_exists}
-        ${is_running}   Is process running   ${process_name}
-        Should Be True   ${is_running}   Process ${process_name} is not running
-    END
+    IF    ${require_exists}   Check that process is running   ${process_name}
     Log   Killing process ${process_name} with signal ${signal} (fallback: ${fallback_signal})   console=True
     # A = ignore pkill process (ancestor), e = display what is killed, f = use full process name to kill
     Run Command    pkill -${signal} -Aef "${process_name}"  sudo=${sudo}  return=rc  rc_match=skip  timeout=15

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -364,7 +364,7 @@ Start screen recording
         END
         Set Global Variable  ${SCREEN_SELECTED}  ${True}
     END
-    Wait Until Keyword Succeeds    5x    1s    Run Command    ls -la /home/${USER_LOGIN}/Videos/${test_name}.mkv
+    Wait Until Keyword Succeeds    10x    0.5s    Run Command    ls -la /home/${USER_LOGIN}/Videos/${test_name}.mkv
     [Teardown]       Run Keyword If   '${KEYWORD_STATUS}' == 'FAIL'   Run Keywords   Timestamp last screenshot
     ...              AND   Run Command   cat /tmp/gpu-screen-recorder.log
 
@@ -401,13 +401,14 @@ Save screen recording
     END
 
 Kill Initial Setup
-    ${status}   ${output}   Run Keyword And Ignore Error   Check file exists   .config/cosmic-initial-setup-done
-    IF   $status == 'FAIL'
+    TRY
+        Check file exists   .config/cosmic-initial-setup-done
+    EXCEPT
         # Wait for the initial setup to start
-        Run Keyword and Ignore Error     Check that the application was started   cosmic-initial-setup   range=5
+        Run Keyword and Ignore Error     Check that App is running in VM   ${GUI_VM}   cosmic-initial-setup   range=5
         # Wait until Ghaf theme is applied, this does not happen if initial setup is killed too fast
         Wait Until Keyword Succeeds   10s   0.5s   Check file exists   .config/cosmic/com.system76.CosmicTheme*
         Sleep    1
         # Kill the initial setup so that it does not interfere with tests
-        Kill App By Name   cosmic-initial-setup
+        Kill process by name   cosmic-initial-setup   sudo=False   require_exists=False
     END

--- a/Robot-Framework/test-suites/functional-tests/apps.robot
+++ b/Robot-Framework/test-suites/functional-tests/apps.robot
@@ -7,7 +7,7 @@ Test Tags           apps  pre-merge  bat  lenovo-x1  darter-pro  dell-7330
 
 Resource            ../../resources/app_keywords.resource
 
-Test Teardown       Kill App in VM   ${TEST_APP-VM}   ${TEST_PROCESS_NAME}
+Test Teardown       Kill App in VM   ${TEST_APP-VM}   ${TEST_PROCESS_NAME}   ${APP_OUTPUT_FILE}
 
 
 *** Test Cases ***

--- a/Robot-Framework/test-suites/functional-tests/files.robot
+++ b/Robot-Framework/test-suites/functional-tests/files.robot
@@ -39,12 +39,9 @@ Open image with Oculante
     [Documentation]    Open PNG image in the Gui VM and check that Oculante app is started and opens the image
     [Tags]             SP-T197  pre-merge
     Switch to vm       ${GUI_VM}  user=${USER_LOGIN}
-
     Run Command        WAYLAND_DISPLAY=wayland-1 grim ./screenshot.png   timeout=5
     Open file with XDG handler   ./screenshot.png   sudo=False
-
-    Switch to vm       ${MEDIA_VM}
-    Check that the application was started    oculante    10
+    Check that App is running in VM    ${MEDIA_VM}   oculante   range=10
     [Teardown]  Run Keywords  Remove the file in VM       ./screenshot.png  ${GUI_VM}   ${USER_LOGIN}   AND
     ...                       Kill app and XDG process    oculante
 
@@ -54,9 +51,9 @@ Open text file with Cosmic Text Editor
     Switch to vm       ${GUI_VM}  user=${USER_LOGIN}
     Create text file   test    /tmp/test_text.txt
     Open file to gui-vm with XDG handler    /tmp/test_text.txt
-    Check that the application was started    cosmic-edit    10
+    Check that App is running in VM         ${GUI_VM}   cosmic-edit   range=10
     [Teardown]  Run Keywords  Remove the file in VM    /tmp/test_text.txt    ${GUI_VM}    ${USER_LOGIN}    AND
-    ...                       Kill App Process And Save Logs    ${GUI_VM}    ${USER_LOGIN}    ${OUTPUT_FILE}    cosmic-edit    ${GUI_VM}
+    ...                       Kill App in VM    ${GUI_VM}    cosmic-edit    log_file=${OUTPUT_FILE}
 
 
 *** Keywords ***
@@ -68,9 +65,9 @@ Remove the file in VM
 
 Kill app and XDG process
     [Arguments]        ${app}
-    Switch to vm       ${MEDIA_VM}
-    Log                Killing ${app} and xdg-open process in ${MEDIA_VM}    console=true
-    Kill App By Name   ${app}|xdg-open        sudo=True
+    Switch to vm           ${MEDIA_VM}
+    Log                    Killing ${app} and xdg-open process in ${MEDIA_VM}    console=true
+    Kill process by name   ${app}|xdg-open   sudo=True   require_exists=False
 
 Open PDF from app-vm
     [Arguments]       ${vm}   ${user}=ghaf   ${sudo}=True
@@ -78,8 +75,7 @@ Open PDF from app-vm
     Put File                     ../test-files/test_pdf.pdf   /tmp/test_pdf_${vm}.pdf
     ${open_timestamp}            Run Command    date +%s
     Open file with XDG handler   /tmp/test_pdf_${vm}.pdf   sudo=${sudo}
-    Switch to vm                 ${MEDIA_VM}
-    Check that the application was started    cosmic-reader   10
+    Check that App is running in VM    ${MEDIA_VM}   cosmic-reader   range=10
     [Teardown]    Run Keywords   Remove the file in VM        /tmp/test_pdf_${vm}.pdf   ${vm}  ${user}
     ...                    AND   Kill app and XDG process     cosmic-reader
     ...                    AND   Run Keyword If   '${KEYWORD_STATUS}' == 'FAIL'   Check for cosmic-reader crash   ${open_timestamp}   ${vm}

--- a/Robot-Framework/test-suites/functional-tests/fmo_apps.robot
+++ b/Robot-Framework/test-suites/functional-tests/fmo_apps.robot
@@ -7,7 +7,7 @@ Test Tags           fmo-apps  bat  fmo
 
 Resource            ../../resources/app_keywords.resource
 
-Test Teardown       Kill App in VM   ${TEST_APP-VM}   ${TEST_PROCESS_NAME}
+Test Teardown       Kill App in VM   ${TEST_APP-VM}   ${TEST_PROCESS_NAME}   ${APP_OUTPUT_FILE}
 
 
 *** Test Cases ***

--- a/Robot-Framework/test-suites/gui-tests/gui_app_store.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_app_store.robot
@@ -65,8 +65,7 @@ Install and Launch App Store app
     # Launch app from app menu, verify and kill it
     Start app via GUI   ${FLATPAK_VM}   ${process_name}   ${app_name}
 
-    [Teardown]   Run Keywords   Switch to vm   ${FLATPAK_VM}
-    ...    AND   Kill App By Name   cosmic-store   sudo=True
+    [Teardown]   Kill App in VM   ${FLATPAK_VM}   cosmic-store   status=${KEYWORD_STATUS}   require_exists=False
 
 Verify app is not preinstalled via flatpak
     [Arguments]    ${app_name}
@@ -139,9 +138,8 @@ Kill app and Uninstall in App Store
     Should Be Empty     ${flatpak_app_id}    App ${app_name} is still installed via flatpak (${flatpak_app_id})
     Log   ${app_name} is now uninstalled   console=True
     Close app via GUI   ${FLATPAK_VM}  cosmic-store  window-close-neg.png
-    [Teardown]   Run Keywords   Switch to vm   ${FLATPAK_VM}
-    ...    AND   Kill App By Name   cosmic-store   sudo=True
-    ...    AND   Kill App By Name   ${process_name}   sudo=True
+    [Teardown]   Run Keywords   Kill App in VM   ${FLATPAK_VM}   cosmic-store      status=${KEYWORD_STATUS}   require_exists=False
+    ...                   AND   Kill App in VM   ${FLATPAK_VM}   ${process_name}   status=${KEYWORD_STATUS}   require_exists=False
 
 Save a file from Onlyoffice
     [Documentation]   Open a file in Onlyoffice and save it to Shares

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -41,9 +41,9 @@ Copy and paste text between VMs
     Copy text to clipboard    ${clipboard_text}
     Start app via GUI   ${BUSINESS_VM}  google-chrome  "Trusted Browser"
     Paste clipboard text and verify     ${clipboard_text}
-    [Teardown]    Run Keywords    Switch to vm    ${BUSINESS_VM}    AND    Kill App By Name   google-chrome   sudo=True
-    ...           AND             Switch to vm    ${GUI_VM}  user=${USER_LOGIN}
-    ...           AND             Kill App By Name    cosmic-edit
+    [Teardown]    Run Keywords    Kill App in VM   ${BUSINESS_VM}   google-chrome
+    ...           AND             Kill App in VM   ${GUI_VM}        cosmic-edit
+    ...           AND             Switch to vm     ${GUI_VM}        user=${USER_LOGIN}
     ...           AND             Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
 Open an app from the dock
@@ -56,7 +56,7 @@ Open an app from the dock
     Verify app window is minimized
     Wait for Zoom icon coordinates to change and restore window    ${zoom_before_x}    ${zoom_before_y}
     Verify Zoom window restored to baseline    ${zoom_window_coords}    ${zoom_anchor_coords}
-    [Teardown]   Run Keywords   Switch to vm    ${COMMS_VM}    AND    Kill App By Name   zoom   sudo=True
+    [Teardown]   Run Keywords    Kill App in VM    ${COMMS_VM}    zoom
     ...    AND   Switch to vm    ${GUI_VM}  user=${USER_LOGIN}    AND    Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
 Maximize and restore window
@@ -68,7 +68,7 @@ Maximize and restore window
     Verify app window is maximized
     Locate and click maximize/restore window button
     Verify Zoom window restored to baseline    ${zoom_window_coords}    ${zoom_anchor_coords}
-    [Teardown]   Run Keywords   Switch to vm    ${COMMS_VM}    AND    Kill App By Name   zoom   sudo=True
+    [Teardown]   Run Keywords    Kill App in VM    ${COMMS_VM}    zoom
     ...    AND   Switch to vm    ${GUI_VM}  user=${USER_LOGIN}    AND    Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
 

--- a/Robot-Framework/test-suites/performance-tests/network.robot
+++ b/Robot-Framework/test-suites/performance-tests/network.robot
@@ -21,7 +21,7 @@ Resource            ../../resources/ssh_keywords.resource
 
 Suite Setup         Run Keywords  Switch to vm    ${NET_VM}
 ...                 AND  Run iperf server on DUT
-Suite Teardown      Run Keywords   Kill App By Name   iperf
+Suite Teardown      Run Keywords   Kill process by name   iperf
 ...                 AND  Close port 5201 from iptables
 ...                 AND  Close All Connections
 

--- a/Robot-Framework/test-suites/security-tests/vm_isolation.robot
+++ b/Robot-Framework/test-suites/security-tests/vm_isolation.robot
@@ -36,10 +36,9 @@ Stopping one VM does not affect another
     Start application in VM   ${app_name}   ${another_vm}    ${process_name}   always_check_vm=True
     Stop VM        ${one_vm}
     ${state}  ${substate}   Verify service status  service=microvm@${another_vm}.service  expected_state=active  expected_substate=running
-    Switch to vm   ${another_vm}
-    Check that the application was started    ${process_name}
+    Check that App is running in VM   ${another_vm}   ${process_name}   range=5
     [Teardown]    Run Keywords   Restart VM   ${one_vm}   start_only=True   restore_sudoers=False
-    ...                    AND   Kill App in VM   ${another_vm}   ${process_name}   PASS
+    ...                    AND   Kill App in VM   ${another_vm}   ${process_name}   log_file=${APP_OUTPUT_FILE}   status=${KEYWORD_STATUS}
 
 Stop VM
     [Documentation]         Try to stop VM and verify it stopped


### PR DESCRIPTION
* Replace `Check that the application was started` with `Check that App is running in VM` and `Check that the application is not running` with `Check that App is not running in VM`. New keywords take care of switching to the correct VM simplifying the keyword calls especially in teardowns. Renaming was done so that these keywords match with the process keywords.
* Remove `Kill App Process And Save Logs`, `Kill App in VM` can now handle everything it did.
* Remove `Kill App By Name`, `Kill process by name` can be called directly now that it has `require_exists` flag.
* Use TRY-EXCEPT in `Open app menu` and `Kill Initial Setup`.

**Testruns**
- [Lenovo X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6752/artifact/Robot-Framework/test-suites/lenovo-x1ANDfunctionalORlenovo-x1ANDguiORlenovo-x1ANDvm-isolationNOTsecboot-onlyNOTinstaller-only/report.html#totals)
- [Darter Pro storeDisk Installer](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6756/artifact/Robot-Framework/test-suites/darter-proANDfunctionalORdarter-proANDguiORdarter-proANDvm-isolationNOTsecboot-onlyNOTinstaller-only/report.html#totals)