### PR TITLE
Measure shutdown time

### DIFF
--- a/Robot-Framework/lib/PerformanceDataProcessing.py
+++ b/Robot-Framework/lib/PerformanceDataProcessing.py
@@ -767,11 +767,15 @@ class PerformanceDataProcessing:
     @keyword("Read Bootime CSV and Plot")
     def read_bootime_csv_and_plot(self, test_name):
 
+        if 'Shutdown' in test_name:
+            threshold = [thresholds['shutdown_time']]
+            monitored_values = ['shutdown_time']
+            data = {
+                    'commit': [],
+                    'shutdown_time': [],
+                    }
         # Omit time_to_desktop for Orin boot tests
-        threshold = {'time_to_desktop': thresholds['boot_time']['time_to_desktop'],
-                     'response_to_ping': thresholds['boot_time']['response_to_ping']}
-        monitored_values = ['time_to_desktop', 'response_to_ping']
-        if 'Orin' in test_name:
+        elif 'Orin' in test_name:
             threshold = [thresholds['boot_time']['response_to_ping']]
             monitored_values = ['response_to_ping']
             data = {
@@ -779,6 +783,9 @@ class PerformanceDataProcessing:
                     'response_to_ping':[],
                     }
         else:
+            threshold = {'time_to_desktop': thresholds['boot_time']['time_to_desktop'],
+                         'response_to_ping': thresholds['boot_time']['response_to_ping']}
+            monitored_values = ['time_to_desktop', 'response_to_ping']
             data = {
                 'commit': [],
                 'time_to_desktop': [],
@@ -792,6 +799,24 @@ class PerformanceDataProcessing:
 
         plt.figure(figsize=(20, 10))
         plt.set_loglevel('WARNING')
+
+        if 'Shutdown' in test_name:
+            plt.ticklabel_format(axis='y', style='plain')
+            plt.plot(data['commit'], data['shutdown_time'], marker='o', linestyle='-', color='b')
+            self.plot_marginals_and_deviations(data['commit'], statistics, 40)
+            plt.yticks(fontsize=14)
+            plt.title('Shutdown time', loc='right', fontweight="bold", fontsize=16)
+            plt.ylabel('seconds', fontsize=12)
+            plt.grid(True)
+            plt.xticks(data['commit'], rotation=90, fontsize=10)
+            plt.suptitle(
+                f'{test_name}\nBuild type: {self.build_type}, Device: {self.device}\nThreshold {threshold}',
+                fontsize=18,
+                fontweight='bold'
+            )
+            plt.tight_layout()
+            plt.savefig(self.plot_dir + f'{self.device}_{test_name}.png')
+            return return_statistics
 
         plt.subplot(2, 1, 1)
         plt.ticklabel_format(axis='y', style='plain')

--- a/Robot-Framework/lib/PerformanceDataProcessing.py
+++ b/Robot-Framework/lib/PerformanceDataProcessing.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import csv
+import math
 import os
 import shutil
 import pandas
@@ -773,6 +774,7 @@ class PerformanceDataProcessing:
             data = {
                     'commit': [],
                     'shutdown_time': [],
+                    'shutdown_time_power': [],
                     }
         # Omit time_to_desktop for Orin boot tests
         elif 'Orin' in test_name:
@@ -801,14 +803,26 @@ class PerformanceDataProcessing:
         plt.set_loglevel('WARNING')
 
         if 'Shutdown' in test_name:
+            while len(data['shutdown_time_power']) < len(data['commit']):
+                data['shutdown_time_power'].append(float('nan'))
             plt.ticklabel_format(axis='y', style='plain')
-            plt.plot(data['commit'], data['shutdown_time'], marker='o', linestyle='-', color='b')
+            plt.plot(data['commit'], data['shutdown_time'], marker='o', linestyle='-', color='b', label='Serial')
             self.plot_marginals_and_deviations(data['commit'], statistics, 40)
+            if any(not math.isnan(value) for value in data['shutdown_time_power']):
+                plt.plot(
+                    data['commit'],
+                    data['shutdown_time_power'],
+                    marker='o',
+                    linestyle='-',
+                    color='g',
+                    label='Power'
+                )
             plt.yticks(fontsize=14)
             plt.title('Shutdown time', loc='right', fontweight="bold", fontsize=16)
             plt.ylabel('seconds', fontsize=12)
             plt.grid(True)
             plt.xticks(data['commit'], rotation=90, fontsize=10)
+            plt.legend()
             plt.suptitle(
                 f'{test_name}\nBuild type: {self.build_type}, Device: {self.device}\nThreshold {threshold}',
                 fontsize=18,

--- a/Robot-Framework/lib/performance_thresholds.py
+++ b/Robot-Framework/lib/performance_thresholds.py
@@ -42,6 +42,7 @@ thresholds = {
         'rd': "5std",
         'rd_lenovo-x1': "5std"
     },
+    'shutdown_time': 10,
     'boot_time': {
         'response_to_ping': 10,
         'time_to_desktop': 12

--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -129,6 +129,15 @@ Soft Reboot Device
     END
     Close All Connections
 
+Soft Shutdown Device
+    IF  ${IS_LAPTOP}
+        Switch to vm          ${GUI_VM}
+    ELSE
+        Switch to vm          ${HOST}
+    END
+    Log To Console        Shutting down device from command line
+    Run Command           shutdown now    sudo=True    rc_match=skip
+
 Connect After Reboot
     [Documentation]   Verify that device rebooted and connect
     [Arguments]      ${soft_reboot}=False
@@ -156,14 +165,14 @@ Wake up device
 
 Wait Until Device Is Down
     [Arguments]    ${power_off}=${False}
-    IF  not ${IS_LAPTOP} or "${SERIAL_PORT}" == "NONE"
+    IF  "${SERIAL_PORT}" == "NONE"
         IF  ${power_off}
             ${time}   Verify shutdown via network    required_down_count=1
         ELSE
             ${time}   Verify shutdown via network
         END
     ELSE
-        ${time}   Verify shutdown via serial
+        ${time}  ${verified_via_network}   Verify shutdown via serial
     END
     RETURN    ${time}
 

--- a/Robot-Framework/resources/measurement_keywords.resource
+++ b/Robot-Framework/resources/measurement_keywords.resource
@@ -66,12 +66,16 @@ Stop recording power
     Run Keyword And Ignore Error  Run Command   pkill python  timeout=3
 
 Get power record
-    [Arguments]       ${file_name}=power_data.csv
+    [Arguments]       ${file_name}=power_data.csv  ${use_switch}=${False}
     IF  $SSH_MEASUREMENT=='${EMPTY}'
         Log To Console            No connection to power measurement device. Ignoring all power measurement related keywords.
         RETURN
     END
-    Run Keyword And Ignore Error  Connect to measurement agent
+    IF  ${use_switch}
+        Switch Connection   ${SSH_MEASUREMENT}
+    ELSE
+        Run Keyword And Ignore Error  Connect to measurement agent
+    END
     Run Keyword And Ignore Error  SSHLibrary.Get File           /home/ghaf/ghaf/power_data/${file_name}  ${LOGGED_PARAMS_DIR}
 
 Save measurement interval

--- a/Robot-Framework/resources/serial_keywords.resource
+++ b/Robot-Framework/resources/serial_keywords.resource
@@ -192,25 +192,65 @@ Get ethernet IP address
     ...           Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
 
 Verify shutdown via serial
-    [Documentation]   Reading serial port and expects 'System Power Off' text.
+    [Documentation]   Reads serial output and expects specific shutdown indicator text.
     ...               Works only in case of Shutdown (not reboot)
-    ...               And only for LAPTOPS
+    ...               If indicator text is not found fallback to Verify shutdown via network
+    [Arguments]       ${open_serial_port}=${True}  ${empty_output_timeout}=10  ${loop_timeout}=180
+    ${verified_via_serial}    Set Variable    ${False}
     Log               Wait until shutdown via serial    console=True
-    ${status}         Open Serial Port  timeout=60
+    IF  ${open_serial_port}
+        ${status}         Open Serial Port
+    ELSE
+        ${status}         Set Variable    ${True}
+    END
     IF    ${status}
-        ${output}         SerialLibrary.Read Until    System Power Off
-        Log               ${output}
-        IF  "System Power Off" in $output
-            Log    Found "System Power Off" in serial logs    console=True
+        IF  ${IS_LAPTOP}
+            ${shutdown_indicator}    Set Variable    System Power Off
         ELSE
-            Log    Can't find "System Power Off" in serial logs of ${DEVICE}
+            ${shutdown_indicator}    Set Variable    Shutting dow
+        END
+        ${empty_output}    Set Variable    ${False}
+        ${serial_output_log}    Set Variable    ${EMPTY}
+        ${loop_start}      Get Time        epoch
+        WHILE  True
+            ${output}    SerialLibrary.Read All Data
+            IF  $output != '${EMPTY}'
+                ${empty_output}     Set Variable    ${False}
+                ${clean_output}     Normalize Serial Output    ${output}
+                ${serial_output_log}    Catenate    SEPARATOR=
+                ...    ${serial_output_log}
+                ...    ${clean_output}
+            ELSE
+                IF  not ${empty_output}
+                    ${empty_output}    Set Variable    ${True}
+                    ${serial_empty_since}    Get Time  epoch
+                END
+                ${diff}=    Evaluate    int(time.time()) - int(${serial_empty_since})
+                IF  ${diff} > ${empty_output_timeout}
+                    BREAK
+                END
+            END
+            IF  "${shutdown_indicator}" in $serial_output_log
+                Log    Found "${shutdown_indicator}" in serial output    console=True
+                ${verified_via_serial}    Set Variable    ${True}
+                BREAK
+            END
+            ${diff}=    Evaluate    int(time.time()) - int(${loop_start})
+            IF  ${diff} > ${loop_timeout}
+                BREAK
+            END
+            Sleep  0.3
+        END
+        Log    ${serial_output_log}
+        IF  not ${verified_via_serial}
+            Log    Could not find "${shutdown_indicator}" in serial output of ${DEVICE}    console=True
             Verify shutdown via network
         END
     ELSE
         Verify shutdown via network
     END
     ${time}           BuiltIn.Get Time   epoch
-    RETURN            ${time}
+    RETURN            ${time}    ${verified_via_serial}
     [Teardown]    Run Keywords    Delete All Ports    AND
     ...           Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
 

--- a/Robot-Framework/test-suites/performance-tests/boot_time.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time.robot
@@ -41,12 +41,6 @@ Measure Shutdown Time
     Get Shutdown Time
     [Teardown]       Shutdown Time Teardown
 
-Measure Shutdown Time By Power
-    [Documentation]  Measure Lenovo-X1 shutdown time until power drops below ${SHUTDOWN_POWER_LIMIT}mW
-    [Tags]           SP-T83  SP-T83-2  lenovo-x1  lab-only
-    Get Shutdown Time By Power
-    [Teardown]       Shutdown Time Teardown
-
 Measure Hard Boot Time
     [Documentation]  Measure how long it takes to device to boot up with hard reboot
     [Tags]           SP-T182  SP-T182-1  lenovo-x1  darter-pro  dell-7330  lab-only
@@ -118,6 +112,14 @@ Get Shutdown Time
     IF  not ${status}
         Skip    Failed to connect via serial
     END
+    ${use_power_measurement}      Set Variable    ${False}
+    ${availability}               Check variable availability  RPI_IP_ADDRESS
+    IF  ${availability}
+        Start power measurement   ${BUILD_ID}_shutdown   timeout=300
+        IF  $SSH_MEASUREMENT!='${EMPTY}'
+            ${use_power_measurement}    Set Variable    ${True}
+        END
+    END
     Soft Shutdown Device
     ${start_time_epoch}           DateTime.Get Current Date   result_format=epoch
     ${shutdown_time_epoch}  ${verified_via_serial}    Verify shutdown via serial    open_serial_port=${False}
@@ -128,35 +130,27 @@ Get Shutdown Time
     END
     &{final_results}              Create Dictionary
     Set To Dictionary             ${final_results}  shutdown_time  ${shutdown_time}
+    IF  ${use_power_measurement}
+        ${shutdown_time_power_epoch}    Wait Until Power Is Low     ${BUILD_ID}_shutdown
+        ${shutdown_time_power}          Evaluate
+        ...                             int(${shutdown_time_power_epoch}) - int(${start_time_epoch})
+        Log                             Shutdown time by power measured: ${shutdown_time_power}   console=True
+        Set To Dictionary               ${final_results}  shutdown_time_power  ${shutdown_time_power}
+    END
     Check Result Validity         ${final_results}
     &{statistics}                 Save Boot time Data   ${TEST NAME}  ${final_results}
+    IF  ${use_power_measurement}
+        Sleep                     5
+        Generate power plot       ${BUILD_ID}_shutdown   ${TEST NAME}
+        Stop recording power
+    END
     Log  <img src="${DEVICE}_${TEST NAME}.png" alt="${plot_name}" width="1200">    HTML
     Determine Test Status         ${statistics}  inverted=1
-
-Get Shutdown Time By Power
-    [Arguments]  ${plot_name}=Shutdown Times
-    ${availability}              Check variable availability  RPI_IP_ADDRESS
-    IF  ${availability}==False
-        SKIP    Power measurement agent IP address not defined. Skipping the test
+    IF  ${use_power_measurement}
+        ${measurement_diff}      Evaluate    abs(${shutdown_time_power} - ${shutdown_time})
+        Should Be True           ${measurement_diff} <= 10
+        ...                      msg=Shutdown time by power differs ${measurement_diff} sec from serial, expected <= 10 sec
     END
-    Start power measurement       ${BUILD_ID}_shutdown   timeout=300
-    IF  $SSH_MEASUREMENT=='${EMPTY}'
-        SKIP    Failed to connect to power measurement agent. Skipping the test
-    END
-    Soft Shutdown Device
-    ${start_time_epoch}           DateTime.Get Current Date   result_format=epoch
-    ${shutdown_time_epoch}        Wait Until Power Is Low     ${BUILD_ID}_shutdown
-    ${shutdown_time}              Evaluate
-    ...                           int(${shutdown_time_epoch}) - int(${start_time_epoch})
-    Log                           Shutdown time measured: ${shutdown_time}   console=True
-    &{final_results}              Create Dictionary
-    Set To Dictionary             ${final_results}  shutdown_time  ${shutdown_time}
-    Check Result Validity         ${final_results}
-    &{statistics}                 Save Boot time Data   ${TEST NAME}  ${final_results}
-    Generate power plot           ${BUILD_ID}_shutdown   ${TEST NAME}
-    Stop recording power
-    Log  <img src="${DEVICE}_${TEST NAME}.png" alt="${plot_name}" width="1200">    HTML
-    Determine Test Status         ${statistics}  inverted=1
 
 Get Boot times
     [Documentation]  Collect boot times from device

--- a/Robot-Framework/test-suites/performance-tests/boot_time.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time.robot
@@ -25,6 +25,7 @@ Test Teardown       Boot Time Test Teardown
 ${PING_TIMEOUT}            180
 ${SEARCH_TIMEOUT}          60
 ${SHUTDOWN_POWER_LIMIT}    1500
+${SHUTDOWN_VERIFIED}       ${False}
 
 
 *** Test Cases ***
@@ -123,11 +124,12 @@ Get Shutdown Time
     Soft Shutdown Device
     ${start_time_epoch}           DateTime.Get Current Date   result_format=epoch
     ${shutdown_time_epoch}  ${verified_via_serial}    Verify shutdown via serial    open_serial_port=${False}
-    ${shutdown_time}              Evaluate    int(${shutdown_time_epoch}) - int(${start_time_epoch})
-    Log                           Shutdown time measured: ${shutdown_time}   console=True
     IF  not ${verified_via_serial}
         SKIP    Shutdown time verification via serial failed, fell back to 'Verify shutdown via network' which is not accurate.\nSkipping the test.
     END
+    ${shutdown_time}              Evaluate    int(${shutdown_time_epoch}) - int(${start_time_epoch})
+    Log                           Shutdown time measured via Serial output: ${shutdown_time}   console=True
+    Set Suite Variable            ${SHUTDOWN_VERIFIED}    ${True}
     &{final_results}              Create Dictionary
     Set To Dictionary             ${final_results}  shutdown_time  ${shutdown_time}
     IF  ${use_power_measurement}
@@ -246,14 +248,25 @@ Shutdown Time Teardown
     Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
     Sleep  10
     IF  ${IS_LAPTOP}
-        Reboot Laptop
+        IF  not ${SHUTDOWN_VERIFIED}
+            Reboot Laptop
+            Check If Device Is Up    retry=110s
+            IF  ${IS_AVAILABLE} == False
+                Log To Console    Turning device on again...
+                Turn Laptop On
+                Check If Device Is Up    retry=110s
+            END
+        ELSE
+            Turn Laptop On
+            Check If Device Is Up    retry=110s
+        END
     ELSE
         Reboot Orin
-    END
-    Check If Device Is Up    retry=110s
-    IF  ${IS_AVAILABLE} == False
-        Log To Console    Turning device on again...
-        Turn Laptop On
-        Check If Device Is Up    retry=110s
+        IF  "orin-agx" in "${DEVICE_TYPE}"
+            # Known issue SSRCSP-8704
+            Check If Device Is Up   retry=230s
+        ELSE
+            Check If Device Is Up   retry=140s
+        END
     END
     Connect After Reboot

--- a/Robot-Framework/test-suites/performance-tests/boot_time.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time.robot
@@ -134,7 +134,7 @@ Get Shutdown Time
     Set To Dictionary             ${final_results}  shutdown_time  ${shutdown_time}
     Set To Dictionary             ${final_results}  shutdown_time_power  ${nan}
     IF  ${use_power_measurement}
-        ${shutdown_time_power_epoch}    Wait Until Power Is Low     ${BUILD_ID}_shutdown
+        ${shutdown_time_power_epoch}    Detect when power went low   ${BUILD_ID}_shutdown
         ${shutdown_time_power}          Evaluate
         ...                             int(${shutdown_time_power_epoch}) - int(${start_time_epoch})
         Log                             Shutdown time by power measured: ${shutdown_time_power}   console=True
@@ -201,6 +201,9 @@ Check Time To Notification
 Check Result Validity
     [Arguments]      ${captured_results}
     FOR  ${key}  ${value}  IN  &{captured_results}
+         IF  '${value}' == 'nan'
+             CONTINUE
+         END
          Should Be True  ${value} > 0
     END
 
@@ -224,12 +227,43 @@ Wait Until Power Is Low
             ...               ${measurement_id}  ${start_time}  ${end_time}
             Log               Measured power: ${mean_power}mW   console=True
             IF  ${mean_power} < ${SHUTDOWN_POWER_LIMIT}
-                RETURN        ${end_time_epoch}
+                RETURN        ${end_time}    ${end_time_epoch}
             END
         EXCEPT
             Log    Ignoring invalid measured power sample    console=True
         END
         Sleep  0.5
+    END
+
+Detect when power went low
+    [Documentation]       Detect the moment of power off more accurately by iterating backwards
+    [Arguments]           ${measurement_id}
+    ${coarse_end_time}    ${coarse_end_epoch}    Wait Until Power Is Low    ${measurement_id}
+    ${scan_interval}      Set Variable    2
+    ${step_back}          Set Variable    1
+    ${last_low_power_time}   Set Variable    ${coarse_end_time}
+    ${last_low_power_epoch}  Set Variable    ${coarse_end_epoch}
+    ${scan_end_time}      Set Variable    ${coarse_end_time}
+    ${scan_end_epoch}     Set Variable    ${coarse_end_epoch}
+    WHILE  True   limit=60 seconds
+        ${scan_start_time}    DateTime.Add Time To Date   ${scan_end_time}   -${scan_interval} seconds
+        ...                   exclude_millis=yes
+        TRY
+            ${mean_power}     Calculate average power over interval
+            ...               ${measurement_id}  ${scan_start_time}  ${scan_end_time}
+            Log               Backward scan power: ${mean_power}mW   console=True
+            IF  ${mean_power} < ${SHUTDOWN_POWER_LIMIT}
+                ${last_low_power_time}   Set Variable    ${scan_end_time}
+                ${last_low_power_epoch}  Set Variable    ${scan_end_epoch}
+                ${scan_end_time}      DateTime.Add Time To Date   ${scan_end_time}   -${step_back} seconds
+                ...                   exclude_millis=yes
+                ${scan_end_epoch}     Evaluate    int(${scan_end_epoch}) - int(${step_back})
+            ELSE
+                RETURN                 ${last_low_power_epoch}
+            END
+        EXCEPT
+            RETURN                     ${last_low_power_epoch}
+        END
     END
 
 Boot Time Test Teardown

--- a/Robot-Framework/test-suites/performance-tests/boot_time.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time.robot
@@ -11,6 +11,7 @@ Library             ../../lib/PerformanceDataProcessing.py  ${DEVICE}  ${BUILD_I
 Library             DateTime
 Library             Collections
 Resource            ../../resources/device_control.resource
+Resource            ../../resources/measurement_keywords.resource
 Resource            ../../resources/performance_keywords.resource
 Resource            ../../resources/serial_keywords.resource
 Resource            ../../resources/setup_keywords.resource
@@ -21,8 +22,9 @@ Suite Teardown      Close All Connections
 Test Teardown       Boot Time Test Teardown
 
 *** Variables ***
-${PING_TIMEOUT}     180
-${SEARCH_TIMEOUT}   60
+${PING_TIMEOUT}            180
+${SEARCH_TIMEOUT}          60
+${SHUTDOWN_POWER_LIMIT}    1500
 
 
 *** Test Cases ***
@@ -32,6 +34,18 @@ Measure Soft Boot Time
     [Tags]           SP-T187  SP-T187-1  lenovo-x1  dell-7330
     Soft Reboot Device
     Get Boot times
+
+Measure Shutdown Time
+    [Documentation]  Measure how long it takes to device to shut down with software shutdown
+    [Tags]           SP-T83  SP-T83-1  lenovo-x1  darter-pro  dell-7330  lab-only
+    Get Shutdown Time
+    [Teardown]       Shutdown Time Teardown
+
+Measure Shutdown Time By Power
+    [Documentation]  Measure Lenovo-X1 shutdown time until power drops below ${SHUTDOWN_POWER_LIMIT}mW
+    [Tags]           SP-T83  SP-T83-2  lenovo-x1  lab-only
+    Get Shutdown Time By Power
+    [Teardown]       Shutdown Time Teardown
 
 Measure Hard Boot Time
     [Documentation]  Measure how long it takes to device to boot up with hard reboot
@@ -44,6 +58,12 @@ Measure Orin Soft Boot Time
     [Tags]           SP-T187  SP-T187-2  orin-agx  orin-agx-64  orin-nx
     Soft Reboot Device
     Get Time To Ping
+
+Measure Orin Shutdown Time
+    [Documentation]  Measure how long it takes to device to shut down with software shutdown
+    [Tags]           SP-T83  SP-T83-1  orin-agx  orin-agx-64  orin-nx  lab-only
+    Get Shutdown Time
+    [Teardown]       Shutdown Time Teardown
 
 Measure Orin Hard Boot Time
     [Documentation]  Measure how long it takes to device to boot up with hard reboot
@@ -89,6 +109,52 @@ Get Time To Ping
     Set To Dictionary             ${final_results}  response_to_ping  ${ping_response_seconds}
     Check Result Validity         ${final_results}
     &{statistics}                 Save Boot time Data   ${TEST NAME}  ${final_results}
+    Log  <img src="${DEVICE}_${TEST NAME}.png" alt="${plot_name}" width="1200">    HTML
+    Determine Test Status         ${statistics}  inverted=1
+
+Get Shutdown Time
+    [Arguments]  ${plot_name}=Shutdown Times
+    ${status}                     Open Serial Port    timeout=10
+    IF  not ${status}
+        Skip    Failed to connect via serial
+    END
+    Soft Shutdown Device
+    ${start_time_epoch}           DateTime.Get Current Date   result_format=epoch
+    ${shutdown_time_epoch}  ${verified_via_serial}    Verify shutdown via serial    open_serial_port=${False}
+    ${shutdown_time}              Evaluate    int(${shutdown_time_epoch}) - int(${start_time_epoch})
+    Log                           Shutdown time measured: ${shutdown_time}   console=True
+    IF  not ${verified_via_serial}
+        SKIP    Shutdown time verification via serial failed, fell back to 'Verify shutdown via network' which is not accurate.\nSkipping the test.
+    END
+    &{final_results}              Create Dictionary
+    Set To Dictionary             ${final_results}  shutdown_time  ${shutdown_time}
+    Check Result Validity         ${final_results}
+    &{statistics}                 Save Boot time Data   ${TEST NAME}  ${final_results}
+    Log  <img src="${DEVICE}_${TEST NAME}.png" alt="${plot_name}" width="1200">    HTML
+    Determine Test Status         ${statistics}  inverted=1
+
+Get Shutdown Time By Power
+    [Arguments]  ${plot_name}=Shutdown Times
+    ${availability}              Check variable availability  RPI_IP_ADDRESS
+    IF  ${availability}==False
+        SKIP    Power measurement agent IP address not defined. Skipping the test
+    END
+    Start power measurement       ${BUILD_ID}_shutdown   timeout=300
+    IF  $SSH_MEASUREMENT=='${EMPTY}'
+        SKIP    Failed to connect to power measurement agent. Skipping the test
+    END
+    Soft Shutdown Device
+    ${start_time_epoch}           DateTime.Get Current Date   result_format=epoch
+    ${shutdown_time_epoch}        Wait Until Power Is Low     ${BUILD_ID}_shutdown
+    ${shutdown_time}              Evaluate
+    ...                           int(${shutdown_time_epoch}) - int(${start_time_epoch})
+    Log                           Shutdown time measured: ${shutdown_time}   console=True
+    &{final_results}              Create Dictionary
+    Set To Dictionary             ${final_results}  shutdown_time  ${shutdown_time}
+    Check Result Validity         ${final_results}
+    &{statistics}                 Save Boot time Data   ${TEST NAME}  ${final_results}
+    Generate power plot           ${BUILD_ID}_shutdown   ${TEST NAME}
+    Stop recording power
     Log  <img src="${DEVICE}_${TEST NAME}.png" alt="${plot_name}" width="1200">    HTML
     Determine Test Status         ${statistics}  inverted=1
 
@@ -145,6 +211,30 @@ Log Journal To Debug
     [Arguments]           ${boot}=0
     ${journal_output}     Run Command   journalctl -b ${boot}
 
+Wait Until Power Is Low
+    [Arguments]           ${measurement_id}
+    ${retro_interval}     Set Variable    3
+    # Give some time for measurement results to accumulate before starting to iterate retrospective time intervals
+    Sleep                 ${retro_interval}
+    WHILE  True   limit=180 seconds
+        ${end_time}        Get current timestamp
+        ${end_time_epoch}  Get Time    epoch
+        Get power record   ${measurement_id}.csv    use_switch=${True}
+        ${start_time}      DateTime.Add Time To Date   ${end_time}   -${retro_interval} seconds
+        ...                exclude_millis=yes
+        TRY
+            ${mean_power}     Calculate average power over interval
+            ...               ${measurement_id}  ${start_time}  ${end_time}
+            Log               Measured power: ${mean_power}mW   console=True
+            IF  ${mean_power} < ${SHUTDOWN_POWER_LIMIT}
+                RETURN        ${end_time_epoch}
+            END
+        EXCEPT
+            Log    Ignoring invalid measured power sample    console=True
+        END
+        Sleep  0.5
+    END
+
 Boot Time Test Teardown
     Run Keyword If Test Failed   Failed Boot Time Test Teardown
     IF   ${IS_LAPTOP}    Login to laptop
@@ -156,3 +246,20 @@ Failed Boot Time Test Teardown
         Log Journal To Debug  boot=-1
     END
 
+Shutdown Time Teardown
+    Close All Connections
+    Delete All Ports
+    Set Global Variable    ${UART_CAPTURE_ACTIVE}    ${False}
+    Sleep  10
+    IF  ${IS_LAPTOP}
+        Reboot Laptop
+    ELSE
+        Reboot Orin
+    END
+    Check If Device Is Up    retry=110s
+    IF  ${IS_AVAILABLE} == False
+        Log To Console    Turning device on again...
+        Turn Laptop On
+        Check If Device Is Up    retry=110s
+    END
+    Connect After Reboot

--- a/Robot-Framework/test-suites/performance-tests/boot_time.robot
+++ b/Robot-Framework/test-suites/performance-tests/boot_time.robot
@@ -132,6 +132,7 @@ Get Shutdown Time
     Set Suite Variable            ${SHUTDOWN_VERIFIED}    ${True}
     &{final_results}              Create Dictionary
     Set To Dictionary             ${final_results}  shutdown_time  ${shutdown_time}
+    Set To Dictionary             ${final_results}  shutdown_time_power  ${nan}
     IF  ${use_power_measurement}
         ${shutdown_time_power_epoch}    Wait Until Power Is Low     ${BUILD_ID}_shutdown
         ${shutdown_time_power}          Evaluate


### PR DESCRIPTION
Add test case for measuring shutdown time. Modify `Verify shutdown via serial` to prefer shutdown detection by serial for all targets but still allow fallback to detection via network. Skip shutdown time measurement because of inaccuracy if shutdown detection via serial was not possible.

Measure shutdown time also by power if power measurement setup is available (prod lenovo-x1 only). If shutdown time measured by serial and power differ more than 10 sec fail the test. Shutdown measurement by power can be considered as the most accurate method of measuring time to HW power off. It can be useful in detecting edge cases on lenovo-x1 where buggy shutdown renders the HW partially powered although all communication with the device is lost. In normal conditions we expect 'Measure Shutdown Time' and 'Measure Shutdown Time By Power' results not to be very far from each other (in my tests there was < 5sec difference).

orin-agx-64
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6819/
orin-agx-64 regression
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6849/

orin-nx
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6835/

lenovo-x1
https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2211/
https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2212/

Regression check on darter-pro
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6821/