### PR TITLE
Add app config file

### DIFF
--- a/Robot-Framework/config/apps.json
+++ b/Robot-Framework/config/apps.json
@@ -1,0 +1,217 @@
+{
+  "Advanced Network Configuration": {
+    "display_name": "Advanced Network Configuration",
+    "VM": "gui-vm",
+    "process_name": "nm-connection-editor",
+    "close_button": "window-close.png"
+  },
+  "App Store": {
+    "display_name": "App Store",
+    "VM": "flatpak-vm",
+    "process_name": "cosmic-store",
+    "close_button": "window-close-neg.png"
+  },
+  "Bluetooth Settings": {
+    "display_name": "Bluetooth Settings",
+    "VM": "gui-vm",
+    "process_name": "blueman-manager-wrapped-wrapped",
+    "close_button": "window-close.png"
+  },
+  "Calculator": {
+    "display_name": "Calculator",
+    "VM": "gui-vm",
+    "process_name": "gnome-calculator",
+    "close_button": "window-close-neg.png"
+  },
+  "COSMIC Document Reader": {
+    "display_name": "COSMIC Document Reader",
+    "VM": "gui-vm",
+    "process_name": "cosmic-reader",
+    "close_button": "ghaf-close.png"
+  },
+  "COSMIC Files": {
+    "display_name": "COSMIC Files",
+    "VM": "gui-vm",
+    "process_name": "^cosmic-files$",
+    "close_button": "ghaf-close.png"
+  },
+  "Cosmic Initial Setup": {
+    "display_name": "Cosmic Initial Setup",
+    "VM": "gui-vm",
+    "process_name": "cosmic-initial-setup"
+  },
+  "COSMIC Media Player": {
+    "display_name": "COSMIC Media Player",
+    "VM": "gui-vm",
+    "process_name": "cosmic-player",
+    "close_button": "ghaf-close.png"
+  },
+  "COSMIC Settings": {
+    "display_name": "COSMIC Settings",
+    "VM": "gui-vm",
+    "process_name": "cosmic-settings$",
+    "close_button": "ghaf-close.png",
+    "icon": "settings.png"
+  },
+  "COSMIC Terminal": {
+    "display_name": "COSMIC Terminal",
+    "VM": "gui-vm",
+    "process_name": "cosmic-term",
+    "close_button": "ghaf-close.png"
+  },
+  "COSMIC Text Editor": {
+    "display_name": "COSMIC Text Editor",
+    "VM": "gui-vm",
+    "process_name": "cosmic-edit",
+    "close_button": "ghaf-close.png"
+  },
+  "Display Settings": {
+    "display_name": "Display Settings",
+    "VM": "gui-vm",
+    "process_name": "wdisplays",
+    "close_button": "ghaf-close.png"
+  },
+  "Element": {
+    "display_name": "Element",
+    "VM": "comms-vm",
+    "process_name": "element",
+    "close_button": "ghaf-close.png"
+  },
+  "Firefox": {
+    "display_name": "Firefox",
+    "VM": "flatpak-vm",
+    "process_name": "firefox"
+  },
+  "Firefox GPU": {
+    "display_name": "Firefox GPU",
+    "VM": "gui-vm",
+    "process_name": "firefox"
+  },
+  "Fingerprints": {
+    "display_name": "Fingerprints",
+    "VM": "gui-vm",
+    "process_name": "fingwit",
+    "close_button": "window-close.png"
+  },
+  "FMO Offboarding": {
+    "display_name": "FMO Offboarding",
+    "VM": "docker-vm",
+    "process_name": "fmo-offboarding"
+  },
+  "FMO Onboarding Agent": {
+    "display_name": "FMO Onboarding Agent",
+    "VM": "docker-vm",
+    "process_name": "fmo-onboarding"
+  },
+  "Gala": {
+    "display_name": "Gala",
+    "VM": "business-vm",
+    "process_name": "gala",
+    "close_button": "ghaf-close.png"
+  },
+  "Getting Started": {
+    "display_name": "Getting Started",
+    "VM": "chrome-vm",
+    "process_name": "ghaf-intro",
+    "close_button": "ghaf-close.png"
+  },
+  "Ghaf Control Panel": {
+    "display_name": "Ghaf Control Panel",
+    "VM": "gui-vm",
+    "process_name": "ctrl-panel",
+    "close_button": "window-close-neg.png"
+  },
+  "Ghaf Isolated Document Viewer": {
+    "display_name": "Ghaf Isolated Document Viewer",
+    "VM": "media-vm",
+    "process_name": "cosmic-reader"
+  },
+  "Ghaf Isolated Image Viewer": {
+    "display_name": "Ghaf Isolated Image Viewer",
+    "VM": "media-vm",
+    "process_name": "oculante"
+  },
+  "Ghaf Isolated Media Player": {
+    "display_name": "Ghaf Isolated Media Player",
+    "VM": "media-vm",
+    "process_name": "cosmic-player"
+  },
+  "Google Chrome": {
+    "display_name": "Google Chrome",
+    "VM": "chrome-vm",
+    "process_name": "chrome",
+    "close_button": "ghaf-close.png"
+  },
+  "Google Chrome GPU": {
+    "display_name": "Google Chrome GPU",
+    "VM": "gui-vm",
+    "process_name": "chrome",
+    "close_button": "ghaf-close.png"
+  },
+  "GPU Screen Recorder": {
+    "display_name": "GPU Screen Recorder",
+    "VM": "gui-vm",
+    "process_name": "gpu-screen-recorder-gtk",
+    "close_button": "window-close.png"
+  },
+  "Microsoft 365": {
+    "display_name": "Microsoft 365",
+    "VM": "business-vm",
+    "process_name": "microsoft365",
+    "close_button": "ghaf-close.png"
+  },
+  "Onlyoffice": {
+    "display_name": "Onlyoffice",
+    "VM": "flatpak-vm",
+    "process_name": "onlyoffice"
+  },
+  "Outlook": {
+    "display_name": "Outlook",
+    "VM": "business-vm",
+    "process_name": "outlook",
+    "close_button": "ghaf-close.png"
+  },
+  "Slack": {
+    "display_name": "Slack",
+    "VM": "comms-vm",
+    "process_name": "slack",
+    "close_button": "ghaf-close.png"
+  },
+  "Sticky Notes": {
+    "display_name": "Sticky Notes",
+    "VM": "gui-vm",
+    "process_name": "sticky-wrapped",
+    "close_button": "window-close-neg.png"
+  },
+  "Teams": {
+    "display_name": "Teams",
+    "VM": "business-vm",
+    "process_name": "teams",
+    "close_button": "ghaf-close.png"
+  },
+  "Trusted Browser": {
+    "display_name": "Trusted Browser",
+    "VM": "business-vm",
+    "process_name": "google-chrome",
+    "close_button": "ghaf-close.png"
+  },
+  "Volume Control": {
+    "display_name": "Volume Control",
+    "VM": "gui-vm",
+    "process_name": "pavucontrol",
+    "close_button": "window-close.png"
+  },
+  "VPN": {
+    "display_name": "VPN",
+    "VM": "business-vm",
+    "process_name": "gp-gui",
+    "close_button": "ghaf-close.png"
+  },
+  "Zoom": {
+    "display_name": "Zoom",
+    "VM": "comms-vm",
+    "process_name": "zoom",
+    "close_button": "ghaf-close.png",
+    "icon": "Zoom.png"
+  }
+}

--- a/Robot-Framework/resources/app_keywords.resource
+++ b/Robot-Framework/resources/app_keywords.resource
@@ -8,7 +8,7 @@ Resource            ../resources/file_keywords.resource
 Resource            ../resources/ssh_keywords.resource
 Resource            ../resources/gui_keywords.resource
 Resource            ../resources/service_keywords.resource
-
+Variables           ../config/apps.json
 
 *** Variables ***
 ${APP_OUTPUT_FILE}   /home/${USER_LOGIN}/output.log
@@ -17,47 +17,51 @@ ${APP_OUTPUT_FILE}   /home/${USER_LOGIN}/output.log
 
 *** Keywords ***
 
-Start application in VM
+App Launch Test Template
+    [Arguments]   ${app_key}
+    Set Test Documentation   Start ${app_key}[display_name] and verify process started
+    Start App in VM          ${app_key}
+    [Teardown]    Kill App in VM   ${app_key}   ${APP_OUTPUT_FILE}   status=${KEYWORD_STATUS} 
+
+Start App in VM
     [Documentation]    Use always_check_vm=True if calling from tests other than functional
     ...                After calling for this keyword use "Kill App in VM" in the test teardown
-    [Arguments]    ${app_name}   ${app-vm}   ${process_name}   ${always_check_vm}=False    ${params_string}=${EMPTY}
-    Set Test Variable    ${TEST_APP-VM}         ${app-vm}
-    Set Test Variable    ${TEST_PROCESS_NAME}   ${process_name}
+    [Arguments]    ${app_key}   ${always_check_vm}=False    ${params_string}=${EMPTY}
 
-    IF    '${app-vm}' not in ${RUNNING_VMS} or ${always_check_vm}   Check that appVM is running   ${app-vm}
-    Check that App is not running in VM    ${app-vm}   ${process_name}   range=1   before_launch_check=True
+    IF    '${app_key}[VM]' not in ${RUNNING_VMS} or ${always_check_vm}   Check that appVM is running   ${app_key}
+    Check that App is not running in VM    ${app_key}   range=1   before_launch_check=True
 
-    Start application   ${app_name}    params_string=${params_string}
-    Check that App is running in VM    ${app-vm}   ${process_name}   range=5
+    Start application   ${app_key}[display_name]    params_string=${params_string}
+    Check that App is running in VM    ${app_key}   range=5
 
 Check that appVM is running
-    [Arguments]    ${app-vm}
-    Check if ssh is ready on vm   ${app-vm}   timeout=60
-    Switch to vm      ${app-vm}
-    # Wait until systemctl status is running (ignore error in case the status is degraded)
-    ${status}     ${failed_units}     Verify Systemctl status
+    [Arguments]    ${app_key}
+    Check if ssh is ready on vm   ${app_key}[VM]   timeout=60
+    Switch to vm      ${app_key}[VM]
+    # Wait until VM systemctl status is not at starting
+    Verify Systemctl status
 
-    Append To List   ${RUNNING_VMS}   ${app-vm}
+    Append To List   ${RUNNING_VMS}   ${app_key}[VM]
     Log    ${RUNNING_VMS}
 
 Start application
     [Arguments]      ${app_name}    ${params_string}=${EMPTY}
     [Setup]    Switch to vm   ${GUI_VM}  user=${USER_LOGIN}
     Log    Starting ${app_name}   console=True
-    Run Command  nohup sh -c 'ghaf-open ${app_name} ${params_string}' > ${APP_OUTPUT_FILE} 2>&1 &
+    Run Command  nohup sh -c 'ghaf-open "${app_name}" ${params_string}' > ${APP_OUTPUT_FILE} 2>&1 &
 
 Check that App is running in VM
-    [Arguments]    ${app-vm}   ${process_name}   ${range}=2
-    ${user}        Set Variable If   '${app-vm}' == '${GUI_VM}'   ${USER_LOGIN}   ghaf
-    Switch to vm   ${app-vm}   user=${user}
-    Wait Until Keyword Succeeds    ${range}x    1s   Check that process is running   ${process_name}
+    [Arguments]    ${app_key}   ${range}=2
+    ${user}        Set Variable If   '${app_key}[VM]' == '${GUI_VM}'   ${USER_LOGIN}   ghaf
+    Switch to vm   ${app_key}[VM]   user=${user}
+    Wait Until Keyword Succeeds    ${range}x    1s   Check that process is running   ${app_key}[process_name]
 
 Check that App is not running in VM
-    [Arguments]   ${app-vm}   ${process_name}   ${range}=2   ${before_launch_check}=False
-    ${user}              Set Variable If   '${app-vm}' == '${GUI_VM}'   ${USER_LOGIN}   ghaf
-    Switch to vm         ${app-vm}   user=${user}
+    [Arguments]   ${app_key}   ${range}=2   ${before_launch_check}=False
+    ${user}              Set Variable If   '${app_key}[VM]' == '${GUI_VM}'   ${USER_LOGIN}   ghaf
+    Switch to vm         ${app_key}[VM]   user=${user}
     ${error_message}     Set Variable If      ${before_launch_check}   already running    still running
-    Wait Until Keyword Succeeds    ${range}x    1s    Check that process is not running    ${process_name}    ${error_message}
+    Wait Until Keyword Succeeds    ${range}x    1s    Check that process is not running    ${app_key}[process_name]    ${error_message}
 
 Log and remove app output
     [Documentation]    Save app output from ${GUI_VM} and remove the output file.
@@ -73,29 +77,29 @@ Log app vm journalctl
     Run Command   journalctl -b
 
 Kill App in VM
-    [Documentation]   Connects to ${app-vm} and kills process ${process_name}.
+    [Documentation]   Connects to app-vm and kills app ${app_key}.
     ...    Use after "Start application in VM", call this keyword from the test teardown.
-    [Arguments]   ${app-vm}   ${process_name}   ${log_file}=None   ${status}=${TEST_STATUS}   ${require_exists}=True
-    ${user}      Set Variable If      '${app-vm}' == '${GUI_VM}'     ${USER_LOGIN}   ghaf
-    ${sudo}      Set Variable If      '${user}' == '${USER_LOGIN}'   False           True
+    [Arguments]   ${app_key}   ${log_file}=None   ${status}=${TEST_STATUS}   ${require_exists}=True
+    ${user}      Set Variable If      '${app_key}[VM]' == '${GUI_VM}'     ${USER_LOGIN}   ghaf
+    ${sudo}      Set Variable If      '${app_key}[VM]' == '${GUI_VM}'     False           True
 
-    Switch to vm            ${app-vm}         user=${user}
-    Kill process by name    ${process_name}   sudo=${sudo}   require_exists=${require_exists}
+    Switch to vm            ${app_key}[VM]             user=${user}
+    Kill process by name    ${app_key}[process_name]   sudo=${sudo}   require_exists=${require_exists}
 
     IF  '${log_file}' != 'None'   Log and remove app output   ${log_file}
-    IF  '${status}'=='FAIL'       Log app vm journalctl       ${app-vm}
+    IF  '${status}'=='FAIL'       Log app vm journalctl       ${app_key}[VM]
 
 Start app via GUI
     [Documentation]    Start Application via GUI and verify related process started
-    [Arguments]        ${app-vm}   ${process_name}   ${display_name}
-    Check that appVM is running           ${app-vm}
-    Check that App is not running in VM   ${app-vm}   ${process_name}   range=1   before_launch_check=True
+    [Arguments]        ${app_key}
+    Check that appVM is running          ${app_key}
+    Check that App is not running in VM   ${app_key}   range=1   before_launch_check=True
 
     Open app menu
-    Type string     ${display_name}  enter_at_end=True
-    Save time       ${process_name}_start
+    Type string     ${app_key}[display_name]  enter_at_end=True
+    Save time       ${app_key}[process_name]_start
 
-    Check that App is running in VM   ${app-vm}   ${process_name}   range=10
+    Check that App is running in VM   ${app_key}   range=10
 
     [Teardown]    Run Keywords    Switch to vm    ${GUI_VM}  user=${USER_LOGIN}
     ...           AND             Move cursor to corner
@@ -116,16 +120,16 @@ Open app menu
 
 Close app via GUI
     [Documentation]    Close Application via GUI and verify related process stopped
-    [Arguments]        ${app-vm}   ${process_name}   ${close_button}   ${verify_is_killed}=True
-    Check that App is running in VM    ${app-vm}   ${process_name}   range=5
+    [Arguments]        ${app_key}   ${verify_is_killed}=True
+    Check that App is running in VM    ${app_key}   range=5
     Switch to vm       ${GUI_VM}  user=${USER_LOGIN}
     Log To Console     Clicking the close button of the application window
-    Locate and click   image  ${close_button}  0.9  iterations=25  wiggle=True
-    Save Time          ${process_name}_launched    ${LAST_SCREENSHOT_TIME}
+    Locate and click   image  ${app_key}[close_button]  0.9  iterations=25  wiggle=True
+    Save Time          ${app_key}[process_name]_launched    ${LAST_SCREENSHOT_TIME}
     IF  ${verify_is_killed}
-        ${status}          Run Keyword And Return Status  Check that App is not running in VM    ${app-vm}   ${process_name}   range=5
+        ${status}          Run Keyword And Return Status  Check that App is not running in VM    ${app_key}   range=5
         Should Be True     ${status}   Failed to close the application
     END
     # In case closing the app via GUI failed
-    [Teardown]     Run Keywords   Kill App in VM   ${app-vm}   ${process_name}   status=${KEYWORD_STATUS}   require_exists=False
+    [Teardown]     Run Keywords   Kill App in VM   ${app_key}   status=${KEYWORD_STATUS}  require_exists=${False}
     ...            AND   Switch to vm   ${GUI_VM}  user=${USER_LOGIN}   AND   Move cursor to corner

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -98,7 +98,7 @@ Type string
     [Arguments]    ${string}=${EMPTY}  ${enter_at_end}=False   ${sudo}=False
     Log To Console    Typing "${string}"
     IF  $string != '${EMPTY}'
-        Run ydotool command   type ${string}  ${sudo}
+        Run ydotool command   type "${string}"  ${sudo}
     END
     Run Keyword If  ${enter_at_end}    Press Key(s)   ENTER   ${sudo}
 
@@ -410,10 +410,10 @@ Kill Initial Setup
         Check file exists   .config/cosmic-initial-setup-done
     EXCEPT
         # Wait for the initial setup to start
-        Run Keyword and Ignore Error     Check that App is running in VM   ${GUI_VM}   cosmic-initial-setup   range=5
+        Run Keyword and Ignore Error     Check that App is running in VM   ${Cosmic Initial Setup}   range=5
         # Wait until Ghaf theme is applied, this does not happen if initial setup is killed too fast
         Wait Until Keyword Succeeds   10s   0.5s   Check file exists   .config/cosmic/com.system76.CosmicTheme*
         Sleep    1
         # Kill the initial setup so that it does not interfere with tests
-        Kill process by name   cosmic-initial-setup   sudo=False   require_exists=False
+        Kill process by name   ${Cosmic Initial Setup}[process_name]   sudo=False   require_exists=False
     END

--- a/Robot-Framework/test-suites/functional-tests/apps.robot
+++ b/Robot-Framework/test-suites/functional-tests/apps.robot
@@ -7,132 +7,111 @@ Test Tags           apps  pre-merge  bat  lenovo-x1  darter-pro  dell-7330
 
 Resource            ../../resources/app_keywords.resource
 
-Test Teardown       Kill App in VM   ${TEST_APP-VM}   ${TEST_PROCESS_NAME}   ${APP_OUTPUT_FILE}
+Test Template       App Launch Test Template
 
 
 *** Test Cases ***
 
+Start Advanced Network Configuration
+    [Tags]            SP-T336  SP-T336-1
+    ${Advanced Network Configuration}
+
 Start App Store
-    [Documentation]   Start App Store and verify process started
     [Tags]            SP-T334  SP-T334-1
-    Start application in VM   "App Store"   ${FLATPAK_VM}   cosmic-store
+    ${App Store}
 
 Start Bluetooth Settings
-    [Documentation]   Start Bluetooth Settings and verify process started
     [Tags]            SP-T204  SP-T204-1  fmo
-    Start application in VM   "Bluetooth Settings"   ${GUI_VM}   blueman-manager-wrapped-wrapped
+    ${Bluetooth Settings}
 
 Start COSMIC Document Reader
-    [Documentation]   Start COSMIC Document Reader and verify process started
     [Tags]            SP-T105  SP-T105-1
-    Start application in VM   "COSMIC Document Reader"   ${GUI_VM}   cosmic-reader
+    ${COSMIC Document Reader}
 
 Start COSMIC Files
-    [Documentation]   Start Cosmic Files and verify process started
     [Tags]            SP-T206  SP-T206-1  fmo
-    Start application in VM   "COSMIC Files"   ${GUI_VM}   ^cosmic-files$
+    ${COSMIC Files}
 
 Start COSMIC Media Player
-    [Documentation]   Start Cosmic Media Player and verify process started
     [Tags]            SP-T294  SP-T294-1
-    Start application in VM   "COSMIC Media Player"   ${GUI_VM}   cosmic-player
+    ${COSMIC Media Player}
 
 Start COSMIC Settings
-    [Documentation]   Start Cosmic Settings and verify process started
     [Tags]            SP-T254  SP-T254-1  fmo
-    Start application in VM   "COSMIC Settings"   ${GUI_VM}   cosmic-settings$
+    ${COSMIC Settings}
 
 Start COSMIC Terminal
-    [Documentation]   Start Cosmic Terminal and verify process started
     [Tags]            SP-T263  SP-T263-1  fmo
-    Start application in VM   "COSMIC Terminal"   ${GUI_VM}   cosmic-term
+    ${COSMIC Terminal}
 
 Start COSMIC Text Editor
-    [Documentation]   Start Cosmic Text Editor and verify process started
     [Tags]            SP-T243  SP-T243-1  fmo
-    Start application in VM   "COSMIC Text Editor"   ${GUI_VM}   cosmic-edit
+    ${COSMIC Text Editor}
 
 Start Calculator
-    [Documentation]   Start Calculator and verify process started
     [Tags]            SP-T202  SP-T202-1  fmo
-    Start application in VM   Calculator   ${GUI_VM}   calculator
+    ${Calculator}
 
 Start Element
-    [Documentation]   Start Element and verify process started
     [Tags]            SP-T52  SP-T52-1
-    Start application in VM   Element   ${COMMS_VM}   element
+    ${Element}
 
 Start Fingerprints
-    [Documentation]   Start Fingerprints and verify process started
     [Tags]            SP-T364  SP-T364-1
-    Start application in VM   Fingerprints   ${GUI_VM}   fingwit
-
-Start GPU Screen Recorder
-    [Documentation]   Start GPU Screen Recorder and verify process started
-    [Tags]            SP-T293  SP-T293-1
-    Start application in VM   "GPU Screen Recorder"   ${GUI_VM}   gpu-screen-recorder
+    ${Fingerprints}
 
 Start Gala
-    [Documentation]   Start Gala and verify process started
     [Tags]            SP-T104  SP-T104-1
-    Start application in VM   Gala   ${BUSINESS_VM}   gala
+    ${Gala}
 
 Start Getting Started
-    [Documentation]   Start 'Getting Started' and verify process started
     [Tags]            SP-T354  SP-T354-1
-    Start application in VM   "Getting Started"  ${CHROME_VM}   ghaf-intro
+    ${Getting Started}
 
 Start Ghaf Control Panel
-    [Documentation]   Start Ghaf Control Panel and verify process started
     [Tags]            SP-T205  SP-T205-1  fmo
-    Start application in VM   "Ghaf Control Panel"   ${GUI_VM}   ctrl-panel
+    ${Ghaf Control Panel}
 
 Start Google Chrome
-    [Documentation]   Start Google Chrome and verify process started
     [Tags]            SP-T92  SP-T92-1
-    Start application in VM   "Google Chrome"   ${CHROME_VM}   chrome
+    ${Google Chrome}
+
+Start GPU Screen Recorder
+    [Tags]            SP-T293  SP-T293-1
+    ${GPU Screen Recorder}
 
 Start Microsoft 365
-    [Documentation]   Start Microsoft 365 and verify process started
     [Tags]            SP-T178  SP-T178-1
-    Start application in VM   "Microsoft 365"   ${BUSINESS_VM}   microsoft365
+    ${Microsoft 365}
 
 Start Outlook
-    [Documentation]   Start Outlook and verify process started
     [Tags]            SP-T176  SP-T176-1
-    Start application in VM   Outlook   ${BUSINESS_VM}   outlook
+    ${Outlook}
 
 Start Slack
-    [Documentation]   Start Slack and verify process started
     [Tags]            SP-T181  SP-T181-1
-    Start application in VM   Slack   ${COMMS_VM}   slack
+    ${Slack}
 
 Start Sticky Notes
-    [Documentation]   Start Sticky Notes and verify process started
     [Tags]            SP-T201  SP-T201-1  fmo
-    Start application in VM   "Sticky Notes"   ${GUI_VM}   sticky-wrapped
+    ${Sticky Notes}
 
 Start Teams
-    [Documentation]   Start Teams and verify process started
     [Tags]            SP-T177  SP-T177-1
-    Start application in VM   Teams   ${BUSINESS_VM}   teams
+    ${Teams}
 
 Start Trusted Browser
-    [Documentation]   Start Trusted Browser and verify process started
     [Tags]            SP-T179  SP-T179-1
-    Start application in VM   "Trusted Browser"  ${BUSINESS_VM}   google-chrome
+    ${Trusted Browser}
 
 Start Volume Control
-    [Documentation]   Start Volume Control and verify process started
     [Tags]            SP-T349  SP-T349-1
-    Start application in VM   "Volume Control"  ${GUI_VM}   pavucontrol
+    ${Volume Control}
 
 Start VPN
-    [Documentation]   Start VPN app and verify process started
     [Tags]            SP-T200  SP-T200-1
-    Start application in VM   VPN  ${BUSINESS_VM}   gp-gui
+    ${VPN}
 
 Start Zoom
-    [Documentation]   Start Zoom and verify process started
     [Tags]            SP-T237  SP-T237-1
-    Start application in VM   Zoom  ${COMMS_VM}   zoom
+    ${Zoom}

--- a/Robot-Framework/test-suites/functional-tests/files.robot
+++ b/Robot-Framework/test-suites/functional-tests/files.robot
@@ -16,37 +16,37 @@ ${OUTPUT_FILE}   /tmp/out.log
 *** Test Cases ***
 
 Open PDF from chrome-vm
-    [Documentation]    Open PDF file from Chrome VM and check that Ghaf Isolated Document Viewer started
+    [Documentation]    Open PDF file from ${CHROME_VM} and check that ${Ghaf Isolated Document Viewer}[display_name] started
     [Tags]             SP-T131  SP-T131-1  pre-merge
     Open PDF from app-vm    ${CHROME_VM}
 
 Open PDF from comms-vm
-    [Documentation]    Open PDF file from Comms VM and check that Ghaf Isolated Document Viewer started
+    [Documentation]    Open PDF file from ${COMMS_VM} and check that ${Ghaf Isolated Document Viewer}[display_name] started
     [Tags]             SP-T131  SP-T131-2
     Open PDF from app-vm    ${COMMS_VM}
 
 Open PDF from business-vm
-    [Documentation]    Open PDF file from Business VM and check that Ghaf Isolated Document Viewer started
+    [Documentation]    Open PDF file from ${BUSINESS_VM} and check that ${Ghaf Isolated Document Viewer}[display_name] started
     [Tags]             SP-T131  SP-T131-3
     Open PDF from app-vm    ${BUSINESS_VM}
 
 Open PDF from gui-vm
-    [Documentation]    Open PDF file from Gui VM and check that Ghaf Isolated Document Viewer started
+    [Documentation]    Open PDF file from ${GUI_VM} and check that ${Ghaf Isolated Document Viewer}[display_name] started
     [Tags]             SP-T131  SP-T131-4
     Open PDF from app-vm    ${GUI_VM}  user=${USER_LOGIN}  sudo=False
 
-Open image with Oculante
-    [Documentation]    Open PNG image in the Gui VM and check that Oculante app is started and opens the image
+Open image with Ghaf Isolated Image Viewer
+    [Documentation]    Open PNG image from ${GUI_VM} and check that ${Ghaf Isolated Image Viewer}[display_name] started
     [Tags]             SP-T197  pre-merge
     Switch to vm       ${GUI_VM}  user=${USER_LOGIN}
     Run Command        WAYLAND_DISPLAY=wayland-1 grim ./screenshot.png   timeout=5
     Open file with XDG handler   ./screenshot.png   sudo=False
-    Check that App is running in VM    ${MEDIA_VM}   oculante   range=10
+    Check that App is running in VM    ${Ghaf Isolated Image Viewer}    range=10
     [Teardown]  Run Keywords  Remove the file in VM       ./screenshot.png  ${GUI_VM}   ${USER_LOGIN}   AND
-    ...                       Kill app and XDG process    oculante
+    ...                       Kill app and XDG process    ${Ghaf Isolated Image Viewer}[process_name]
 
 Open video with COSMIC Media Player
-    [Documentation]    Record a video in the Gui VM and check that xdg-open opens it with COSMIC Media Player
+    [Documentation]    Record a video in ${GUI_VM} and check that ${Ghaf Isolated Media Player}[display_name] started
     [Tags]             SP-T367
     Switch to vm       ${GUI_VM}  user=${USER_LOGIN}
     ${test_name}       Replace String   ${TEST_NAME}   ${SPACE}   _
@@ -57,22 +57,22 @@ Open video with COSMIC Media Player
     Check file exists              ${video_file}
     ${open_timestamp}            Run Command    date +%s
     Open file with XDG handler     ${video_file}   sudo=False
-    Check that App is running in VM    ${MEDIA_VM}   cosmic-player   range=10
+    Check that App is running in VM    ${Ghaf Isolated Media Player}   range=10
     [Teardown]  Run Keywords  Switch to vm    ${GUI_VM}  user=${USER_LOGIN}   AND
     ...                       Stop screen recording service   robot-video-file-test-recording   AND
     ...                       Remove the file in VM       ${video_file}  ${GUI_VM}   ${USER_LOGIN}   AND
-    ...                       Kill app and XDG process    cosmic-player   AND
-    ...                       Run Keyword If   '${TEST_STATUS}' == 'FAIL'   Check for cosmic app crash   ${open_timestamp}   cosmic-player   ${test_name}.mkv
+    ...                       Kill app and XDG process    ${Ghaf Isolated Media Player}[process_name]   AND
+    ...                       Run Keyword If   '${TEST_STATUS}' == 'FAIL'   Check for cosmic app crash   ${open_timestamp}   ${Ghaf Isolated Media Player}[process_name]   ${test_name}.mkv
 
-Open text file with Cosmic Text Editor
-    [Documentation]    Open text file and check that Cosmic Text Editor app is started
+Open text file with COSMIC Text Editor
+    [Documentation]    Open text file and check that ${COSMIC Text Editor}[display_name] started
     [Tags]             SP-T262  pre-merge
     Switch to vm       ${GUI_VM}  user=${USER_LOGIN}
     Create text file   test    /tmp/test_text.txt
     Open file to gui-vm with XDG handler    /tmp/test_text.txt
-    Check that App is running in VM         ${GUI_VM}   cosmic-edit   range=10
+    Check that App is running in VM         ${COSMIC Text Editor}   range=10
     [Teardown]  Run Keywords  Remove the file in VM    /tmp/test_text.txt    ${GUI_VM}    ${USER_LOGIN}    AND
-    ...                       Kill App in VM    ${GUI_VM}    cosmic-edit    log_file=${OUTPUT_FILE}
+    ...                       Kill App in VM    ${COSMIC Text Editor}    log_file=${OUTPUT_FILE}
 
 
 *** Keywords ***
@@ -94,10 +94,10 @@ Open PDF from app-vm
     Put File                     ../test-files/test_pdf.pdf   /tmp/test_pdf_${vm}.pdf
     ${open_timestamp}            Run Command    date +%s
     Open file with XDG handler   /tmp/test_pdf_${vm}.pdf   sudo=${sudo}
-    Check that App is running in VM    ${MEDIA_VM}   cosmic-reader   range=10
+    Check that App is running in VM    ${Ghaf Isolated Document Viewer}   range=10
     [Teardown]    Run Keywords   Remove the file in VM        /tmp/test_pdf_${vm}.pdf   ${vm}  ${user}
-    ...                    AND   Kill app and XDG process     cosmic-reader
-    ...                    AND   Run Keyword If   '${KEYWORD_STATUS}' == 'FAIL'   Check for cosmic app crash   ${open_timestamp}   cosmic-reader   test_pdf_${vm}.pdf
+    ...                    AND   Kill app and XDG process     ${Ghaf Isolated Document Viewer}[process_name]
+    ...                    AND   Run Keyword If   '${KEYWORD_STATUS}' == 'FAIL'   Check for cosmic app crash   ${open_timestamp}   ${Ghaf Isolated Document Viewer}[process_name]   test_pdf_${vm}.pdf
 
 Open file with XDG handler
     [Arguments]      ${file}  ${sudo}=True

--- a/Robot-Framework/test-suites/functional-tests/fmo_apps.robot
+++ b/Robot-Framework/test-suites/functional-tests/fmo_apps.robot
@@ -7,32 +7,27 @@ Test Tags           fmo-apps  bat  fmo
 
 Resource            ../../resources/app_keywords.resource
 
-Test Teardown       Kill App in VM   ${TEST_APP-VM}   ${TEST_PROCESS_NAME}   ${APP_OUTPUT_FILE}
+Test Template       App Launch Test Template
 
 
 *** Test Cases ***
 
-Start Display Settings on FMO
-    [Documentation]   Start Display Settings and verify process started
+Start Display Settings
     [Tags]            display_settings
-    Start application in VM   'Display Settings'   ${GUI_VM}   wdisplays
+    ${Display Settings}
 
-Start Firefox GPU on FMO
-    [Documentation]   Start Firefox GPU and verify process started
+Start Firefox GPU
     [Tags]            firefox_gpu
-    Start application in VM   'Firefox GPU'   ${GUI_VM}   firefox
+    ${Firefox GPU}
 
 Start FMO Onboarding Agent
-    [Documentation]   Start FMO Onboarding Agent and verify process started
     [Tags]            onboarding
-    Start application in VM   "FMO Onboarding Agent"   ${DOCKER_VM}   fmo-onboarding
+    ${FMO Onboarding Agent}
 
 Start FMO Offboarding
-    [Documentation]   Start FMO Offboarding and verify process started
     [Tags]            offboarding
-    Start application in VM   "FMO Offboarding"   ${DOCKER_VM}   fmo-offboarding
+    ${FMO Offboarding}
 
-Start Google Chrome GPU on FMO
-    [Documentation]   Start Google Chrome GPU and verify process started
+Start Google Chrome GPU
     [Tags]            chrome_gpu
-    Start application in VM   'Google Chrome GPU'   ${GUI_VM}   chrome
+    ${Google Chrome GPU}

--- a/Robot-Framework/test-suites/gui-tests/__init__.robot
+++ b/Robot-Framework/test-suites/gui-tests/__init__.robot
@@ -39,5 +39,5 @@ Save gui icons and icon path
     Negate app icon         ${ICONS_DIR}/search.png  ${ICONS_DIR}/search-neg.png
     Get icon                ${icons}/Papirus/24x24/actions  system-shutdown.svg  crop=0  background=black  output_filename=power.png
     # App icons
-    Get icon                ${icons}/Papirus/48x48/apps  Zoom.svg  crop=0  background=black  output_filename=Zoom.png
-    Get icon                ${icons}/hicolor/48x48/apps  com.system76.CosmicSettings.svg  background=black  output_filename=settings.png
+    Get icon                ${icons}/Papirus/48x48/apps  Zoom.svg  crop=0  background=black  output_filename=${Zoom}[icon]
+    Get icon                ${icons}/hicolor/48x48/apps  com.system76.CosmicSettings.svg  background=black  output_filename=${COSMIC Settings}[icon]

--- a/Robot-Framework/test-suites/gui-tests/gui_app_launch.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_app_launch.robot
@@ -16,186 +16,122 @@ Resource            ../../resources/ssh_keywords.resource
 Test Setup          Start screen recording
 Test Teardown       Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 Suite Teardown      Create App Launch Montage And Move Graphs
+Test Template       Launch App And Save Time
 
 
 *** Test Cases ***
 
+Start Advanced Network Configuration via GUI
+    [Tags]            SP-T336  SP-T336-2
+    ${Advanced Network Configuration}
+
 Start App Store via GUI
-    [Documentation]   Start App Store via GUI and measure launch time
     [Tags]            SP-T334  SP-T334-2
-    Start app via GUI   ${FLATPAK_VM}  cosmic-store  "App Store"
-    Close app via GUI   ${FLATPAK_VM}  cosmic-store  window-close-neg.png
-    Save launch time    cosmic-store
+    ${App Store}
 
 Start Bluetooth Settings via GUI
-    [Documentation]   Start Bluetooth Settings via GUI and measure launch time
     [Tags]            SP-T204  SP-T204-2
-    Start app via GUI   ${GUI_VM}  blueman-manager-wrapped-wrapped  "Bluetooth Settings"
-    Close app via GUI   ${GUI_VM}  blueman-manager-wrapped-wrapped  window-close.png
-    Save launch time    blueman-manager-wrapped-wrapped
+    ${Bluetooth Settings}
 
 Start COSMIC Document Reader via GUI
-    [Documentation]   Start COSMIC Document Reader via GUI and measure launch time
     [Tags]            SP-T105  SP-T105-2
-    Start app via GUI   ${GUI_VM}  cosmic-reader   "COSMIC Document Reader"
-    Close app via GUI   ${GUI_VM}  cosmic-reader   ghaf-close.png
-    Save launch time    cosmic-reader
+    ${COSMIC Document Reader}
 
 Start COSMIC Files via GUI
-    [Documentation]   Start COSMIC Files via GUI and measure launch time
     [Tags]            SP-T206  SP-T206-2
-    Start app via GUI   ${GUI_VM}  ^cosmic-files$  "COSMIC Files"
-    Close app via GUI   ${GUI_VM}  ^cosmic-files$  ghaf-close.png
-    Save launch time    ^cosmic-files$
+    ${COSMIC Files}
 
 Start COSMIC Media Player via GUI
-    [Documentation]   Start COSMIC Media Player via GUI and measure launch time
     [Tags]            SP-T294  SP-T294-2
-    Start app via GUI   ${GUI_VM}  cosmic-player  "COSMIC Media Player"
-    Close app via GUI   ${GUI_VM}  cosmic-player  ghaf-close.png
-    Save launch time    cosmic-player
+    ${COSMIC Media Player}
 
 Start COSMIC Settings via GUI
-    [Documentation]   Start COSMIC Settings via GUI and measure launch time
     [Tags]            SP-T254  SP-T254-2
-    Start app via GUI   ${GUI_VM}  cosmic-settings$  "COSMIC Settings"
-    Close app via GUI   ${GUI_VM}  cosmic-settings$  ghaf-close.png
-    Save launch time    cosmic-settings$
+    ${COSMIC Settings}
 
 Start COSMIC Terminal via GUI
-    [Documentation]   Start COSMIC Terminal via GUI and measure launch time
     [Tags]            SP-T263  SP-T263-2
-    Start app via GUI   ${GUI_VM}  cosmic-term  "COSMIC Terminal"
-    Close app via GUI   ${GUI_VM}  cosmic-term  ghaf-close.png
-    Save launch time    cosmic-term
+    ${COSMIC Terminal}
 
 Start COSMIC Text Editor via GUI
-    [Documentation]   Start COSMIC Text Editor via GUI and measure launch time
     [Tags]            SP-T243  SP-T243-2
-    Start app via GUI   ${GUI_VM}  cosmic-edit  "COSMIC Text Editor"
-    Close app via GUI   ${GUI_VM}  cosmic-edit  ghaf-close.png
-    Save launch time    cosmic-edit
+    ${COSMIC Text Editor}
 
 Start Calculator via GUI
-    [Documentation]   Start Calculator via GUI and measure launch time
     [Tags]            SP-T202  SP-T202-2
-    Start app via GUI   ${GUI_VM}  gnome-calculator  Calculator
-    Close app via GUI   ${GUI_VM}  gnome-calculator  window-close-neg.png
-    Save launch time    gnome-calculator
+    ${Calculator}
 
 Start Element via GUI
-    [Documentation]   Start Element via GUI and measure launch time
     [Tags]            SP-T52  SP-T52-2
-    Start app via GUI   ${COMMS_VM}  element  Element
-    Close app via GUI   ${COMMS_VM}  element  ghaf-close.png
-    Save launch time    element
+    ${Element}
 
 Start Fingerprints via GUI
-    [Documentation]   Start Fingerprints via GUI and measure launch time
     [Tags]            SP-T364  SP-T364-2
-    Start app via GUI   ${GUI_VM}  fingwit  Fingerprints
-    Close app via GUI   ${GUI_VM}  fingwit  window-close.png
-    Save launch time    fingwit
-
-Start GPU Screen Recorder via GUI
-    [Documentation]   Start GPU Screen Recorder via GUI and measure launch time
-    [Tags]            SP-T293  SP-T293-2
-    Start app via GUI   ${GUI_VM}  gpu-screen-recorder-gtk  "GPU Screen Recorder"
-    Close app via GUI   ${GUI_VM}  gpu-screen-recorder-gtk  window-close.png
-    Save launch time    gpu-screen-recorder-gtk
+    ${Fingerprints}
 
 Start Gala via GUI
-    [Documentation]   Start Gala via GUI and measure launch time
     [Tags]            SP-T104  SP-T104-2
-    Start app via GUI   ${BUSINESS_VM}  gala  Gala
-    Close app via GUI   ${BUSINESS_VM}  gala  ghaf-close.png
-    Save launch time    gala
+    ${Gala}
 
 Start Getting Started via GUI
-    [Documentation]   Start 'Getting Started' via GUI and measure launch time
     [Tags]            SP-T354  SP-T354-2
-    Start app via GUI   ${CHROME_VM}  ghaf-intro  "Getting Started"
-    Close app via GUI   ${CHROME_VM}  ghaf-intro  ghaf-close.png
-    Save launch time    ghaf-intro
+    ${Getting Started}
 
 Start Ghaf Control Panel via GUI
-    [Documentation]   Start Ghaf Control Panel via GUI and measure launch time
     [Tags]            SP-T205  SP-T205-2
-    Start app via GUI   ${GUI_VM}  ctrl-panel  "Ghaf Control Panel"
-    Close app via GUI   ${GUI_VM}  ctrl-panel  window-close-neg.png
-    Save launch time    ctrl-panel
+    ${Ghaf Control Panel}
 
 Start Google Chrome via GUI
-    [Documentation]   Start Google Chrome via GUI and measure launch time
     [Tags]            SP-T92  SP-T92-2
-    Start app via GUI   ${CHROME_VM}  chrome  "Google Chrome"
-    Close app via GUI   ${CHROME_VM}  chrome  ghaf-close.png
-    Save launch time    chrome
+    ${Google Chrome}
+
+Start GPU Screen Recorder via GUI
+    [Tags]            SP-T293  SP-T293-2
+    ${GPU Screen Recorder}
 
 Start Microsoft 365 via GUI
-    [Documentation]   Start Microsoft 365 via GUI and measure launch time
     [Tags]            SP-T178  SP-T178-2
-    Start app via GUI   ${BUSINESS_VM}  microsoft365  "Microsoft 365"
-    Close app via GUI   ${BUSINESS_VM}  microsoft365  ghaf-close.png
-    Save launch time    microsoft365
+    ${Microsoft 365}
 
 Start Outlook via GUI
-    [Documentation]   Start Outlook via GUI and measure launch time
     [Tags]            SP-T176  SP-T176-2
-    Start app via GUI   ${BUSINESS_VM}  outlook  Outlook
-    Close app via GUI   ${BUSINESS_VM}  outlook  ghaf-close.png
-    Save launch time    outlook
+    ${Outlook}
 
 Start Slack via GUI
-    [Documentation]   Start Slack via GUI and measure launch time
     [Tags]            SP-T181  SP-T181-2
-    Start app via GUI   ${COMMS_VM}  slack  Slack
-    Close app via GUI   ${COMMS_VM}  slack  ghaf-close.png
-    Save launch time    slack
+    ${Slack}
 
 Start Sticky Notes via GUI
-    [Documentation]   Start Sticky Notes via GUI and measure launch time
     [Tags]            SP-T201  SP-T201-2
-    Start app via GUI   ${GUI_VM}  sticky-wrapped  "Sticky Notes"
-    Close app via GUI   ${GUI_VM}  sticky-wrapped  window-close-neg.png
-    Save launch time    sticky-wrapped
+    ${Sticky Notes}
 
 Start Teams via GUI
-    [Documentation]   Start Teams via GUI and measure launch time
     [Tags]            SP-T177  SP-T177-2
-    Start app via GUI   ${BUSINESS_VM}  teams  Teams
-    Close app via GUI   ${BUSINESS_VM}  teams  ghaf-close.png
-    Save launch time    teams
+    ${Teams}
 
 Start Trusted Browser via GUI
-    [Documentation]   Start Trusted Browser via GUI and measure launch time
     [Tags]            SP-T179  SP-T179-2
-    Start app via GUI   ${BUSINESS_VM}  google-chrome  "Trusted Browser"
-    Close app via GUI   ${BUSINESS_VM}  google-chrome  ghaf-close.png
-    Save launch time    google-chrome
+    ${Trusted Browser}
 
 Start Volume Control via GUI
-    [Documentation]   Start Volume Control via GUI and measure launch time
     [Tags]            SP-T349  SP-T349-2
-    Start app via GUI   ${GUI_VM}  pavucontrol  "Volume Control"
-    Close app via GUI   ${GUI_VM}  pavucontrol  window-close.png
-    Save launch time    pavucontrol
+    ${Volume Control}
 
 Start VPN via GUI
-    [Documentation]   Start VPN app via GUI and measure launch time
     [Tags]            SP-T200  SP-T200-2
-    Start app via GUI   ${BUSINESS_VM}  gp-gui  VPN
-    Close app via GUI   ${BUSINESS_VM}  gp-gui  ghaf-close.png
-    Save launch time    gp-gui
+    ${VPN}
 
 Start Zoom via GUI
-    [Documentation]   Start Zoom via GUI and measure launch time
     [Tags]            SP-T237  SP-T237-2
-    Start app via GUI   ${COMMS_VM}  zoom  Zoom
-    Close app via GUI   ${COMMS_VM}  zoom  ghaf-close.png
-    Save launch time    zoom
+    ${Zoom}
 
 *** Keywords ***
+Launch App And Save Time
+    [Arguments]    ${app_key}
+    Set Test Documentation   Start ${app_key}[display_name] via GUI and measure launch time
+    Start app via GUI   ${app_key}
+    Close app via GUI   ${app_key}
+    Save launch time    ${app_key}
 
 Create App Launch Montage And Move Graphs
     [Documentation]   Combine all graphs to one image and move the single graphs to their own folder
@@ -207,17 +143,17 @@ Save launch time
     [Documentation]    Evaluate the time between starting the app from the GUI app menu
     ...                and locating & clicking the close button on the app window.
     ...                Threshold is read from performance_thresholds.py (storeDisk uses its dedicated value).
-    [Arguments]    ${app_boot}    ${app_proc}=${app_boot}
+    [Arguments]        ${app_key}
     IF    "storeDisk" in "${JOB}"
         ${threshold}    Set Variable    ${static_thresholds}[app_launch_time_storedisk]
     ELSE
         ${threshold}    Set Variable    ${static_thresholds}[app_launch_time]
     END
-    ${diff}        Evaluate    ${TIME_${app_proc}_launched} - ${TIME_${app_boot}_start}
+    ${diff}        Evaluate    ${TIME_${app_key}[process_name]_launched} - ${TIME_${app_key}[process_name]_start}
     &{results}     Create Dictionary
     Set To Dictionary  ${results}    time_to_launch  ${diff}
     ${passed}      Save App Launch Time Data   ${TEST NAME}  ${results}  ${threshold}
-    Log  <img src="${DEVICE}_${TEST NAME}.png" alt="Launch Time of ${app_boot}" width="1200">    HTML
+    Log  <img src="${DEVICE}_${TEST NAME}.png" alt="Launch Time of ${app_key}[process_name]" width="1200">    HTML
     IF    not ${passed}
-        FAIL    ${app_boot} was started in ~${diff} sec, expected <=${threshold} sec
+        FAIL    ${app_key}[display_name] was started in ~${diff} sec, expected <=${threshold} sec
     END

--- a/Robot-Framework/test-suites/gui-tests/gui_app_store.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_app_store.robot
@@ -19,13 +19,13 @@ Test Timeout        10 minutes
 Install Firefox
     [Documentation]    Install and launch Firefox from App Store
     [Tags]    SP-T335
-    Install and Launch App Store app   firefox
+    Install and Launch App Store app   ${Firefox}
 
 Install Onlyoffice and save documents
     [Documentation]    Install and launch Onlyoffice from App Store
     ...                Save different types of files to Shares
     [Tags]    SP-T312  SP-T313  SP-T314  SP-T355
-    Install and Launch App Store app   onlyoffice
+    Install and Launch App Store app   ${Onlyoffice}
 
     Save a file from Onlyoffice   Document       test_Document.docx
     Save a file from Onlyoffice   Spreadsheet    test_Spreadsheet.xlsx
@@ -34,38 +34,38 @@ Install Onlyoffice and save documents
 *** Keywords ***
 
 App Store Test Teardown
-    ${availability}         Check variable availability   app_name
-    IF   ${availability}    Kill app and Uninstall in App Store   ${app_name}
+    ${availability}         Check variable availability   app_key
+    IF   ${availability}    Kill app and Uninstall in App Store   ${app_key}
     Switch to vm            ${GUI_VM}  user=${USER_LOGIN}
     Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
 Install and Launch App Store app
-    [Documentation]   Install app from App Store and launch the app from the app menu
-    [Arguments]       ${app_name}   ${process_name}=${app_name}
-    [Setup]           Verify app is not preinstalled via flatpak   ${app_name}
+    [Documentation]   Install app from App Store and launch it from the app menu
+    [Arguments]       ${app_key}
+    [Setup]           Verify app is not preinstalled via flatpak   ${app_key}[process_name]
 
-    Set Test Variable   ${app_name}
+    Set Test Variable   ${app_key}
 
     Open App Store
 
     # Search for app page and open it
-    Type string        ${app_name}[:-1]  # Last letter removed to not disturb text recognition
+    Type string        ${app_key}[display_name][:-1]  # Last letter removed to not disturb text recognition
     Sleep   1
-    Locate and click   text   ${app_name}   wiggle=True
+    Locate and click   text   ${app_key}[display_name]   wiggle=True
     Tab and enter      tabs=1    # Close the sidebar
 
     # Install app
     Locate and click   text   nstall   scale=3   wiggle=True   #Typo intentional, "I" is sometimes not recognized by the text recognition
     Move cursor to corner
-    Wait until flatpak app is installed    ${app_name}
+    Wait until flatpak app is installed    ${app_key}[process_name]
 
     # Close App Store
-    Close app via GUI   ${FLATPAK_VM}  cosmic-store  window-close-neg.png
+    Close app via GUI   ${App Store}
 
     # Launch app from app menu, verify and kill it
-    Start app via GUI   ${FLATPAK_VM}   ${process_name}   ${app_name}
+    Start app via GUI   ${app_key}
 
-    [Teardown]   Kill App in VM   ${FLATPAK_VM}   cosmic-store   status=${KEYWORD_STATUS}   require_exists=False
+    [Teardown]   Kill App in VM   ${App Store}   status=${KEYWORD_STATUS}   require_exists=False
 
 Verify app is not preinstalled via flatpak
     [Arguments]    ${app_name}
@@ -108,7 +108,7 @@ Get flatpak app id
     [Teardown]    Run Keyword if   ${switch_to_vm}   Switch to vm   ${GUI_VM}  user=${USER_LOGIN}
 
 Open App Store
-    Start application in VM   "App Store"   ${FLATPAK_VM}   cosmic-store   always_check_vm=True
+    Start app via GUI    ${App Store}
     Switch to vm   ${GUI_VM}  user=${USER_LOGIN}
     # Wait for the window to be active and fullscreen it
     Locate on screen   text   Editor   iterations=20
@@ -116,13 +116,12 @@ Open App Store
 
 Kill app and Uninstall in App Store
     [Documentation]   Kill app, uninstall it via GUI and verify
-    [Arguments]       ${app_name}  ${process_name}=${app_name}
-    Switch to vm      ${FLATPAK_VM}
-    Kill process by name   ${process_name}   sudo=True
+    [Arguments]       ${app_key}
+    Kill App in VM    ${app_key}
     Open App Store
-    Log     Uninstalling ${app_name}   console=True
+    Log     Uninstalling ${app_key}[display_name]   console=True
     Locate and click   text   nstalled      scale=2   wiggle=True  #Typo intentional, "I" is sometimes not recognized by the text recognition
-    Locate and click   text   ${app_name}   wiggle=True
+    Locate and click   text   ${app_key}[display_name]   wiggle=True
     # Uninstall app
     Locate and click   text   Uninstall     scale=3   wiggle=True
     Locate and click   text   Permanently   scale=2   wiggle=True
@@ -131,15 +130,15 @@ Kill app and Uninstall in App Store
     Sleep  1
     Locate and click   text   Back   scale=3   wiggle=True
     # Verify uninstallation via GUI
-    ${is_installed}    Run Keyword And Return Status   Locate on screen   text   ${app_name}   iterations=3   expected_result=FAIL
-    IF   ${is_installed}   FAIL   App ${app_name} is still shown as installed in App Store
+    ${is_installed}    Run Keyword And Return Status   Locate on screen   text   ${app_key}[display_name]   iterations=3   expected_result=FAIL
+    Should Not Be True   ${is_installed}     App ${app_key}[display_name] is still shown as installed in ${App Store}[display_name]
     # Verify uninstallation via flatpak
-    ${flatpak_app_id}   Get flatpak app id   ${app_name}
-    Should Be Empty     ${flatpak_app_id}    App ${app_name} is still installed via flatpak (${flatpak_app_id})
-    Log   ${app_name} is now uninstalled   console=True
-    Close app via GUI   ${FLATPAK_VM}  cosmic-store  window-close-neg.png
-    [Teardown]   Run Keywords   Kill App in VM   ${FLATPAK_VM}   cosmic-store      status=${KEYWORD_STATUS}   require_exists=False
-    ...                   AND   Kill App in VM   ${FLATPAK_VM}   ${process_name}   status=${KEYWORD_STATUS}   require_exists=False
+    ${flatpak_app_id}   Get flatpak app id   ${app_key}[process_name]
+    Should Be Empty     ${flatpak_app_id}    App ${app_key}[display_name] is still installed via flatpak (${flatpak_app_id})
+    Log   ${app_key}[display_name] is now uninstalled   console=True
+    Close app via GUI    ${App Store}
+    [Teardown]   Run Keywords   Kill App in VM  ${App Store}   status=${KEYWORD_STATUS}   require_exists=False
+    ...                   AND   Kill App in VM  ${app_key}     status=${KEYWORD_STATUS}   require_exists=False
 
 Save a file from Onlyoffice
     [Documentation]   Open a file in Onlyoffice and save it to Shares
@@ -162,7 +161,7 @@ Save a file from Onlyoffice
     Press Key(s)       ENTER
 
     Wait Until Keyword Succeeds   5x   1s   Check file exists   /Shares/'Unsafe flatpak-vm share'/${file_name}
-    Locate and click    text   Onlyoffice   wiggle=True
+    Locate and click    text   ${Onlyoffice}[display_name]   wiggle=True
 
     [Teardown]   Remove file  /Shares/'Unsafe flatpak-vm share'/${file_name}
 

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -15,66 +15,66 @@ Test Teardown       Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 *** Test Cases ***
 
 Create and save text file from COSMIC Text Editor via GUI
-    [Documentation]   Create a new document in COSMIC Text Editor, save it to Shares and verify the file was created
+    [Documentation]   Create a new document in ${COSMIC Text Editor}[display_name], save it to Shares and verify the file was created
     [Tags]            SP-T194
     ${file_name}       Set Variable    cosmic_text_editor_save_test.txt
     ${doc_text}        Set Variable    test_content
     ${share_path}      Set Variable    /Shares/'Unsafe comms-vm share'/${file_name}
 
-    Start app via GUI   ${GUI_VM}  cosmic-edit  "COSMIC Text Editor"
-    Locate on screen    image      ghaf-close.png
+    Start app via GUI   ${COSMIC Text Editor}
+    Locate on screen    image      ${COSMIC Text Editor}[close_button]
     Type string         ${doc_text}   enter_at_end=True
-    Save current document from Cosmic Text Editor to Shares   ${file_name}
+    Save current document from COSMIC Text Editor to Shares   ${file_name}
     Check file exists   ${share_path}
     ${saved_content}    Run Command    cat ${share_path}
     Should Contain      ${saved_content}   ${doc_text}
-    Close app via GUI   ${GUI_VM}  cosmic-edit  ghaf-close.png
+    Close app via GUI   ${COSMIC Text Editor}
     [Teardown]   Run Keywords   Remove file by name    ${file_name}
     ...    AND   Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
 Copy and paste text between VMs
-    [Documentation]   Copy text in COSMIC Text Editor (GUI VM) and paste it into Trusted Browser (BUSINESS VM)
+    [Documentation]   Copy text in ${COSMIC Text Editor}[display_name] and paste it into ${Trusted Browser}[display_name]
     [Tags]            SP-T72
     ${clipboard_text}    Set Variable  COPYPASTE
-    Start app via GUI    ${GUI_VM}     cosmic-edit  "COSMIC Text Editor"
-    Locate on screen     image         ghaf-close.png
+    Start app via GUI    ${COSMIC Text Editor}
+    Locate on screen     image         ${COSMIC Text Editor}[close_button]
     Copy text to clipboard    ${clipboard_text}
-    Start app via GUI   ${BUSINESS_VM}  google-chrome  "Trusted Browser"
+    Start app via GUI    ${Trusted Browser}
     Paste clipboard text and verify     ${clipboard_text}
-    [Teardown]    Run Keywords    Kill App in VM   ${BUSINESS_VM}   google-chrome
-    ...           AND             Kill App in VM   ${GUI_VM}        cosmic-edit
+    [Teardown]    Run Keywords    Kill App in VM   ${Trusted Browser}
+    ...           AND             Kill App in VM   ${COSMIC Text Editor}
     ...           AND             Switch to vm     ${GUI_VM}        user=${USER_LOGIN}
     ...           AND             Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
 Open an app from the dock
     [Documentation]   Open Zoom, minimize its window, verify it is hidden, then restore it from dock and compare coordinates.
     [Tags]            SP-T79
-    Start app via GUI   ${COMMS_VM}   zoom    "Zoom"
+    Start app via GUI    ${Zoom}
     ${zoom_window_coords}    ${zoom_anchor_coords}    Save Zoom window baseline coordinates
     ${zoom_before_x}   ${zoom_before_y}    Save Zoom icon coordinates
     Locate and click minimize window button
     Verify app window is minimized
     Wait for Zoom icon coordinates to change and restore window    ${zoom_before_x}    ${zoom_before_y}
     Verify Zoom window restored to baseline    ${zoom_window_coords}    ${zoom_anchor_coords}
-    [Teardown]   Run Keywords    Kill App in VM    ${COMMS_VM}    zoom
+    [Teardown]   Run Keywords    Kill App in VM   ${Zoom}
     ...    AND   Switch to vm    ${GUI_VM}  user=${USER_LOGIN}    AND    Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
 Maximize and restore window
     [Documentation]   Open Zoom, maximize its window, verify it, then restore it and compare coordinates.
     [Tags]            SP-T78
-    Start app via GUI   ${COMMS_VM}   zoom    "Zoom"
+    Start app via GUI    ${Zoom}
     ${zoom_window_coords}    ${zoom_anchor_coords}    Save Zoom window baseline coordinates
     Locate and click maximize/restore window button
     Verify app window is maximized
     Locate and click maximize/restore window button
     Verify Zoom window restored to baseline    ${zoom_window_coords}    ${zoom_anchor_coords}
-    [Teardown]   Run Keywords    Kill App in VM    ${COMMS_VM}    zoom
+    [Teardown]   Run Keywords    Kill App in VM   ${Zoom}
     ...    AND   Switch to vm    ${GUI_VM}  user=${USER_LOGIN}    AND    Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
 
 *** Keywords ***
 
-Save current document from Cosmic Text Editor to Shares
+Save current document from COSMIC Text Editor to Shares
     [Arguments]      ${file_name}
     Press Key(s)       LEFTCTRL+LEFTSHIFT+S
     Locate on screen   text    Shares    scale=3
@@ -98,17 +98,17 @@ Paste clipboard text and verify
     Verify Text Is On The Screen    ${text}
 
 Locate and click minimize window button
-    ${mouse_x}  ${mouse_y}  Locate on screen  image  ghaf-close.png  0.99  10  timeout=120  scale=2
+    ${mouse_x}  ${mouse_y}  Locate on screen  image  ${Zoom}[close_button]  0.99  10  timeout=120  scale=2
     ${target_x}    Evaluate    ${mouse_x} - 40
     Run ydotool command   mousemove --absolute -x ${target_x} -y ${mouse_y}
     Click
 
 Verify app window is minimized
     [Documentation]    Wait until Window disappear from the screen by checking close button
-    Wait Until Keyword Succeeds    3x    1s    Verify Image On The Screen    ghaf-close.png    ${False}
+    Wait Until Keyword Succeeds    3x    1s    Verify Image On The Screen    ${Zoom}[close_button]    ${False}
 
 Verify app window restored near coordinates
-    [Arguments]    ${expected_x}   ${expected_y}   ${searched_type}=image   ${searched_item}=ghaf-close.png   ${tolerance}=5
+    [Arguments]    ${expected_x}   ${expected_y}   ${searched_type}=image   ${searched_item}=${Zoom}[close_button]   ${tolerance}=5
     ${actual_x}   ${actual_y}    Locate on screen   ${searched_type}   ${searched_item}   0.99   10   timeout=120   scale=2
     ${x_in_range}    Evaluate    abs(${actual_x} - ${expected_x}) <= ${tolerance}
     ${y_in_range}    Evaluate    abs(${actual_y} - ${expected_y}) <= ${tolerance}
@@ -117,9 +117,9 @@ Verify app window restored near coordinates
     END
 
 Save Zoom window baseline coordinates
-    ${status}   Run Keyword And Return Status   Locate on screen   image   ghaf-close.png   0.99   10   timeout=120   scale=2
+    ${status}   Run Keyword And Return Status   Locate on screen   image   ${Zoom}[close_button]   0.99   10   timeout=120   scale=2
     Run Keyword If    not ${status}    Focus Zoom window
-    ${window_x}   ${window_y}    Locate on screen   image   ghaf-close.png   0.99   10   timeout=120   scale=2
+    ${window_x}   ${window_y}    Locate on screen   image   ${Zoom}[close_button]   0.99   10   timeout=120   scale=2
     Focus Zoom window
     ${anchor_x}   ${anchor_y}    Locate on screen   text    Workplace        0.99   10   timeout=120   scale=2
     ${window_coords}    Create List    ${window_x}    ${window_y}
@@ -129,7 +129,7 @@ Save Zoom window baseline coordinates
 Verify Zoom window restored to baseline
     [Arguments]    ${window_coords}    ${anchor_coords}
     Focus Zoom window
-    Run Keyword And Ignore Error   Verify Image Is On The Screen    ghaf-close.png
+    Run Keyword And Ignore Error   Verify Image On The Screen    ${Zoom}[close_button]
     Run Keyword And Continue On Failure    Verify app window restored near coordinates
     ...    ${anchor_coords}[0]   ${anchor_coords}[1]   searched_type=text   searched_item=Workplace   tolerance=3
     Verify app window restored near coordinates    ${window_coords}[0]   ${window_coords}[1]
@@ -141,29 +141,29 @@ Focus Zoom window
     Wiggle cursor
 
 Save Zoom icon coordinates
-    ${zoom_x}   ${zoom_y}    Locate on screen   image   Zoom.png   0.80   10   timeout=120   scale=2
+    ${zoom_x}   ${zoom_y}    Locate on screen   image   ${Zoom}[icon]   0.80   10   timeout=120   scale=2
     RETURN    ${zoom_x}    ${zoom_y}
 
 Wait for Zoom icon coordinates to change and restore window
     [Arguments]    ${old_x}    ${old_y}
     FOR    ${i}    IN RANGE    5
-        ${new_x}   ${new_y}    Locate on screen   image   Zoom.png   0.90   10   timeout=10   scale=2
+        ${new_x}   ${new_y}    Locate on screen   image   ${Zoom}[icon]   0.90   10   timeout=10   scale=2
         ${changed}    Evaluate    abs(${new_x} - ${old_x}) > 2 or abs(${new_y} - ${old_y}) > 2
         IF    ${changed}
-            Locate and click   image   Zoom.png   confidence=0.90  scale=2
+            Locate and click   image   ${Zoom}[icon]   confidence=0.90  scale=2
             RETURN
         END
     END
     FAIL    An additional minimized Zoom session icon hasn't appeared.
 
 Locate and click maximize/restore window button
-    ${mouse_x}  ${mouse_y}  Locate on screen  image  ghaf-close.png  0.99  10  timeout=120  scale=2
+    ${mouse_x}  ${mouse_y}  Locate on screen  image  ${Zoom}[close_button]  0.99  10  timeout=120  scale=2
     ${target_x}    Evaluate    ${mouse_x} - 20
     Run ydotool command   mousemove --absolute -x ${target_x} -y ${mouse_y}
     Click
 
 Verify app window is maximized
     [Arguments]    ${tolerance}=3
-    ${window_x}   ${window_y}    Locate on screen   image   ghaf-close.png   0.99   10   timeout=120   scale=2
+    ${window_x}   ${window_y}    Locate on screen   image   ${Zoom}[close_button]   0.99   10   timeout=120   scale=2
     ${x_in_range}    Evaluate    abs(${window_x} - 947) <= ${tolerance}
     ${y_in_range}    Evaluate    abs(${window_y} - 25) <= ${tolerance}

--- a/Robot-Framework/test-suites/gui-tests/gui_security.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_security.robot
@@ -19,7 +19,7 @@ Test Teardown       Run keywords      Switch to vm            ${GUI_VM}  user=${
 Check Access List In Trusted Browser
     [Tags]    SP-T209  SP-T210  SP-T211  SP-T362  lenovo-x1  darter-pro
     [Template]    Check Access List In Trusted Browser Template
-    # Pages outside access list shouldn't be available via Trusted Browser. Http and https has different errors
+    # Pages outside access list shouldn't be available via Trusted Browser. Http and https have different errors
     https://yle.fi                          text_to_find=This site can’t be reached
     http://yle.fi                           text_to_find=Access Denied
 
@@ -66,14 +66,13 @@ Check Access List In Trusted Browser Template
     ...                   https: 'This site can’t be reached'
     ...                   http:  'Access Denied'
     [Arguments]    ${url}   ${text_to_find}
-    Start application in VM   "Trusted Browser"   ${BUSINESS_VM}   google-chrome    params_string=-- ${url}    always_check_vm=True
-    Switch to vm              ${GUI_VM}    user=${USER_LOGIN}
+    Start App in VM    ${Trusted Browser}    params_string=-- ${url}    always_check_vm=True
+    Switch to vm       ${GUI_VM}    user=${USER_LOGIN}
 
     Wait Until Keyword Succeeds     10x                        1s
     ...                             Verify Text Is On The Screen    ${text_to_find}
 
-    [Teardown]    Run keywords      Switch to vm           ${BUSINESS_VM}    AND
-    ...                             Kill process by name   google-chrome
+    [Teardown]    Kill App in VM   ${Trusted Browser}   status=${KEYWORD_STATUS}
 
 Unlock account and login
     [Documentation]  Unlock the user account and log back in
@@ -91,7 +90,7 @@ Check faillock entry count
     [Documentation]    Verify that the current faillock entry count matches ${expected_count}
     [Arguments]        ${expected_count}
     [Setup]       Switch to vm    ${GUI_VM}
-    Run Command    faillock --user ${USER_LOGIN}    sudo=True    rc_match=skip   # For debugging
+    Run Command   faillock --user ${USER_LOGIN}    sudo=True    rc_match=skip   # For debugging
     ${count}      Run Command    faillock --user ${USER_LOGIN} | grep -c '^[0-9]'    sudo=True    rc_match=skip
     Should Be Equal As Integers    ${count}    ${expected_count}
     Log           Wrong password detected ${expected_count} times    console=True

--- a/Robot-Framework/test-suites/gui-tests/gui_settings.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_settings.robot
@@ -16,7 +16,7 @@ Change timezone in settings
     [Tags]            SP-T136
     [Setup]           Run Keywords   Start screen recording   AND  Save original timezone
     Set timezone      UTC
-    Search in Cosmic Settings   zone
+    Search in COSMIC Settings   zone
     Tab and enter     tabs=5
     Tab and enter     tabs=9
     Type string       Dubai    enter_at_end=True
@@ -26,15 +26,15 @@ Change timezone in settings
 
     [Teardown]   Run Keywords   Set timezone   ${ORIGINAL_TIMEZONE}
     ...          AND   Move cursor to corner
-    ...          AND   Kill process by name    cosmic-settings$   sudo=False
+    ...          AND   Kill App in VM          ${COSMIC Settings}
     ...          AND   Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
 *** Keywords ***
 
-Search in Cosmic Settings
+Search in COSMIC Settings
     [Arguments]     ${search_term}
     Move cursor to corner
-    Locate and click  image  settings.png  0.95
+    Locate and click  image  ${COSMIC Settings}[icon]  0.95
     # Wait for settings to open
     Locate on screen  text   Network   iterations=20
     Tab and enter     tabs=1

--- a/Robot-Framework/test-suites/security-tests/vm_isolation.robot
+++ b/Robot-Framework/test-suites/security-tests/vm_isolation.robot
@@ -22,23 +22,23 @@ Stopping one VM does not affect others
     ...                 that it doesn't affect the first VM and app running
     [Tags]              SP-T286
     [Template]          Stopping one VM does not affect another
-    ${BUSINESS_VM}  ${COMMS_VM}     Slack            slack
-    ${CHROME_VM}    ${FLATPAK_VM}   "App Store"      cosmic-store
-    ${MEDIA_VM}     ${BUSINESS_VM}  Gala             gala
-    ${COMMS_VM}     ${CHROME_VM}    "Google Chrome"  chrome
+    ${Slack}            ${BUSINESS_VM}
+    ${App Store}        ${CHROME_VM}
+    ${Gala}             ${MEDIA_VM}
+    ${Google Chrome}    ${COMMS_VM}
 
 
 *** Keywords ***
 
 Stopping one VM does not affect another
-    [Arguments]     ${one_vm}    ${another_vm}    ${app_name}    ${process_name}
-    Switch to vm   ${another_vm}
-    Start application in VM   ${app_name}   ${another_vm}    ${process_name}   always_check_vm=True
-    Stop VM        ${one_vm}
-    ${state}  ${substate}   Verify service status  service=microvm@${another_vm}.service  expected_state=active  expected_substate=running
-    Check that App is running in VM   ${another_vm}   ${process_name}   range=5
-    [Teardown]    Run Keywords   Restart VM   ${one_vm}   start_only=True   restore_sudoers=False
-    ...                    AND   Kill App in VM   ${another_vm}   ${process_name}   log_file=${APP_OUTPUT_FILE}   status=${KEYWORD_STATUS}
+    [Arguments]     ${app_key}   ${another_vm}
+    Should Not Be Equal       ${app_key}[VM]    ${another_vm}    App is running in the VM that is going to be stopped
+    Start App in VM           ${app_key}   always_check_vm=True
+    Stop VM                   ${another_vm}
+    ${state}  ${substate}     Verify service status  service=microvm@${app_key}[VM].service  expected_state=active  expected_substate=running
+    Check that App is running in VM     ${app_key}   range=5
+    [Teardown]    Run Keywords   Restart VM   ${another_vm}   start_only=True   restore_sudoers=False
+    ...                    AND   Kill App in VM   ${app_key}   log_file=${APP_OUTPUT_FILE}   status=${KEYWORD_STATUS}
 
 Stop VM
     [Documentation]         Try to stop VM and verify it stopped

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -4,6 +4,7 @@
 
 | DATE SET   | TEST CASE                                               | TICKET / Additional Data.                                                                     |
 | ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| 06.07.2026 | Open text file with COSMIC Text Editor                  | SSRCSP-8367                                                                                   |
 | 01.07.2026 | Account lockout after failed GUI login                  | Test under development                                                                        |
 | 15.06.2026 | VM memory usage snapshot (Dell)                         | Dell has less memory than other targets                                                       |
 | 11.06.2026 | Verify booting after restart by power (orin-nx)         | SSRCSP-8585                                                                                   |


### PR DESCRIPTION
~~https://github.com/tiiuae/ghaf-infra/pull/1137 needs to be merged and deployed before this PR can be merged~~ merged and deployed to dev and prod

**Changes**
* Add `Robot-Framework/config/apps.json` as a centralized configuration for app metadata:
    * display name (currently same as app key)
    * VM
    * process name
    * [optional] close button icon
    * [optional] app icon
* Refactor tests to use shared app config instead of passing app details around as separate arguments
* Add test templates for functional and GUI app launch tests
* Add app launch tests for Advanced Network Configuration

**Testruns**
- [Lenovo X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6845/artifact/Robot-Framework/test-suites/lenovo-x1ANDregressionNOTinstaller-onlyNOTsecboot-onlyNOTsuspension/report.html#totals)
- [StoreDisk Darter Pro](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6840/artifact/Robot-Framework/test-suites/darter-proANDregressionNOTinstaller-only/report.html#totals)