### PR TITLE
Skip device ID and hostname tests for X1 SecBoot Installer

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -162,11 +162,12 @@ Check Persistent Storage Size
 
 Check device id failure
     [Arguments]    ${actual_device_id}
-    IF    "storeDisk-debug-installer" in "${JOB}" and "${DEVICE_TYPE}" == "darter-pro"
+    IF    ("storeDisk-debug-installer" in "${JOB}" and "${DEVICE_TYPE}" == "darter-pro") or ("intel-laptop-debug-installer" in "${JOB}" and "${DEVICE_TYPE}" == "x1-sec-boot")
         &{ids}    Create Dictionary
         ...    DarterPRO-prod=00-c0-44-19-76
         ...    DarterPRO-rel=00-89-3c-52-5d
         ...    DarterPRO-dev=00-e7-04-ed-e3
+        ...    LenovoSecBoot=00-40-76-6d-36
         ${expected_wrong_id}    Get From Dictionary    ${ids}    ${SWITCH_BOT}
         IF    "${actual_device_id}" == "${expected_wrong_id}"
             SKIP   Known issue: SSRCSP-7997

--- a/Robot-Framework/test-suites/functional-tests/net-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/net-vm.robot
@@ -87,11 +87,12 @@ Interfaces Should Be In Same Network
     Should Be Equal    ${ip1_net}    ${ip2_net}
 
 Check net-vm hostname failure
-    IF    "storeDisk-debug-installer" in "${JOB}" and "${DEVICE_TYPE}" == "darter-pro"
+    IF    ("storeDisk-debug-installer" in "${JOB}" and "${DEVICE_TYPE}" == "darter-pro") or ("intel-laptop-debug-installer" in "${JOB}" and "${DEVICE_TYPE}" == "x1-sec-boot")
         &{ids}    Create Dictionary
         ...    DarterPRO-prod=ghaf-3225688438
         ...    DarterPRO-rel=ghaf-2302431837
         ...    DarterPRO-dev=ghaf-3875859939
+        ...    LenovoSecBoot=ghaf-1081503030
         ${expected_wrong_name}    Get From Dictionary    ${ids}    ${SWITCH_BOT}
         IF    "${NETVM_NAME}" == "${expected_wrong_name}"
             SKIP   Known issue: SSRCSP-7997


### PR DESCRIPTION
[LenovoSecBoot in Prod](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2226/artifact/Robot-Framework/test-suites/lenovo-x1ANDbatNOTstoreDisk-onlyNOTexcl-installerNOTexcl-secboot/report.html)
