### PR TITLE
Update skips, list workarounds

### DIFF
--- a/Robot-Framework/resources/app_keywords.resource
+++ b/Robot-Framework/resources/app_keywords.resource
@@ -71,9 +71,10 @@ Log and remove app output
     Remove file   ${file}
 
 Log app vm journalctl
-    [Documentation]    Log journalctl from ${app-vm}, specify the VM where the App is actually running.
-    [Arguments]   ${app-vm}
-    Switch to vm  ${app-vm}
+    [Documentation]    Log journalctl from ${app_key}[VM]
+    [Arguments]   ${app_key}
+    ${user}       Set Variable If   '${app_key}[VM]' == '${GUI_VM}'   ${USER_LOGIN}   ghaf
+    Switch to vm  ${app_key}[VM]  user=${user}
     Run Command   journalctl -b
 
 Kill App in VM
@@ -87,7 +88,7 @@ Kill App in VM
     Kill process by name    ${app_key}[process_name]   sudo=${sudo}   require_exists=${require_exists}
 
     IF  '${log_file}' != 'None'   Log and remove app output   ${log_file}
-    IF  '${status}'=='FAIL'       Log app vm journalctl       ${app_key}[VM]
+    IF  '${status}'=='FAIL'       Log app vm journalctl       ${app_key}
 
 Start app via GUI
     [Documentation]    Start Application via GUI and verify related process started

--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -22,7 +22,6 @@ ${ICONS_DIR}           ${OUTPUT_DIR}/outputs/icons
 ${SCREENSHOT_GHAF}     /home/${USER_LOGIN}/test-images/screenshot.jpeg
 ${SCREENSHOT_LOCAL}    ${GUI_OUTPUT_DIR}/screenshot.jpeg
 ${YDOTOOL_SOCKET}      /tmp/.ydotool_socket
-${SCREEN_SELECTED}     ${False}
 
 
 *** Keywords ***
@@ -264,8 +263,6 @@ Unlock
     [Documentation]    Unlock the screen be typing password
     # Make sure that password field is active by clicking it
     Locate and click   image  ${LOCK_ICON}   0.95  10
-    # Can't explain the second click but does not work without
-    Locate and click   image  ${LOCK_ICON}   0.95  10
     Confidential password write  ${USER_PASSWORD}
     Sleep   2
 
@@ -356,19 +353,17 @@ Start screen recording
     ...    -o ${video_file}
     ...    </dev/null >${log_file} 2>&1'
     Run Command      ${cmd}
-    IF   ${SCREEN_SELECTED}==${False}
-        # The window to record needs to be selected when recording first time
-        # Check if selection window opened
-        ${pass_status}  ${output}  Run Keyword And Ignore Error   Locate on screen   text   Share   iterations=5   debug_screenshot=False
-        IF  $pass_status=='PASS'
-            # Select the display to record
-            Run ydotool command   mousemove --absolute -x 500 -y 300
-            Run ydotool command   click 0xC0
-            Press Key(s)          ENTER
-        END
-        Set Global Variable  ${SCREEN_SELECTED}  ${True}
+    TRY
+        Wait Until Keyword Succeeds    10x    0.5s    Run Command    ls -la ${video_file}
+    EXCEPT
+        # Try to allow screen capture if recording file was not created
+        Locate on screen   text   Share   iterations=5   debug_screenshot=False
+        # Select the display to record
+        Run ydotool command   mousemove --absolute -x 500 -y 300
+        Run ydotool command   click 0xC0
+        Press Key(s)          ENTER
+        Wait Until Keyword Succeeds    10x    0.5s    Run Command    ls -la ${video_file}
     END
-    Wait Until Keyword Succeeds    10x    0.5s    Run Command    ls -la ${video_file}
     [Teardown]       Run Keyword If   '${KEYWORD_STATUS}' == 'FAIL'   Run Keywords   Timestamp last screenshot
     ...              AND   Run Command   cat ${log_file}
 

--- a/Robot-Framework/resources/service_keywords.resource
+++ b/Robot-Framework/resources/service_keywords.resource
@@ -37,7 +37,7 @@ Verify service status
         # 'Welcome to NixOS' is not got if 'non-vm service' or if service is expected to be inactive/dead.
         IF  ${vmservice} and '${expected_substate}' == 'running' and ${state_status} and ${substate_status} and ${welcome_check}
             ${logs}        Run Command   journalctl -b -u ${service} --no-pager -n 200
-#            Check of "Welcome message" is temporary disabled because sometimes logs of VMs are not saved due to the rotation (probably a bug)
+#            Check of "Welcome message" is temporary disabled because sometimes logs of VMs are not saved due to the rotation (SSRCSP-8662)
 #            ${finished}    Run Keyword And Return Status    Should Contain    ${logs}    Welcome to NixOS
             ${logs}        Run Command   systemctl status ${service} --no-pager
             ${finished}    Set Variable  True

--- a/Robot-Framework/test-suites/functional-tests/vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/vm.robot
@@ -19,17 +19,10 @@ Suite Setup         VM Suite Setup
 # device|vm|service-name|ticket-number
 @{known_issues}=    ANY|audio-vm|systemd-rfkill.service|SSRCSP-7321
              ...    ANY|ghaf-host|systemd-rfkill.service|SSRCSP-7321
-             ...    dell-7330|ghaf-host|autovt@ttyUSB0.service|SSRCSP-6667
              ...    ANY|gui-vm|plymouth-start.service|SSRCSP-7306
              ...    ANY|gui-vm|plymouth-quit.service|SSRCSP-7306
-             ...    ANY|ANY|tuned.service|SSRCSP-7717
-             ...    ANY|ANY|fail2ban.service|SSRCSP-7759
              ...    ANY|ANY|journal-fss-verify.service|SSRCSP-8425
-             ...    orin|ghaf-host|nvfancontrol.service|SSRCSP-6303
-             ...    orin-agx|ghaf-host|systemd-rfkill.service|SSRCSP-6303
-             ...    orin|ghaf-host|systemd-oomd.service|SSRCSP-6685
              ...    darter-pro|ghaf-host|systemd-tpm2-setup.service|SSRCSP-8357
-             ...    orin-agx|ghaf-host|ghaf-provision-ek-certs.service|SSRCSP-8535
 
 # Container for test message. Keyword `Set Test Message` doesn't work properly with Templates.
 # Accumulates messages from tests that use 'Check systemctl status Template' to be added to the main test message in teardown

--- a/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
+++ b/Robot-Framework/test-suites/update-tests/x-nixos-rebuild-tests.robot
@@ -13,12 +13,11 @@ Resource            ../../resources/setup_keywords.resource
 Resource            ../../resources/update_keywords.resource
 Resource            ../../resources/service_keywords.resource
 
-Suite Setup          Rebuild Setup
+Suite Setup          Rebuild from modified ghaf repo
 Suite Teardown       Rebuild Teardown
 
 *** Variables ***
 ${repository_path}      /persist/ghaf
-${setup_skipped}        ${False}
 
 
 *** Test Cases ***
@@ -82,18 +81,6 @@ Check audit update logging
 
 
 *** Keywords ***
-
-Rebuild Setup
-    ${setup_ok}    Run Keyword And Return Status    Rebuild from modified ghaf repo
-    # If rebuild fails skip for laptops, fail for Orin
-    IF  not ${setup_ok}
-        IF  ${IS_LAPTOP}
-            Set Suite Variable    ${setup_skipped}    ${True}
-            Skip                  Something went wrong in 'Rebuild from modified ghaf repo'. Skipping the suite.
-        ELSE
-            FAIL                  Failure in Setup / Rebuild from modified ghaf repo
-        END
-    END
 
 Rebuild from modified ghaf repo
     [Timeout]               50 minutes
@@ -223,13 +210,8 @@ Remove Ghaf Repository
     Run Command     rm -r ${repository_path}   sudo=True
 
 Rebuild Teardown
-    Set Client Configuration      timeout=10
-    IF  ${setup_skipped} or '${PREV_TEST_STATUS}'=='FAIL'
+    IF  '${SUITE_STATUS}'=='FAIL'
         Hard Reboot Device And Connect
-        IF  not ${IS_AVAILABLE}
-            Log To Console    Connecting the device after boot failed. Rebuild may have left ghaf unbootable.\nStopping Teardown execution.
-            RETURN
-        END
         Run Keyword If    ${IS_LAPTOP}    Login to laptop
     END
     Switch to vm    ${HOST}

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -2,36 +2,47 @@
 
 ## Active SKIPS
 
-| DATE SET   | TEST CASE                                               | TICKET / Additional Data.                                                                     |
-| ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| 06.07.2026 | Open text file with COSMIC Text Editor                  | SSRCSP-8367                                                                                   |
-| 01.07.2026 | Account lockout after failed GUI login                  | Test under development                                                                        |
-| 15.06.2026 | VM memory usage snapshot (Dell)                         | Dell has less memory than other targets                                                       |
-| 25.05.2026 | Reboot from power menu                                  | SSRCSP-8490                                                                                   |
-| 22.05.2026 | Check logging rate (Dell)                               | SSRCSP-8481                                                                                   |
-| 13.05.2026 | Validate Forward Secure Sealing                         | SSRCSP-8425                                                                                   |
-| 30.04.2026 | Open PDF from VM                                        | SSRCSP-8367                                                                                   |
-| 30.03.2026 | Check Camera in VMs (Dell)                              | SSRCSP-8266                                                                                   |
-| 30.03.2026 | Check Camera Application (Dell checked in chrome-vm)    | SSRCSP-8266                                                                                   |
-| 23.03.2026 | Verify camera block persisted (Lenovo X1)               | SSRCSP-8224                                                                                   |
-| 26.02.2026 | Check systemctl status in every VM (retry added for NX) | Timeout of Executing command 'systemctl list-units --plain --no-legend --no-pager '.          |
-| 11.02.2026 | Check device id                                         | SSRCSP-7997                                                                                   |
-| 11.02.2026 | Check net-vm hostname                                   | SSRCSP-7997                                                                                   |
-| 23.10.2025 | Save host journalctl/Verify NetVM is started            | SSRCSP-7453                                                                                   |
-| 16.09.2025 | Check systemctl status in every VM                      | [Full list of skips in the test case](/Robot-Framework/test-suites/functional-tests/vm.robot) |
-|            | Measure Hard Boot Time                                  | The searched journalctl line is sometimes (randomly) not there. Didn't find it this time      |
-|            | Measure Soft Boot Time -Dell                            | The searched journalctl line is sometimes (randomly) not there. Didn't find it this time.     |
-|            | OP-TEE xtest 1033 -orin-agx & orin-nx                   | Known issue encountered, skipping the test                                                    |
-|            | OP-TEE xtest 1008 -orin-agx & orin-nx                   | Known issue encountered, skipping the test                                                    |
-|            | OP-TEE xtest 1006 -orin-agx & orin-nx                   | Known issue SSRCSP-8198 encountered, skipping the test                                        |
-|            | OP-TEE xtest 1024 -orin-agx & orin-nx                   | Known issue SSRCSP-8198 encountered, skipping the test                                        |
+| DATE SET   | TEST CASE                                            | TICKET / Additional Data                                                |
+| ---------- | ---------------------------------------------------- | ----------------------------------------------------------------------- |
+| 06.07.2026 | Open video with COSMIC Media Player                  | SSRCSP-8367                                                             |
+| 01.07.2026 | Account lockout after failed GUI login               | Test under development                                                  |
+| 15.06.2026 | VM memory usage snapshot (Dell 7330)                 | Dell has less memory than other targets                                 |
+| 25.05.2026 | Reboot from power menu                               | SSRCSP-8490                                                             |
+| 22.05.2026 | Check logging rate (Dell)                            | SSRCSP-8481                                                             |
+| 13.05.2026 | Validate Forward Secure Sealing                      | SSRCSP-8425                                                             |
+| 30.04.2026 | Open PDF from VM                                     | SSRCSP-8367                                                             |
+| 30.03.2026 | Check Camera in VMs (Dell)                           | SSRCSP-8266                                                             |
+| 30.03.2026 | Check Camera Application (Dell checked in chrome-vm) | SSRCSP-8266                                                             |
+| 23.03.2026 | Verify camera block persisted (Lenovo X1)            | SSRCSP-8224                                                             |
+| 17.03.2026 | OP-TEE xtest 1006, OP-TEE xtest 1024 (Orins)         | SSRCSP-8198                                                             |
+| 11.02.2026 | Check device id (storeDisk)                          | SSRCSP-7997                                                             |
+| 11.02.2026 | Check net-vm hostname (storeDisk)                    | SSRCSP-7997                                                             |
+| 23.10.2025 | Verify NetVM is started (Orin NX)                    | SSRCSP-7453                                                             |
+| 16.09.2025 | Check systemctl status in every VM                   | [List of skips](/Robot-Framework/test-suites/functional-tests/vm.robot) |
+| 21.12.2023 | OP-TEE xtest 1033, OP-TEE xtest 1008 (Orins)         | Known issue encountered, skipping the test                              |
 
 ## TAGs removed
 
-| DATE SET   | TEST CASE                                  | TICKET / Additional Data.                                                              |
-| ---------- | ------------------------------------------ | -------------------------------------------------------------------------------------- |
-| 24.04.2026 | Rebuild tests removed from regression      | Rebuild tests do not work properly with signed images                                  |
-| 27.02.2026 | Measure Soft Boot Time (Darter Pro)        | Test removed because the Enter finger causes inaccuracy to the result                  |
-| 20.02.2026 | Test ballooning in chrome-vm / business-vm | Ballooning feature was turned off in ghaf by PR#1770                                   |
-| 03.09.2025 | Performance/network suite (AGX)            | SSRCSP-7160. Network-adapter usage had impact on results. Needs further investigation. |
-| 03/2025    | Performance Network.robot - ‘orin-nx’      | SSRCSP-6372 - Works locally but problems when Jenkins used, fails all..                |
+| DATE SET   | TEST CASE (removed tag)                                  | TICKET / Additional Data                                                               |
+| ---------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| 24.04.2026 | Rebuild tests (regression)                               | Rebuild tests do not work properly with signed images                                  |
+| 27.02.2026 | Measure Soft Boot Time (darter-pro)                      | Test removed because the Enter finger causes inaccuracy to the result                  |
+| 20.02.2026 | Test ballooning in chrome-vm / business-vm (performance) | Ballooning feature was turned off in ghaf by PR#1770                                   |
+| 03.09.2025 | Performance/network suite (orin-agx)                     | SSRCSP-7160. Network-adapter usage had impact on results. Needs further investigation. |
+| 17.03.2025 | Performance/network suite (orin-nx)                      | SSRCSP-6372 - Works locally but problems when Jenkins used, fails all..                |
+
+## Workarounds
+
+| DATE SET   | TEST CASE / KEYWORD                   | TICKET / Additional Data                                                                                   |
+| ---------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| 30.06.2026 | Unlock account and login              | Try to login twice after unlocking, first login after unlocking the account fails                          |
+| 22.06.2026 | Set RTC time                          | SSRCSP-8622, separate command for Lenovo X1                                                                |
+| 17.06.2026 | Verify service status                 | SSRCSP-8662, welcome check disabled                                                                        |
+| 15.06.2026 | VM memory usage snapshot              | Orin host check is skipped, swap is not enabled                                                            |
+| 08.06.2026 | Soft Reboot Device                    | SSRCSP-8490, reboot from host if reboot from gui-vm failed                                                 |
+| 27.03.2026 | Get Actual Device ID                  | Additional Device ID path added for https://github.com/tiiuae/ghaf/pull/1421                               |
+| 26.02.2026 | Check systemctl status in every VM    | Retry on Orin NX, Executing command 'systemctl list-units --plain --no-legend --no-pager ' fails sometimes |
+| 17.02.2026 | Verify booting after restart by power | Try to boot Orin NX second time if first time did not work                                                 |
+| 29.01.2026 | Reboot Orin if ssh connection dropped | This keyword is a workaround for the SSH connection dropping on Orin, reboots and connect again            |
+| 27.01.2026 | Verify shutdown via serial            | Shutdown is checked via network if shutdown log was not found in serial output                             |
+| 23.10.2025 | Clean Up Test Environment             | SSRCSP-7453, Journalctl check removed from Orin NX because it kept getting stuck                           |


### PR DESCRIPTION
**Changes to skips**
* Add workarounds to `list_of_skipped_tests.md` so that it is easier to track them. Let me know if I missed some.
* Update `Check systemctl status in every VM` skips, 7 /13 are not needed anymore.
* Remove skip from rebuild setup. Skip was originally added so that failures do not create noise in regression results, but after that the test have been removed from regression.
* Remove double click from `Unlock`, it is not needed anymore.

**Other fixes**
* Fix `Switch to vm` in `Log app vm journalctl`, this caused the screen recording to fail last night after failed test ([testrun](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6887/artifact/Robot-Framework/test-suites/lenovo-x1ANDgui-settings/log.html#s1-s1-s1-t1) where test failed but teardown did not)
* Try to accept screen recording always if it did not start, not only on first recording. With this change we also have an up-to-date debug screenshot if starting the recording fails.

**Testrun**
[Lenovo X1](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6880/) (rebuild tests that failed are also failing with [mainline](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6892/artifact/Robot-Framework/test-suites/lenovo-x1ANDrebuild/report.html#totals))