### PR TITLE
Remove continue on failure in teardown

### DIFF
--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -121,6 +121,7 @@ Check Network Availability
 
 Check If Device Is Up
     [Arguments]    ${retry}=100s
+    [Tags]    robot:recursive-stop-on-failure
     ${ssh_status}=       Try To Check Ssh On Device  retry=${retry}  interval=${PING_SPACING}s
     ${serial_status}=    Run Keyword If   not ${ssh_status}    Try To Check Serial On Device    range=3x
 


### PR DESCRIPTION
[Device is off, check is failed, try doesn't continue](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6896/artifact/Robot-Framework/test-suites/SP-T290/log.html#s1-s1-s1-t1-k10-k1-k1-k2)
[Regular run, device is up](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6889/artifact/Robot-Framework/test-suites/SP-T290/log.html#s1-s1-s1-t1-k10-k1-k1-k2)