### PR TITLE
Add test of Givc-cli device info

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -60,6 +60,12 @@ Check variable availability
         RETURN  ${False}
     END
 
+Get Ghaf Version
+    [Documentation]    Get version of Ghaf system
+    ${output}   Run Command   ghaf-version
+    Log To Console    ghaf-version: ${output}
+    RETURN    ${output}
+
 
 Get VM list
     [Arguments]    ${with_host}=False

--- a/Robot-Framework/test-suites/functional-tests/gui-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/gui-vm.robot
@@ -3,19 +3,20 @@
 
 *** Settings ***
 Documentation       Testing Gui-vm
-Test Tags           gui-vm  pre-merge  lenovo-x1  darter-pro  dell-7330  fmo
+Test Tags           gui-vm  pre-merge
 
 Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 Resource            ../../resources/service_keywords.resource
+
+Suite Setup         Switch to vm    ${GUI_VM}  user=${USER_LOGIN}
 
 
 *** Test Cases ***
 
 Check user systemctl status
     [Documentation]   Verify systemctl status --user is running
-    [Tags]            SP-T260  systemctl
-    [Setup]           Switch to vm    ${GUI_VM}  user=${USER_LOGIN}
+    [Tags]            SP-T260  systemctl  darter-pro  lenovo-x1  dell-7330  fmo
     [Teardown]        Set Test Message    append=${True}  separator=\n    message=${found_known_issues_message}
     Set Test Variable   ${found_known_issues_message}   ${EMPTY}
 
@@ -35,3 +36,42 @@ Check user systemctl status
     IF    ${filtered_failed_units}
         Check systemctl status for known issues  ${DEVICE_TYPE}  ${GUI_VM}  ${known_issues}  ${filtered_failed_units}   user=True
     END
+
+Givc-cli shows Ghaf version
+    [Documentation]    Verify that givc-cli sysinfo shows current Ghaf version.
+    [Tags]             SP-T369  SP-T369-1  darter-pro  lenovo-x1
+    ${version}         Get Ghaf Version
+    Verify givc-cli sysinfo field    Ghaf Version    ${version}
+
+Givc-cli shows Secure Boot enabled
+    [Documentation]    Verify that givc-cli sysinfo shows Secure Boot enabled on Secure Boot devices.
+    [Tags]             SP-T369  SP-T369-2  lenovo-x1  secboot-only
+    Verify givc-cli sysinfo field    Secure Boot    enabled
+
+Givc-cli shows Secure Boot disabled
+    [Documentation]    Verify that givc-cli sysinfo shows Secure Boot disabled on non-Secure Boot devices.
+    [Tags]             SP-T369  SP-T369-3  darter-pro  lenovo-x1  excl-secboot
+    Verify givc-cli sysinfo field    Secure Boot    disabled
+
+Givc-cli shows Disk Encryption
+    [Documentation]    Verify that givc-cli sysinfo shows Disk Encryption enabled on installer images and disabled on non-installers.
+    [Tags]             SP-T369  SP-T369-4  darter-pro  lenovo-x1
+    IF    "installer" in "${JOB}"
+        Verify givc-cli sysinfo field    Disk Encryption    enabled
+    ELSE
+        Verify givc-cli sysinfo field    Disk Encryption    disabled
+    END
+
+*** Keywords ***
+
+Verify givc-cli sysinfo field
+    [Arguments]    ${field}    ${expected}
+    ${output}      Run Command    givc-cli sysinfo
+    ${actual}      Get givc-cli sysinfo field    ${output}    ${field}
+    Should Be Equal As Strings    ${actual}    ${expected}    ignore_case=True    msg=${field} value in givc-cli sysinfo is ${actual}, expected ${expected}.
+
+Get givc-cli sysinfo field
+    [Arguments]    ${output}    ${field}
+    ${matches}     Get Regexp Matches    ${output}    (?m)^${field}:\\s*(\\S(?:.*\\S)?)\\s*$    1
+    Should Not Be Empty    ${matches}    Could not find ${field} in givc-cli sysinfo output:\n${output}
+    RETURN         ${matches}[0]

--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -128,13 +128,6 @@ Verify Nixos Version Format
         FAIL    Expected NixOS version name, but there is None
     END
 
-Get Ghaf Version
-    [Documentation]    Get version of Ghaf system, Example:
-    ...     "ghaf-version"    output: 23.05   parse result: 23.05
-    ${output}   Run Command   ghaf-version
-    Log To Console    ghaf-version: ${output}
-    RETURN    ${output}
-
 Get Nixos Version
     [Documentation]    Get version of NixOS, Example:
     ...     "nixos-version"   output: 23.05.20230625.35130d4 (Stoat)    parse result: 23.05, 20230625, 35130d4, Stoat


### PR DESCRIPTION
Tested on:
[Darter Pro Installer](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6936/artifact/Robot-Framework/test-suites/SP-T369ANDdarter-pro/report.html#totals): checked Ghaf version and that Secure Boot: disabled, Disk Encryption: enabled 
[Lenovo X1 SecBoot](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2239/artifact/Robot-Framework/test-suites/lenovo-x1ANDSP-T369NOTstoreDisk-onlyNOTinstaller-onlyNOTexcl-secboot/report.html#totals): checked Ghaf version and that Secure Boot: enabled, Disk Encryption: disabled 