### PR TITLE
Add Log Error keyword

### DIFF
--- a/Robot-Framework/resources/common_keywords.resource
+++ b/Robot-Framework/resources/common_keywords.resource
@@ -66,6 +66,10 @@ Get Ghaf Version
     Log To Console    ghaf-version: ${output}
     RETURN    ${output}
 
+Log Error
+    [Documentation]   Send a log about an error to Grafana
+    [Arguments]    ${context}    ${message}
+    Run Command    logger --priority=user.info "ROBOT_LOG (${context}): ${message} | device=${DEVICE_TYPE}, job=${JOB}"
 
 Get VM list
     [Arguments]    ${with_host}=False

--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -119,7 +119,7 @@ Soft Reboot Device
             # Known issue SSRCSP-8490
             Log To Console    GUI-VM reboot did not shut down the full device. Retrying reboot from host.
             Switch to vm   ${HOST}
-            Run Command  logger --priority=user.info "ROBOT_LOG: Soft reboot failed on ${DEVICE_TYPE}, job ${JOB}"
+            Log Error    Soft reboot failed    Soft reboot from ${GUI_VM} failed
             Run Command  reboot  sudo=True   rc_match=skip
             Log To Console  Rebooting device from host as fallback
             Verify shutdown via network
@@ -197,7 +197,12 @@ Verify shutdown via network
     Fail       Device at ${DEVICE_IP_ADDRESS} still responds after ${diff} seconds.
 
 Reboot Orin if ssh connection dropped
+    [Arguments]    ${context_name}=${EMPTY}
     ${ssh_available}  Run Keyword And Return Status    Run Command    ls  timeout=5
     IF  not ${ssh_available} and "orin" in "${DEVICE_TYPE}"
         Hard Reboot Device And Connect
+        IF    '${context_name}' == ''
+            ${context_name}    Get Variable Value    ${TEST NAME}    UNKNOWN_TEST
+        END
+        Log Error    Orin connection dropped    Connection dropped during ${context_name}
     END

--- a/Robot-Framework/resources/service_keywords.resource
+++ b/Robot-Framework/resources/service_keywords.resource
@@ -208,7 +208,9 @@ Check systemctl status for known issues
             Append To List    ${new_issues}    ${failing_service}
         END
     END
-    Run Command  logger --priority=user.info "ROBOT_LOG (systemctl status): Known failed services ${old_issues} failed on ${DEVICE_TYPE}, job ${JOB}"
+    FOR    ${known_issue}    IN    @{old_issues}
+        Log Error    Systemctl status    ${known_issue} failed on ${vm}
+    END
     IF   ${new_issues} != []
         Fail    Unexpected failed services in ${vm}: ${new_issues}, known failed services: ${old_issues}
     ELSE

--- a/Robot-Framework/resources/setup_keywords.resource
+++ b/Robot-Framework/resources/setup_keywords.resource
@@ -59,9 +59,8 @@ Clean Up Test Environment
     [Timeout]     5 minutes
     [Arguments]   ${disable_dnd}=False
     IF    ${IS_AVAILABLE} == True and "${CONNECTION_TYPE}" == "ssh"
-        # Temporarily taking journal log taking our from Orin-NX [SSRCSP-7453]
-        Run Keyword If   "${SUITE STATUS}" != "PASS" and "${DEVICE_TYPE}" != "orin-nx"    Save host journalctl
-        Run Keyword If   ${IS_LAPTOP}    Log out from laptop
+        IF   "${SUITE STATUS}" != "PASS"    Save host journalctl
+        IF   ${IS_LAPTOP}                   Log out from laptop
     END
     Close All Connections
 
@@ -72,6 +71,7 @@ Save host journalctl
     # Copy journal log file to Robot outputs
     SSHLibrary.Get file  /tmp/jrnl.txt   ${OUTPUT_DIR}/journal_${SUITE_NAME}.txt
     OperatingSystem.File Should Exist    ${OUTPUT_DIR}/journal_${SUITE_NAME}.txt
+    [Teardown]         Reboot Orin if ssh connection dropped    Save host journalctl
 
 Log versions and device unique data
     [Setup]             Switch to vm    ${HOST}
@@ -188,7 +188,9 @@ Ensure Robot sudoers is installed in all VMs
         Run Command    chmod 755 ${robot_sudoers_install_script_remote}
         Start Command  ${robot_sudoers_install_script_remote}    sudo=True    sudo_password=${PASSWORD}
     END
-    IF    $skipped_vms    Run Command  logger --priority=user.info "ROBOT_LOG: Sudoers not installed to ${skipped_vms} on ${DEVICE_TYPE}, job ${JOB}"
+    FOR    ${vm}    IN    @{skipped_vms}
+        Log Error    Sudoers installation failed    Sudoers not installed to ${vm}
+    END
     # Check that installation has finished everywhere
     FOR    ${vm}    IN    @{vm_list_with_host}
         IF    $vm in $skipped_vms

--- a/Robot-Framework/test-suites/functional-tests/files.robot
+++ b/Robot-Framework/test-suites/functional-tests/files.robot
@@ -6,6 +6,7 @@ Documentation       Testing launching files
 Test Tags           files  bat  lenovo-x1  darter-pro  dell-7330
 
 Resource            ../../resources/app_keywords.resource
+Resource            ../../resources/common_keywords.resource
 Resource            ../../resources/file_keywords.resource
 Resource            ../../resources/ssh_keywords.resource
 
@@ -115,4 +116,7 @@ Check for cosmic app crash
     Switch to vm        ${MEDIA_VM}
     ${app_started}      Run Keyword And Return Status   Run Command    journalctl -b --since @${journal_since} | grep -E "Started \\[systemd-run\\].*${app}.*${file_name}"
     Run Command         journalctl -b --since @${journal_since}   # All logs for debugging
-    IF  ${app_started}   SKIP   Known Issue: SSRCSP-8367
+    IF  ${app_started}
+        Log Error    Crash in media-vm    ${app} crashed in ${MEDIA_VM}
+        SKIP         Known Issue: SSRCSP-8367
+    END

--- a/Robot-Framework/test-suites/functional-tests/logging.robot
+++ b/Robot-Framework/test-suites/functional-tests/logging.robot
@@ -158,6 +158,7 @@ Check logging rate
 Validate Forward Secure Sealing
     [Documentation]   Run Forward Secure Sealing tests in all VMs
     [Tags]            SP-T353
+    ${failed_vms}   Create List
     FOR  ${vm}  IN  @{VM_LIST}
         Switch to vm   ${vm}
         ${output}   Run Command   fss-test   sudo=True   return=out,rc   rc_match=skip
@@ -165,12 +166,15 @@ Validate Forward Secure Sealing
             ${cleaned_output}   Remove Colors   ${output}[0]
             Log  ${cleaned_output}
             ${failed_tests}     Get Matching Lines   ${cleaned_output}   FAIL
+            Append To List      ${failed_vms}   ${vm}
             ${msg}              Catenate   SEPARATOR=\n   Fss test failed in ${vm}:
             ...    @{failed_tests}
             Run Keyword And Continue On Failure   FAIL   ${msg}
         END
     END
-    [Teardown]  Run Keyword If Test Failed   SKIP   Known issue: SSRCSP-8425
+    ${failed_vm_msg}   Catenate   SEPARATOR=,    @{failed_vms}
+    [Teardown]  Run Keyword If Test Failed   Run Keywords    Log Error    FSS test failed    FSS test failed in VMs: ${failed_vm_msg}
+    ...                                               AND    SKIP   Known issue: SSRCSP-8425
 
 *** Keywords ***
 

--- a/Robot-Framework/test-suites/functional-tests/vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/vm.robot
@@ -101,13 +101,13 @@ Check systemctl status Template
             ${status}   ${failed_units}   Verify Systemctl status   timeout=${timeout}
         EXCEPT    AS    ${error_message}
             Log    ${error_message}   console=True
-            Reboot Orin if ssh connection dropped
+            Reboot Orin if ssh connection dropped    Check systemctl status
             Switch to vm     ${vm}
             TRY
                 ${status}   ${failed_units}   Verify Systemctl status   timeout=${timeout}
             EXCEPT    AS    ${error_message}
                 Log    ${error_message}   console=True
-                Reboot Orin if ssh connection dropped
+                Reboot Orin if ssh connection dropped    Check systemctl status
                 Switch to vm     ${vm}
                 FAIL    Systemctl check failed twice in ${vm}
             END

--- a/Robot-Framework/test-suites/gui-tests/gui_power.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power.robot
@@ -68,8 +68,6 @@ Reboot from power menu
     Log               Reboot took ${elapsed} seconds   console=True
 
     Should Not Be True    ${elapsed} > ${reboot_limit}    msg=Reboot took too long: ${elapsed} seconds (expected < ${reboot_limit})
-    [Teardown]    Run Keywords   GUI Power Test Teardown   AND
-    ...           Run Keyword If Test Failed    Run Keyword If   "storeDisk" in "${JOB}" and "took too long" in $TEST_MESSAGE   SKIP    Known Issue: SSRCSP-8621
 
 Shutdown from power menu
     [Documentation]   Shutdown the device via GUI power menu shutdown icon.

--- a/Robot-Framework/test-suites/gui-tests/gui_security.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_security.robot
@@ -84,7 +84,7 @@ Unlock account and login
     # First login after unlocking the account fails
     Log in via GUI   password=reset_login   sleep_seconds=1
     Log in, unlock and verify
-    Run Keyword If Test Failed   Run Command  logger --priority=user.info "ROBOT_LOG: Account lockout after failed GUI login failed on ${DEVICE_TYPE}, job ${JOB}"
+    Run Keyword If Test Failed   Log Error    Account lockout    Account lockout after failed GUI login failed
 
 Check faillock entry count
     [Documentation]    Verify that the current faillock entry count matches ${expected_count}

--- a/Robot-Framework/test-suites/security-tests/persistence.robot
+++ b/Robot-Framework/test-suites/security-tests/persistence.robot
@@ -31,7 +31,9 @@ Verify camera block persisted
     ${cam_state}      Get device state   cam
     Should Be Equal   ${EXPECTED_CAM_STATE}  ${cam_state}
     [Teardown]   Run Keyword If Test Failed   Run Keywords   Log persistence setup errors
-    ...    AND   Run Keyword If   "${DEVICE_TYPE}" == "lenovo-x1" or "${DEVICE_TYPE}" == "x1-sec-boot"   SKIP   Known issue: SSRCSP-8224
+    ...    AND   Run Keyword If   "${DEVICE_TYPE}" == "lenovo-x1" or "${DEVICE_TYPE}" == "x1-sec-boot"
+    ...          Run Keywords     Log Error    Camera persistence    Verify camera block persisted failed
+    ...    AND   SKIP   Known issue: SSRCSP-8224
 
 Verify microphone block persisted
     [Tags]    SP-T305  SP-T305-2

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -45,4 +45,3 @@
 | 17.02.2026 | Verify booting after restart by power | Try to boot Orin NX second time if first time did not work                                                 |
 | 29.01.2026 | Reboot Orin if ssh connection dropped | This keyword is a workaround for the SSH connection dropping on Orin, reboots and connect again            |
 | 27.01.2026 | Verify shutdown via serial            | Shutdown is checked via network if shutdown log was not found in serial output                             |
-| 23.10.2025 | Clean Up Test Environment             | SSRCSP-7453, Journalctl check removed from Orin NX because it kept getting stuck                           |


### PR DESCRIPTION
**Changes**
* Add keyword `Log Error` for sending debug logs to Grafana. This unifies the debug log format so that logs are easier to read and sort.
* Add debug logging to a few more keywords.
* Return `Save host journalctl` to Orin-NX. I ran this keyword 40 times on NX and it did not fail once. Even if it starts failing again, this keyword is only ran if the suite failed so it won't be the only issue :) I believe `Reboot Orin if ssh connection dropped` might not be needed at all anymore, but it will be easy to confirm that in a week with the debug logs.
* Remove storeDisk skip from `Reboot from power menu`. I forgot to remove it in https://github.com/tiiuae/ci-test-automation/pull/881

**Testruns**
- [Laptop skips in action](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6955/artifact/Robot-Framework/test-suites/persistenceORSP-T267ORSP-T353ORfiles/report.html#totals) (Failed on purpose with [this commit](https://github.com/tiiuae/ci-test-automation/commit/c1d736aa8671fed4399d8f35a4945016ede983a5))
- [Normal laptop testrun](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6956/artifact/Robot-Framework/test-suites/persistenceORSP-T267ORSP-T353ORfiles/report.html#totals)
- [Orin NX connection dropped](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6958/artifact/Robot-Framework/test-suites/orin-nxANDSP-T333-2/log.html#s1-s1-s1-t1-k5) (Failed on purpose with [this commit](https://github.com/tiiuae/ci-test-automation/commit/c1d736aa8671fed4399d8f35a4945016ede983a5))
- [Normal Orin NX testrun](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6959/artifact/Robot-Framework/test-suites/orin-nxANDregression/report.html#totals)
- Skips logged to Grafana during purposefully dailing testruns used `ROBOT_LOG_TEST` tag, logs can be seen [here](https://ghaflogs.vedenemo.dev/goto/cfrkynl1ldam8c?orgId=1).