### PR TITLE
Skip Device ID and hostname checks on Orin AGX

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -167,6 +167,8 @@ Check device id failure
         ELSE
             FAIL   Actual device ID: ${actual_device_id}, Should be: ${STATIC_DEVICE_ID}, expected to fail with ${expected_wrong_id}
         END
+    ELSE IF   "${DEVICE_TYPE}" == "orin-agx"
+        SKIP    Known issue: Device ID needs to be updated in ghaf-infra
     END
 
 Get Secure Boot Status

--- a/Robot-Framework/test-suites/functional-tests/net-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/net-vm.robot
@@ -99,4 +99,6 @@ Check net-vm hostname failure
         ELSE
             FAIL   Actual net-vm hostname: ${NETVM_NAME}, Should be: ${STATIC_NETVM_NAME}, Expected to fail with ${expected_wrong_name}
         END
+    ELSE IF   "${DEVICE_TYPE}" == "orin-agx"
+        SKIP    Known issue: Hostname needs to be updated in ghaf-infra
     END

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -4,6 +4,8 @@
 
 | DATE SET   | TEST CASE                                            | TICKET / Additional Data                                                |
 | ---------- | ---------------------------------------------------- | ----------------------------------------------------------------------- |
+| 15.07.2026 | Check device id (Orin AGX)                           | Device ID needs to be updated in ghaf-infra                             |
+| 15.07.2026 | Check net-vm hostname (Orin AGX)                     | Hostname needs to be updated in ghaf-infra                              |
 | 06.07.2026 | Open video with COSMIC Media Player                  | SSRCSP-8367                                                             |
 | 01.07.2026 | Account lockout after failed GUI login               | Test under development                                                  |
 | 15.06.2026 | VM memory usage snapshot (Dell 7330)                 | Dell has less memory than other targets                                 |


### PR DESCRIPTION
To be merged together with https://github.com/tiiuae/ghaf/pull/2033 and/or https://github.com/tiiuae/ghaf/pull/2036. Both change Device ID and hostname on Orin AGX.

This is a temporary skip to allow time to collect new values, update them in ghaf-infra and deploy the changes. The PRs may still change, so it does not make sense to update the values before it is merged.

[AGX testrun](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6989/artifact/Robot-Framework/test-suites/orin-agxANDregression/report.html#totals) with #2033