### PR TITLE
Give Orins extra boot time and other fixes

### DIFF
--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -141,6 +141,9 @@ Connect After Reboot
             IF   ${IS_AVAILABLE} == True and "${CONNECTION_TYPE}" == "ssh"   BREAK
         END
         Check If Device Is Available   retry=5x    action=reboot
+    ELSE IF   "orin" in "${DEVICE_TYPE}"
+        # Workaround for SSRCSP-8701
+        Check If Device Is Available   retry=90s   action=reboot
     ELSE
         Check If Device Is Available   retry=60s   action=reboot
     END

--- a/Robot-Framework/resources/ssh_keywords.resource
+++ b/Robot-Framework/resources/ssh_keywords.resource
@@ -136,7 +136,7 @@ Check If Device Is Available
     ELSE IF  "${CONNECTION_TYPE}" == "serial"
         FAIL    The device is available only via serial ${extra_log}, but SSH is required.
     ELSE
-        Log To Console   Device is available ${extra_log}.
+        Log     Device is available ${extra_log}.   console=True
     END
     Switch to vm     ${NET_VM}
 
@@ -309,7 +309,7 @@ Wait Until Ssh Is Ready On Device
 
 Switch to vm
     [Arguments]         ${hostname}   ${user}=ghaf   ${timeout}=60
-
+    Log    Switching to vm ${hostname} as ${user}, timeout ${timeout}
     Set Log Level           NONE
     IF  $user=='ghaf'
         ${pw}   Set Variable    ${PASSWORD}

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -29,7 +29,9 @@ Create and save text file from COSMIC Text Editor via GUI
     ${saved_content}    Run Command    cat ${share_path}
     Should Contain      ${saved_content}   ${doc_text}
     Close app via GUI   ${COSMIC Text Editor}
-    [Teardown]   Run Keywords   Remove file by name    ${file_name}
+    [Teardown]   Run Keywords   Kill App in VM   ${COSMIC Text Editor}   require_exists=False
+    ...    AND   Switch to vm            ${GUI_VM}        user=${USER_LOGIN}
+    ...    AND   Remove file by name     ${file_name}
     ...    AND   Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
 Copy and paste text between VMs

--- a/Robot-Framework/test-suites/security-tests/persistence.robot
+++ b/Robot-Framework/test-suites/security-tests/persistence.robot
@@ -72,8 +72,6 @@ Verify timezone persisted
 Persistence Suite Setup
     ${PERSISTENCE_SETUP_ERRORS}    Create List
     Set Suite Variable             ${PERSISTENCE_SETUP_ERRORS}
-    Switch to vm      ${NET_VM}
-    Login to laptop
     Save original values
     Set values        EXPECTED
     Soft Reboot Device And Connect   vm=${GUI_VM}

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -35,6 +35,7 @@
 
 | DATE SET   | TEST CASE / KEYWORD                   | TICKET / Additional Data                                                                                   |
 | ---------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| 14.07.2026 | Connect After Reboot                  | SSRCSP-8701, extra 30 seconds added for Orins                                                              |
 | 30.06.2026 | Unlock account and login              | Try to login twice after unlocking, first login after unlocking the account fails                          |
 | 22.06.2026 | Set RTC time                          | SSRCSP-8622, separate command for Lenovo X1                                                                |
 | 17.06.2026 | Verify service status                 | SSRCSP-8662, welcome check disabled                                                                        |


### PR DESCRIPTION
* Extend connection time on Orin after soft reboot due to https://jira.tii.ae/browse/SSRCSP-8701.
* Add `Kill App in VM` to `Create and save text file from COSMIC Text Editor via GUI` teardown.
* Log hostname and user at the beginning of `Switch to vm`, after app refactoring it is now sometimes hard find this information.
* Remove extra `Login to laptop` from `Persistence Suite Setup`. It is not needed, laptop is already logged in.

[Orin AGX](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6997/artifact/Robot-Framework/test-suites/orin-agxANDregression/report.html#totals) regression
[Darter Pro](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/6998/artifact/Robot-Framework/test-suites/darter-proANDgui-appsORdarter-proANDpersistence/report.html#totals) gui-apps and persistence