### PR TITLE
Add extra 90 seconds for Orin AGX boot

### DIFF
--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -32,10 +32,17 @@ Verify booting after restart by power
     Start UART Log Capture
 
     Check If Device Is Up   retry=140s
+
     IF      "${DEVICE_TYPE}" == "orin-nx" and ${IS_AVAILABLE} == False
             Log                     message=Orin-nx failed to start, rebooting via relay one more time...    level=WARN
             Reboot Orin
             Check If Device Is Up   retry=140s
+    END
+
+    IF  "orin-agx" in "${DEVICE_TYPE}" and ${IS_AVAILABLE} == False
+        # Known issue SSRCSP-8704
+        Log   Device did not boot in 140 seconds, giving it some extra time due to SSRCSP-8704   console=True
+        Check If Device Is Up   retry=100s
     END
 
     IF    ${IS_AVAILABLE} == False

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -37,6 +37,7 @@
 
 | DATE SET   | TEST CASE / KEYWORD                   | TICKET / Additional Data                                                                                   |
 | ---------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| 15.07.2026 | Verify booting after restart by power | SSRCSP-8704, extra 90 seconds added for AGX boot                                                           |
 | 14.07.2026 | Connect After Reboot                  | SSRCSP-8701, extra 30 seconds added for Orins                                                              |
 | 30.06.2026 | Unlock account and login              | Try to login twice after unlocking, first login after unlocking the account fails                          |
 | 22.06.2026 | Set RTC time                          | SSRCSP-8622, separate command for Lenovo X1                                                                |


### PR DESCRIPTION
Workaround for https://jira.tii.ae/browse/SSRCSP-8704

Testrun https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2305/console