### PR TITLE
Remove AGX Device ID and hostname skips

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/host.robot
+++ b/Robot-Framework/test-suites/functional-tests/host.robot
@@ -167,8 +167,6 @@ Check device id failure
         ELSE
             FAIL   Actual device ID: ${actual_device_id}, Should be: ${STATIC_DEVICE_ID}, expected to fail with ${expected_wrong_id}
         END
-    ELSE IF   "${DEVICE_TYPE}" == "orin-agx"
-        SKIP    Known issue: Device ID needs to be updated in ghaf-infra
     END
 
 Get Secure Boot Status

--- a/Robot-Framework/test-suites/functional-tests/net-vm.robot
+++ b/Robot-Framework/test-suites/functional-tests/net-vm.robot
@@ -99,6 +99,4 @@ Check net-vm hostname failure
         ELSE
             FAIL   Actual net-vm hostname: ${NETVM_NAME}, Should be: ${STATIC_NETVM_NAME}, Expected to fail with ${expected_wrong_name}
         END
-    ELSE IF   "${DEVICE_TYPE}" == "orin-agx"
-        SKIP    Known issue: Hostname needs to be updated in ghaf-infra
     END

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -4,8 +4,6 @@
 
 | DATE SET   | TEST CASE                                            | TICKET / Additional Data                                                |
 | ---------- | ---------------------------------------------------- | ----------------------------------------------------------------------- |
-| 15.07.2026 | Check device id (Orin AGX)                           | Device ID needs to be updated in ghaf-infra                             |
-| 15.07.2026 | Check net-vm hostname (Orin AGX)                     | Hostname needs to be updated in ghaf-infra                              |
 | 06.07.2026 | Open video with COSMIC Media Player                  | SSRCSP-8367                                                             |
 | 01.07.2026 | Account lockout after failed GUI login               | Test under development                                                  |
 | 15.06.2026 | VM memory usage snapshot (Dell 7330)                 | Dell has less memory than other targets                                 |


### PR DESCRIPTION
Reverts https://github.com/tiiuae/ci-test-automation/pull/894

Temporary skip did what it was supposed to, I updated new values to ghaf-infra and deployed testagents.