### PR TITLE
Remove AGX extra boottime

### DIFF
--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -39,12 +39,6 @@ Verify booting after restart by power
             Check If Device Is Up   retry=140s
     END
 
-    IF  "orin-agx" in "${DEVICE_TYPE}" and ${IS_AVAILABLE} == False
-        # Known issue SSRCSP-8704
-        Log   Device did not boot in 140 seconds, giving it some extra time due to SSRCSP-8704   console=True
-        Check If Device Is Up   retry=100s
-    END
-
     IF    ${IS_AVAILABLE} == False
         FAIL    The device did not start
     ELSE

--- a/Robot-Framework/test-suites/security-tests/persistence.robot
+++ b/Robot-Framework/test-suites/security-tests/persistence.robot
@@ -30,10 +30,7 @@ Verify camera block persisted
     [Tags]    SP-T305  SP-T305-1
     ${cam_state}      Get device state   cam
     Should Be Equal   ${EXPECTED_CAM_STATE}  ${cam_state}
-    [Teardown]   Run Keyword If Test Failed   Run Keywords   Log persistence setup errors
-    ...    AND   Run Keyword If   "${DEVICE_TYPE}" == "lenovo-x1" or "${DEVICE_TYPE}" == "x1-sec-boot"
-    ...          Run Keywords     Log Error    Camera persistence    Verify camera block persisted failed
-    ...    AND   SKIP   Known issue: SSRCSP-8224
+    [Teardown]   Run Keyword If Test Failed    Verify camera block persisted teardown
 
 Verify microphone block persisted
     [Tags]    SP-T305  SP-T305-2
@@ -83,6 +80,13 @@ Persistence Suite Teardown
         Login to laptop
     END
     Set values   ORIGINAL
+
+Verify camera block persisted teardown
+    Log persistence setup errors
+    IF    "${DEVICE_TYPE}" == "lenovo-x1" or "${DEVICE_TYPE}" == "x1-sec-boot"
+        Log Error    Camera persistence    Verify camera block persisted failed
+        SKIP         Known issue: SSRCSP-8224
+    END
 
 Save original values
     Save original value    ORIGINAL_BRIGHTNESS   Get screen brightness  False

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -35,7 +35,6 @@
 
 | DATE SET   | TEST CASE / KEYWORD                   | TICKET / Additional Data                                                                                   |
 | ---------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| 15.07.2026 | Verify booting after restart by power | SSRCSP-8704, extra 90 seconds added for AGX boot                                                           |
 | 14.07.2026 | Connect After Reboot                  | SSRCSP-8701, extra 30 seconds added for Orins                                                              |
 | 30.06.2026 | Unlock account and login              | Try to login twice after unlocking, first login after unlocking the account fails                          |
 | 22.06.2026 | Set RTC time                          | SSRCSP-8622, separate command for Lenovo X1                                                                |


### PR DESCRIPTION
Reverts https://github.com/tiiuae/ci-test-automation/commit/f45fa126c6ba81d6a5c25cfcb828724ee48a9148, issue was fixed https://github.com/tiiuae/ghaf/pull/2050

Also a fix for `Verify camera block persisted` teardown. I noticed yesterday that the parsing was not working [here](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2320/artifact/Robot-Framework/test-suites/lenovo-x1ANDregressionNOTsecboot-onlyNOTintaller-onlyNOTstoredisk-only/log.html#s1-s3-s10-t1-k3-k1).
```
2) Keyword 'common_keywords.Log Error' expected 2 arguments, got 0.
3) No keyword with name 'Camera persistence' found.
4) No keyword with name 'Verify camera block persisted failed' found.
```

Camera persistence testruns
- [Pass](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7026/artifact/Robot-Framework/test-suites/lenovo-x1ANDpersistence/log.html#s1-s1-s1-t1)
- [Fail](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7027/artifact/Robot-Framework/test-suites/lenovo-x1ANDpersistence/log.html#s1-s1-s1-t1)