### PR TITLE
Skip power mode test

### DIFF
--- a/Robot-Framework/test-suites/performance-tests/performance.robot
+++ b/Robot-Framework/test-suites/performance-tests/performance.robot
@@ -101,6 +101,7 @@ nvpmodel check test
     IF  not ("Power mode check ok: ${ExpectedNVPmode}" in $output)
         FAIL  ${output}\n\nExpected: ${ExpectedNVPmode}
     END
+    [Teardown]     Run Keyword If Test Failed    SKIP     Known issue: SSRCSP-8712
 
 Cyclictest latency on ghaf-host
     [Documentation]    Run four cyclictest latency measurements on ghaf-host and track min/avg/max

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -4,6 +4,7 @@
 
 | DATE SET   | TEST CASE                                            | TICKET / Additional Data                                                |
 | ---------- | ---------------------------------------------------- | ----------------------------------------------------------------------- |
+| 20.07.2026 | nvpmodel check test                                  | SSRCSP-8712                                                             |
 | 17.07.2026 | Shutdown from power menu (Lenovo X1)                 | SSRCSP-8714                                                             |
 | 06.07.2026 | Open video with COSMIC Media Player                  | SSRCSP-8367                                                             |
 | 01.07.2026 | Account lockout after failed GUI login               | Test under development                                                  |


### PR DESCRIPTION
To be merged after https://github.com/tiiuae/ghaf/pull/2036

Powermode check won't work after that PR.

[Testrun](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2341/artifact/Robot-Framework/test-suites/orin-agxANDSP-T175/report.html#totals)