### PR TITLE
Scan for wifi before connecting, extend AGX boot time

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -87,10 +87,13 @@ Log out with loginctl
         RETURN
     END
     Switch to vm          ${GUI_VM}
-    ${session_id}         Run Command      loginctl list-sessions --no-legend | grep seat0 | awk '{print $1}'
+    ${session_ids}        Run Command      loginctl list-sessions --no-legend | awk '$3 == "${USER_LOGIN}" && $4 == "seat0" {print $1}'
     Run Command           loginctl         # For debugging
-    Should Not Be Empty   ${session_id}    No active session found for ${USER_LOGIN}
-    Run Command           loginctl terminate-session ${session_id}   sudo=True
+    @{session_ids}        Split To Lines    ${session_ids}
+    Should Not Be Empty   ${session_ids}    No active session found for ${USER_LOGIN}
+    FOR    ${session_id}    IN    @{session_ids}
+        Run Command       loginctl terminate-session ${session_id}   sudo=True
+    END
     [Teardown]   Switch to vm   ${GUI_VM}  user=${USER_LOGIN}
 
 Type string
@@ -231,12 +234,12 @@ Check if logged out
     [Documentation]    Check if system is in logged out state
     [Arguments]        ${iterations}=10
     FOR   ${i}   IN RANGE  ${iterations}
-        ${status}    ${output}    Run Keyword And Ignore Error    Verify login session
+        ${status}    ${output}    Run Keyword And Ignore Error    Verify login session    greeter
         IF    '${status}' == 'PASS'
-            Log      Found active GUI session for ${USER_LOGIN}, user is logged in  console=True
-        ELSE
-            Log      No active GUI session found for ${USER_LOGIN}, user is logged out  console=True
+            Log      Found active greeter session, user is logged out  console=True
             RETURN    ${True}
+        ELSE
+            Log      No active greeter session found, user is logged in  console=True
         END
         Sleep  1
     END

--- a/Robot-Framework/resources/wifi_keywords.resource
+++ b/Robot-Framework/resources/wifi_keywords.resource
@@ -9,6 +9,7 @@ Resource            ../resources/ssh_keywords.resource
 Configure wifi
     [Arguments]         ${SSID}  ${passw}
     Switch to vm        ${NET_VM}
+    Wait Until Keyword Succeeds     10x   1s   Scan for Wifi   ${SSID}
     Log To Console      Configuring Wifi
     Wait Until Keyword Succeeds   3x   1s   Try to connect wifi   ${SSID}  ${passw}
 

--- a/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
+++ b/Robot-Framework/test-suites/boot-test/relay_boot_test.robot
@@ -31,7 +31,12 @@ Verify booting after restart by power
     Reboot Orin
     Start UART Log Capture
 
-    Check If Device Is Up   retry=140s
+    IF  "orin-agx" in "${DEVICE_TYPE}"
+        # Known issue SSRCSP-8704
+        Check If Device Is Up   retry=230s
+    ELSE
+        Check If Device Is Up   retry=140s
+    END
 
     IF      "${DEVICE_TYPE}" == "orin-nx" and ${IS_AVAILABLE} == False
             Log                     message=Orin-nx failed to start, rebooting via relay one more time...    level=WARN

--- a/Robot-Framework/test-suites/security-tests/killswitch.robot
+++ b/Robot-Framework/test-suites/security-tests/killswitch.robot
@@ -35,7 +35,7 @@ Killswitch disconnects microphone
 
 Killswitch blocks all devices at once
     [Documentation]  Verify that ghaf-killswitch block --all and unblock --all change all device states
-    [Tags]           SP-T368    bat
+    [Tags]           SP-T368  bat  lab-only
     Set all devices state      blocked
     Verify all devices state   blocked
     Set all devices state      unblocked
@@ -56,7 +56,6 @@ Killswitch disconnects WLAN
     Check Network Availability    8.8.8.8        expected_result=True    limit_freq=${False}    interface=eth
     Set device state   unblocked    net
     Remove Wifi configuration       ${TEST_WIFI_SSID}
-    Wait Until Keyword Succeeds     10x   1s   Scan for Wifi   ${TEST_WIFI_SSID}
     Configure wifi                  ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Get wifi IP
     [Teardown]       WLAN teardown
@@ -68,7 +67,6 @@ WLAN setup
     Switch to vm       ${NET_VM}
     ${wifi_if}         Get Interface name    wifi
     Set Test Variable  ${wifi_if}
-    Wait Until Keyword Succeeds     30x   2s   Scan for Wifi   ${TEST_WIFI_SSID}
     Configure wifi     ${TEST_WIFI_SSID}  ${TEST_WIFI_PSWD}
     Get wifi IP
 

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -35,6 +35,8 @@
 
 | DATE SET   | TEST CASE / KEYWORD                   | TICKET / Additional Data                                                                                   |
 | ---------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| 17.07.2026 | Log out with loginctl                 | Log out all testuser sessions if the are many on seat (controlling the screen) (probably a Cosmic bug)     |
+| 15.07.2026 | Verify booting after restart by power | SSRCSP-8704, extra 90 seconds added for AGX boot                                                           |
 | 14.07.2026 | Connect After Reboot                  | SSRCSP-8701, extra 30 seconds added for Orins                                                              |
 | 30.06.2026 | Unlock account and login              | Try to login twice after unlocking, first login after unlocking the account fails                          |
 | 22.06.2026 | Set RTC time                          | SSRCSP-8622, separate command for Lenovo X1                                                                |


### PR DESCRIPTION
* Add extended boot time back for Orin AGX.
    * Originally added [here](https://github.com/tiiuae/ci-test-automation/pull/896) and then removed as fixed [here](https://github.com/tiiuae/ci-test-automation/pull/898). After workaround was removed the issue happened again in the nightly pipeline.
    * Added the extra time directly to the `Check If Device Is Up` so that UART capture works during the whole boot. With previous workaround it stopped working during the extra boot time.
* Always `Scan for Wifi` before trying to connect.
  * This fixes `Wifi password is not revealed in Grafana` test in bat. It started failing after [Killswitch blocks all devices at once](https://github.com/tiiuae/ci-test-automation/pull/888) was added last week. Wifi needs to be rescanned after it is unblocked. In nightly pipeline `Killswitch disconnects WLAN` does that, but it is not a part of bat.
* Add `lab-only` tag to `Killswitch blocks all devices at once` because it blocks the wifi.
* I also tried to fix `Failed to log out.` issue.
    * Check for active cosmic-greeter session to determine logging out instead of checking for active testuser session.
    * Log out all testuser sessions that are on the seat.


**Testruns**

* [Lenovo X1 bat](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7049/artifact/Robot-Framework/test-suites/lenovo-x1ANDbatNOTinstaller-onlyNOTsecboot-only/report.html)
* [Lenovo X1 wifi & logout tests](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7053/artifact/Robot-Framework/test-suites/SP-T101ORkillswitchORSP-T328-1ORgui-power/report.html)
* [Darter Pro bat](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7050/artifact/Robot-Framework/test-suites/darter-proANDbatNOTinstaller-onlyNOTsecboot-only/report.html)
* [Darter Pro wifi & logout tests](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7055/artifact/Robot-Framework/test-suites/SP-T101ORkillswitchORSP-T328-1ORgui-power/report.html)
* [Orin AGX regression](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2342/) (extended boot time was needed in this run)