### PR TITLE
Add tests for Cosmic System Monitor

### DIFF
--- a/Robot-Framework/config/apps.json
+++ b/Robot-Framework/config/apps.json
@@ -53,6 +53,12 @@
     "close_button": "ghaf-close.png",
     "icon": "settings.png"
   },
+  "COSMIC System Monitor": {
+    "display_name": "COSMIC System Monitor",
+    "VM": "gui-vm",
+    "process_name": "cosmic-monitor",
+    "close_button": "ghaf-close.png"
+  },
   "COSMIC Terminal": {
     "display_name": "COSMIC Terminal",
     "VM": "gui-vm",

--- a/Robot-Framework/test-suites/functional-tests/apps.robot
+++ b/Robot-Framework/test-suites/functional-tests/apps.robot
@@ -40,6 +40,10 @@ Start COSMIC Settings
     [Tags]            SP-T254  SP-T254-1  fmo
     ${COSMIC Settings}
 
+Start COSMIC System Monitor
+    [Tags]            SP-T372  SP-T372-1
+    ${COSMIC System Monitor}
+
 Start COSMIC Terminal
     [Tags]            SP-T263  SP-T263-1  fmo
     ${COSMIC Terminal}

--- a/Robot-Framework/test-suites/gui-tests/gui_app_launch.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_app_launch.robot
@@ -49,6 +49,10 @@ Start COSMIC Settings via GUI
     [Tags]            SP-T254  SP-T254-2
     ${COSMIC Settings}
 
+Start COSMIC System Monitor via GUI
+    [Tags]            SP-T372  SP-T372-2
+    ${COSMIC System Monitor}
+
 Start COSMIC Terminal via GUI
     [Tags]            SP-T263  SP-T263-2
     ${COSMIC Terminal}


### PR DESCRIPTION
Cosmic System Monitor was added in https://github.com/tiiuae/ghaf/pull/2029

[Testrun](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7080/artifact/Robot-Framework/test-suites/appsORgui-app-launch/report.html#tags?SP-T372)