### PR TITLE
Test forwarding to normal browser from Trusted

### DIFF
--- a/Robot-Framework/resources/gui_keywords.resource
+++ b/Robot-Framework/resources/gui_keywords.resource
@@ -121,9 +121,9 @@ Take Remote Screenshot And Download
     RETURN    ${to}
 
 Verify Text Is On The Screen
-    [Arguments]    ${text}    ${expected}=${True}
+    [Arguments]    ${text}    ${expected}=${True}    ${scale}=1
     ${screenshot_path}      Take Remote Screenshot And Download
-    ${is_visible}           Is Text On The Screen   ${screenshot_path}   ${text}
+    ${is_visible}           Is Text On The Screen   ${screenshot_path}   ${text}   scale=${scale}
     Should Be Equal         ${is_visible}    ${expected}
     ...                     msg=Text '${text}' is on the screen: ${is_visible}, expected: ${expected}
 

--- a/Robot-Framework/test-suites/gui-tests/__init__.robot
+++ b/Robot-Framework/test-suites/gui-tests/__init__.robot
@@ -35,6 +35,9 @@ Save gui icons and icon path
     Negate app icon         ${ICONS_DIR}/window-close.png  ${ICONS_DIR}/window-close-neg.png
     OperatingSystem.Copy File    ../test-files/ghaf-close.png    ${ICONS_DIR}/
     OperatingSystem.Copy File    ../test-files/gala_signin_arrow.png    ${ICONS_DIR}/
+    ${open_normal_icon}     Run Command   ls -d /nix/store/*-open-normal/ghaf-logo-512px.png
+    SSHLibrary.Get File     ${open_normal_icon}    ${ICONS_DIR}/open-normal-browser.png
+    OperatingSystem.Run     magick ${ICONS_DIR}/open-normal-browser.png -resize 16x16 -background white -alpha remove ${ICONS_DIR}/open-normal-browser.png
     # Desktop
     Get icon                ${icons}/Cosmic/scalable/actions  system-search-symbolic.svg  crop=0  background=white  output_filename=search.png
     Negate app icon         ${ICONS_DIR}/search.png  ${ICONS_DIR}/search-neg.png

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -82,6 +82,17 @@ Verify Gala is loaded
     [Teardown]   Run Keywords    Kill App in VM   ${Gala}   require_exists=False
     ...    AND   Switch to vm    ${GUI_VM}  user=${USER_LOGIN}    AND    Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
+Trusted Browser opens blocked page in normal browser
+    [Documentation]    Open blocked Yle in ${Trusted Browser}[display_name], then open it in ${Google Chrome}[display_name].
+    [Tags]             SP-T220
+    Open restricted page in Trusted Browser
+    Verify page is blocked in Trusted Browser
+    Forward page to normal browser
+    Verify page opened in normal browser
+    [Teardown]   Run Keywords    Kill App in VM   ${Google Chrome}   require_exists=False
+    ...    AND   Kill App in VM   ${Trusted Browser}   require_exists=False
+    ...    AND   Switch to vm    ${GUI_VM}  user=${USER_LOGIN}    AND    Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
+
 *** Keywords ***
 
 Save current document from COSMIC Text Editor to Shares
@@ -106,6 +117,28 @@ Paste clipboard text and verify
     Press Key(s)       LEFTCTRL+V
     Move cursor to corner
     Verify Text Is On The Screen    ${text}
+
+Open restricted page in Trusted Browser
+    Start App in VM    ${Trusted Browser}    params_string=-- https://yle.fi    always_check_vm=True
+
+Verify page is blocked in Trusted Browser
+    Switch to vm       ${GUI_VM}    user=${USER_LOGIN}
+    Wait Until Keyword Succeeds    10x    1s    Verify Text Is On The Screen    This site can’t be reached
+    Verify Text Is On The Screen    Uutiset    expected=${False}    scale=2
+
+Forward page to normal browser
+    Locate and click   image   open-normal-browser.png   confidence=0.80   iterations=20   scale=2
+
+Verify page opened in normal browser
+    Check that App is running in VM    ${Google Chrome}    range=10
+    Switch to vm       ${GUI_VM}    user=${USER_LOGIN}
+    Skip Chrome sign-in prompt if shown
+    Wait Until Keyword Succeeds    10x    1s    Verify Text Is On The Screen    Uutiset    scale=2
+
+Skip Chrome sign-in prompt if shown
+    [Documentation]    Chrome sign-in prompt is shown not every time
+    ${status}    Run Keyword And Return Status      Locate on screen    text    Stay    0.9    10    scale=2
+    Run Keyword If    ${status}    Locate and click    text    Stay    iterations=3    timeout=15    scale=2
 
 Locate and click minimize window button
     ${mouse_x}  ${mouse_y}  Locate on screen  image  ${Zoom}[close_button]  0.99  10  timeout=120  scale=2


### PR DESCRIPTION
* Add GUI test for forwarding a restricted Trusted Browser page to normal browser.
* Resize the open-normal-browser.png before using it in image recognition. Chrome uses the same `ghaf-logo-512px.png` for all icon sizes, so the test converts it to the toolbar size.
* Handle optional Chrome sign-in prompt that may appear when opening a fresh browser profile.
* Add support for scaling OCR in `Verify Text Is On The Screen`.

Testruns with recorded video:
[DarterPro fresh](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7145/)
[DaterPro second open](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7146/)
[LenovoX1 all gui tests](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7148/artifact/Robot-Framework/test-suites/guiANDlenovo-x1/log.html#s1-s1-s6-t1)