### PR TITLE
Support Darter Pro SB in tests

### DIFF
--- a/Robot-Framework/config/variables.robot
+++ b/Robot-Framework/config/variables.robot
@@ -65,7 +65,7 @@ Set Variables
         Run Keyword And Ignore Error    Set Global Variable  ${RELAY_NUMBER}       ${config['addresses']['${DEVICE}']['relay_number']}
         Run Keyword And Ignore Error    Set Global Variable  ${RPI_IP_ADDRESS}     ${config['addresses']['${DEVICE}']['rpi_ip_address']}
     END
-    IF  "${DEVICE_TYPE}" == "lenovo-x1" or "${DEVICE_TYPE}" == "dell-7330" or "${DEVICE_TYPE}" == "darter-pro" or "${DEVICE_TYPE}" == "x1-sec-boot"
+    IF  "${DEVICE_TYPE}" == "lenovo-x1" or "${DEVICE_TYPE}" == "dell-7330" or "${DEVICE_TYPE}" == "darter-pro" or "${DEVICE_TYPE}" == "x1-sec-boot" or "${DEVICE_TYPE}" == "darter-sec-boot"
         Set Global Variable  ${IS_LAPTOP}           True
     ELSE
         Set Global Variable  ${IS_LAPTOP}           False

--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -61,7 +61,7 @@ Reboot Laptop
 Turn Laptop On
     Log To Console    ${\n}Booting the device by pressing the power button
     Press Button      ${SWITCH_BOT}-ON
-    IF    "${DEVICE_TYPE}" == "darter-pro"
+    IF    "${DEVICE_TYPE}" == "darter-pro" or "${DEVICE_TYPE}" == "darter-sec-boot"
         Wait    15
         Log     Pressing Enter    console=True
         Press Button      ${SWITCH_BOT}-Enter
@@ -133,7 +133,7 @@ Connect After Reboot
     [Documentation]   Verify that device rebooted and connect
     [Arguments]      ${soft_reboot}=False
     Wait   30
-    IF    "${DEVICE_TYPE}" == "darter-pro" and ${soft_reboot}
+    IF    ("${DEVICE_TYPE}" == "darter-pro" or "${DEVICE_TYPE}" == "darter-sec-boot") and ${soft_reboot}
         WHILE    True    limit=120 seconds
             Log              Pressing Enter    console=True
             Press Button     ${SWITCH_BOT}-Enter

--- a/Robot-Framework/test-suites/gui-tests/gui_power.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_power.robot
@@ -66,7 +66,7 @@ Reboot from power menu
     ${end_time}       Get Time    epoch
     Login to laptop   enable_dnd=True
     ${elapsed}        Evaluate    ${end_time} - ${start_time}
-    ${reboot_limit}   Set Variable If    "${DEVICE_TYPE}" == "darter-pro"    100    90
+    ${reboot_limit}   Set Variable If    "${DEVICE_TYPE}" == "darter-pro" or "${DEVICE_TYPE}" == "darter-sec-boot"     100    90
     Log               Reboot took ${elapsed} seconds   console=True
 
     Should Not Be True    ${elapsed} > ${reboot_limit}    msg=Reboot took too long: ${elapsed} seconds (expected < ${reboot_limit})


### PR DESCRIPTION
[bat and bat tests](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2398/)
(devices id and hostname test failed, will be fixed separately in the config)
[Reboot from power menu](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2399/artifact/Robot-Framework/test-suites/SP-T75-4/log.html#s1-s1-s1-t1)