### PR TITLE
Don't require pre-existing destination file

### DIFF
--- a/Robot-Framework/test-suites/security-tests/givc_policy.robot
+++ b/Robot-Framework/test-suites/security-tests/givc_policy.robot
@@ -20,11 +20,15 @@ ${POLICY_BACKUP_DIR}    /tmp
 *** Test Cases ***
 
 GIVC policy init on boot in policy-enabled VMs
-    [Documentation]  Verify givc-policy-init completed without known errors and created policy files.
+    [Documentation]  Verify givc-policy-init completed and preserves already delivered policies.
     [Tags]           SP-T365
+    @{failures}    Create List
     FOR    ${vm}    IN    @{POLICY_CLIENT_VMS}
-        Verify givc policy init in ${vm}
+        Verify givc policy init in ${vm}    ${failures}
     END
+    ${failure_count}    Get Length    ${failures}
+    ${failure_text}    Evaluate    "\\n".join($failures)
+    Run Keyword If    ${failure_count} > 0    FAIL    ${failure_text}
 
 *** Keywords ***
 
@@ -32,13 +36,15 @@ GIVC policy suite setup
     @{VM_LIST_WITH_HOST}    Get VM list    with_host=True
     @{POLICY_CLIENT_VMS}    Create List
     FOR    ${vm}    IN    @{VM_LIST_WITH_HOST}
-        ${status}    ${message}    Run Keyword And Ignore Error    Switch to vm    ${vm}
-        IF    '${status}' != 'PASS'
+        TRY
+            Switch to vm    ${vm}
+        EXCEPT    AS    ${message}
             Log To Console    Excluding inaccessible VM from GIVC tests: ${vm}
             CONTINUE
         END
-        ${status}    ${config_raw}    Run Keyword And Ignore Error    Run Command    cat /etc/givc-agent/config.json
-        IF    '${status}' != 'PASS'
+        TRY
+            ${config_raw}    Run Command    cat /etc/givc-agent/config.json
+        EXCEPT    AS    ${message}
             Log To Console    Excluding VM without readable GIVC config from GIVC tests: ${vm}
             CONTINUE
         END
@@ -75,29 +81,56 @@ Get stored policy path
     ${store_path}    Evaluate    $policy_cfg["storePath"]
     RETURN    ${store_path}/${policy_name}/policy.bin
 
+Append failure
+    [Arguments]    ${failures}    ${message}
+    Append To List    ${failures}    ${message}
+    Log To Console    ${message}
+
 Verify givc policy init in ${vm}
+    [Arguments]    ${failures}
     Switch to vm    ${vm}
-    ${policy_cfg}    Get current VM policy config
+    TRY
+        ${policy_cfg}    Get current VM policy config
+    EXCEPT    AS    ${message}
+        Append failure    ${failures}    ${vm}: failed to read current VM policy config: ${message}
+        RETURN
+    END
 
     ${rc}    Run Command    systemctl is-enabled givc-policy-init    return=rc    rc_match=skip
     IF    ${rc}[0] != 0
-        FAIL    givc-policy-init is not enabled in ${vm}
+        Append failure    ${failures}    ${vm}: givc-policy-init is not enabled
+        RETURN
     END
 
-    Service should not be failed    givc-policy-init
-    ${journal}    Run Command    journalctl -u givc-policy-init -b --no-pager    rc_match=skip
-    Should Not Contain    ${journal}    Error! file not found
+    TRY
+        Service should not be failed    givc-policy-init
+    EXCEPT    AS    ${message}
+        Append failure    ${failures}    ${vm}: givc-policy-init service check failed: ${message}
+    END
 
     ${policy_names}    Evaluate    list($policy_cfg.get("policies", {}).keys())
-    Should Not Be Empty    ${policy_names}
+    IF    not ${policy_names}
+        Append failure    ${failures}    ${vm}: policy client is enabled but no policies are configured
+        RETURN
+    END
     FOR    ${policy_name}    IN    @{policy_names}
-        ${destination}    Get configured policy destination    ${policy_cfg}    ${policy_name}
-        Run Command    test -f ${destination}
+        TRY
+            ${destination}    Get configured policy destination    ${policy_cfg}    ${policy_name}
+        EXCEPT    AS    ${message}
+            Append failure    ${failures}    ${vm}/${policy_name}: failed to get policy destination: ${message}
+            CONTINUE
+        END
         ${stored_path}    Get stored policy path    ${policy_cfg}    ${policy_name}
         # Check stored_path == destination only if stored_path exists.
         ${stored_rc}    Run Command    test -f ${stored_path}    return=rc    rc_match=skip
         IF    ${stored_rc}[0] == 0
-            Stored policy file should match destination    ${stored_path}    ${destination}
+            TRY
+                Stored policy file should match destination    ${stored_path}    ${destination}
+            EXCEPT    AS    ${message}
+                Append failure
+                ...    ${failures}
+                ...    ${vm}/${policy_name}: stored policy does not match destination (${stored_path} -> ${destination}): ${message}
+            END
         END
     END
 


### PR DESCRIPTION
At first boot policy destination files don't exist. Policy destination file is created at run-time (at first boot) when ghaf-givc policy delivery happens.

This is why 'journalctl -u givc-policy-init -b --no-pager' output can contain 'Error! file not found' at first boot. Removing that check.

Also make 'GIVC policy init on boot in policy-enabled VMs' more robust, continuing policy init checks even at failure, failing collectively only at the end (if necessary).

https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7201/