### PR TITLE
Add Ghaf Control Panel GUI test

### DIFF
--- a/Robot-Framework/lib/GuiTesting.py
+++ b/Robot-Framework/lib/GuiTesting.py
@@ -6,6 +6,7 @@ from PIL import Image
 from pyscreeze import locate, center
 import logging
 import pytesseract
+import re
 import subprocess
 
 def locate_image(screenshot, image, confidence):
@@ -42,6 +43,66 @@ def get_text(data: pytesseract.Output.DICT):
 
     logging.info(text_list)
     return text_list
+
+def _normalize_ocr_text(text):
+    # OCR can add punctuation or split words oddly. Normalize labels before matching.
+    return re.sub(r"[^a-z0-9]+", "", text.lower())
+
+def _get_ocr_words(data):
+    # Keep each recognized word together with its position so field values can be read by layout.
+    words = []
+    for i, text in enumerate(data['text']):
+        text = text.strip()
+        if not text:
+            continue
+
+        words.append({
+            'text': text,
+            'normalized': _normalize_ocr_text(text),
+            'left': data['left'][i],
+            'top': data['top'][i],
+            'width': data['width'][i],
+            'height': data['height'][i],
+        })
+
+    return words
+
+def get_text_field_from_image(image, field, scale=1):
+    # Read table-like UI rows where the label is on the left and the value is on the same row to the right.
+    logging.info(f"Reading field '{field}' from {image}")
+    data = get_data_from_image(image, scale)
+    words = _get_ocr_words(data)
+    expected_words = [_normalize_ocr_text(word) for word in field.split()]
+
+    for i in range(len(words)):
+        label_words = words[i:i + len(expected_words)]
+        if len(label_words) != len(expected_words):
+            continue
+
+        label_text = [word['normalized'] for word in label_words]
+        if label_text != expected_words:
+            continue
+
+        label_right = max(word['left'] + word['width'] for word in label_words)
+        label_center_y = sum(word['top'] + word['height'] / 2 for word in label_words) / len(label_words)
+        label_height = max(word['height'] for word in label_words)
+        row_tolerance = max(20, label_height)
+
+        # The value is expected to be horizontally after the label and vertically aligned with it.
+        value_words = [
+            word for word in words
+            if word['left'] > label_right
+            and abs((word['top'] + word['height'] / 2) - label_center_y) <= row_tolerance
+        ]
+        value_words.sort(key=lambda word: word['left'])
+
+        if value_words:
+            value = ' '.join(word['text'] for word in value_words)
+            logging.info(f"Field '{field}' value: {value}")
+            return value
+
+    recognized_text = get_text(data)
+    raise AssertionError(f"Field '{field}' not found in image. Recognized text: {recognized_text}")
 
 def is_text_on_the_screen(screenshot, text, scale=1):
     logging.info("Searching " + text)

--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -93,7 +93,55 @@ Trusted Browser opens blocked page in normal browser
     ...    AND   Kill App in VM   ${Trusted Browser}   require_exists=False
     ...    AND   Switch to vm    ${GUI_VM}  user=${USER_LOGIN}    AND    Stop screen recording   ${TEST_STATUS}   ${TEST_NAME}
 
+Ghaf Control Panel shows device information
+    [Documentation]    Open Ghaf Control Panel 'About' page and verify device information matches system data.
+    [Tags]             SP-T370
+    Start app via GUI   ${Ghaf Control Panel}
+    Navigate To Device Information Page
+    Verify Device Information
+
+
 *** Keywords ***
+
+Navigate To Device Information Page
+    [Documentation]   Open the 'About' page from the initial Services view.
+    Open Ghaf Control Panel Settings
+    Locate and click   text   About
+
+Open Ghaf Control Panel Settings
+    [Documentation]   Click Settings by offset from the close button because OCR does not reliably detect the tab text.
+    ...               Offsets are in ydotool mouse coordinates: Settings center is about 33 px left and 30 px down
+    ...               from the Ghaf Control Panel close button center.
+    ${close_x}   ${close_y}   Locate on screen   image   ${Ghaf Control Panel}[close_button]   0.90
+    ${settings_x}   Evaluate   ${close_x} - 33
+    ${settings_y}   Evaluate   ${close_y} + 30
+    Run ydotool command   mousemove --absolute -x ${settings_x} -y ${settings_y}
+    Click
+
+Verify Device Information
+    ${ghaf_version}     Get Ghaf Version
+    ${device_id}        Get Actual Device ID
+    ${sysinfo}          Run Command   givc-cli sysinfo
+    ${secure_boot}      Get givc-cli sysinfo field   ${sysinfo}   Secure Boot
+    ${disk_encryption}  Get givc-cli sysinfo field   ${sysinfo}   Disk Encryption
+
+    Verify Device Information Field   Ghaf Version       ${ghaf_version}
+    Verify Device Information Field   Device ID          ${device_id}
+    Verify Device Information Field   Secure Boot        ${secure_boot}
+    Verify Device Information Field   Disk Encryption    ${disk_encryption}
+
+Verify Device Information Field
+    [Arguments]    ${field}    ${expected}
+    ${screenshot_path}  Take Remote Screenshot And Download
+    ${actual}           Get Text Field From Image   ${screenshot_path}   ${field}   scale=2
+    Should Be Equal As Strings    ${actual}    ${expected}    ignore_case=True
+    ...                         msg=${field} value in Ghaf Control Panel is ${actual}, expected ${expected}.
+
+Get givc-cli sysinfo field
+    [Arguments]    ${output}    ${field}
+    ${matches}     Get Regexp Matches    ${output}    (?m)^${field}:\\s*(\\S(?:.*\\S)?)\\s*$    1
+    Should Not Be Empty    ${matches}    Could not find ${field} in givc-cli sysinfo output:\n${output}
+    RETURN         ${matches}[0]
 
 Save current document from COSMIC Text Editor to Shares
     [Arguments]      ${file_name}


### PR DESCRIPTION
Open Ghaf Control Panel app - Settings - About
And verify values: Ghaf Version, Device ID, Secure Boot, Disk Encryption (compare with system information)

[Secure boot X1](https://ci-prod.vedenemo.dev/job/ghaf-hw-test-manual/2406/) 
[X1 installer](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7193/artifact/Robot-Framework/test-suites/outputs/gui/) 
[Darter storeDisk Installer](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7216/) 
[regular Darter](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7217/) 