### PR TITLE
Increase time to reboot Orin

### DIFF
--- a/Robot-Framework/resources/device_control.resource
+++ b/Robot-Framework/resources/device_control.resource
@@ -143,7 +143,7 @@ Connect After Reboot
         Check If Device Is Available   retry=5x    action=reboot
     ELSE IF   "orin" in "${DEVICE_TYPE}"
         # Workaround for SSRCSP-8701
-        Check If Device Is Available   retry=90s   action=reboot
+        Check If Device Is Available   retry=120s   action=reboot
     ELSE
         Check If Device Is Available   retry=60s   action=reboot
     END


### PR DESCRIPTION
Increased time to connect after Reboot Orin to 120 sec
[Orin NX](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7256/artifact/Robot-Framework/test-suites/SP-T283/log.html#s1-s1-s1-t1-k17-k1-k2-k1-k2-k3-k1) took 108 sec
[Orin AGX](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7257/artifact/Robot-Framework/test-suites/SP-T283/log.html#s1-s1-s1-t1-k17-k1-k2-k1-k2-k3-k1) took 116 sec