### PR TITLE
fix(camera): drop Dell 7330 chrome-vm workaround

### DIFF
--- a/Robot-Framework/test-suites/functional-tests/camera.robot
+++ b/Robot-Framework/test-suites/functional-tests/camera.robot
@@ -22,15 +22,12 @@ ${VIDEO_DIR}    ${OUTPUT_DIR}/outputs/camera
 *** Test Cases ***
 
 Check Camera in VMs
-    [Documentation]  Check that camera is available in business-vm (for Dell in chrome-vm) and not in other VMs
+    [Documentation]  Check that camera is available in business-vm and not in other VMs
     [Tags]  SP-T235
     @{vms}      Get VM list
     FOR  ${vm}  IN  @{vms}
         Switch to vm        ${vm}
-        IF  '${vm}' == '${BUSINESS_VM}' and "${DEVICE_TYPE}" != "dell-7330"
-            Run Keyword And Continue On Failure   Run Command  ls /dev/ | grep video  sudo=True
-        ELSE IF  '${vm}' == '${CHROME_VM}' and "${DEVICE_TYPE}" == "dell-7330"
-            # Special case for Dell due to SSRCSP-8266
+        IF  '${vm}' == '${BUSINESS_VM}'
             Run Keyword And Continue On Failure   Run Command  ls /dev/ | grep video  sudo=True
         ELSE
             Run Keyword And Continue On Failure   Run Command  ls /dev/ | grep video  sudo=True  rc_match=not_equal  compare_rc=0
@@ -61,6 +58,3 @@ Record Video With Camera
     FOR  ${id}  IN  @{recorded_video_ids}
         Verify Video File  ${id}
     END
-
-    # Can't be tested on Dell because v4l2-ctl is not available in chrome-vm
-    [Teardown]    Run Keyword If  "${DEVICE_TYPE}" == "dell-7330"   Run Keyword If Test Failed   SKIP   "Known issue: SSRCSP-8266"

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -24,8 +24,6 @@
 | ---------- | ---------------------------------------------------- | --------------------------------------- |
 | 15.06.2026 | VM memory usage snapshot (Dell 7330)                 | Dell has less memory than other targets |
 | 22.05.2026 | Check logging rate (Dell)                            | SSRCSP-8481                             |
-| 30.03.2026 | Check Camera in VMs (Dell)                           | SSRCSP-8266                             |
-| 30.03.2026 | Check Camera Application (Dell checked in chrome-vm) | SSRCSP-8266                             |
 
 ## TAGs removed
 


### PR DESCRIPTION
The Dell Latitude 7330's integrated webcam (1bcf:2a03, Sunplus) was missing from ghaf's `internalWebcams` list. business-vm allows exactly that list and chrome-vm denies it, so on the Dell neither matched: the camera fell through to chrome-vm's generic interfaceClass=14 rule. vhotplug logged "Found multiple VMs for 1bcf:2a03" and then attached it to chrome-vm.

This suite encoded that as expected behaviour for dell-7330. Check Camera in VMs looked for the camera in chrome-vm rather than business-vm, and Record Video With Camera skipped on failure because v4l2-ctl is not available in chrome-vm -- so the recording path was never exercised on this target at all.

tiiuae/ghaf now carries 1bcf:2a03 in internalWebcams, so the Dell routes the camera to business-vm like every other laptop. Verified on hardware after a reflash: vhotplug logs "Attaching 1bcf:2a03 ... to business-vm" with the "Found multiple VMs" ambiguity gone, and Record Video With Camera passes -- it lists devices with v4l2-ctl, records 8 seconds with ffmpeg and verifies the resulting file.

Remove both special cases so the Dell is checked like the rest of the fleet, and drop the two now-stale SSRCSP-8266 rows from the skip list.