### PR TITLE
Fix firewall flood tests

### DIFF
--- a/Robot-Framework/test-suites/security-tests/firewall.robot
+++ b/Robot-Framework/test-suites/security-tests/firewall.robot
@@ -16,11 +16,11 @@ Suite Setup         Suite Setup
 *** Variables ***
 ${port}             5432
 ${BLOCKED_PAGE}     www.instant-gaming.com
-${PING_FLOOD_ATTACK_COUNT}     200
-${PING_FLOOD_INTERVAL}         0.01
-${TCP_SYN_FLOOD_ATTACK_COUNT}  200
-${TCP_SYN_FLOOD_INTERVAL}      0.05
-${TCP_SYN_FLOOD_TIMEOUT}       0.1
+${PING_FLOOD_ATTACK_COUNT}     300
+${PING_FLOOD_INTERVAL}         0.005
+${TCP_SYN_FLOOD_ATTACK_COUNT}  1100
+${TCP_SYN_FLOOD_INTERVAL}      0.0001
+${TCP_SYN_FLOOD_TIMEOUT}       0.005
 
 
 *** Test Cases ***

--- a/Robot-Framework/test-suites/security-tests/network.robot
+++ b/Robot-Framework/test-suites/security-tests/network.robot
@@ -12,21 +12,20 @@ Resource            ../../resources/setup_keywords.resource
 Resource            ../../resources/security_blacklist_keywords.resource
 
 *** Variables ***
-${FAILED_SSH_LOGIN_ATTACK_COUNT}    11
+${FAILED_SSH_LOGIN_ATTACK_COUNT}    12
 
 
 *** Test Cases ***
 
 Account lockout after failed SSH login
     [Documentation]  Try to connect from the external test agent to the device with a wrong password for several times, then check that
-    ...              test agent's ip is blacklisted in net-vm and it is not possible to connect even with correct password.
-    ...              Remove IP from blacklist via serial and verify SSH connectivity is restored.
+    ...              it is not possible to connect even with correct password.
+    ...              Wait for the lockout window to pass and verify SSH connectivity is restored.
     [Tags]           SP-T268  lenovo-x1  darter-pro  lab-only
-    ${ip}            Get External Attacker IP
+    Close All Connections
+    ${blacklisted_at}    Set Variable    ${None}
     Try External Login With Wrong Password
     ${blacklisted_at}    Get Time    epoch
-    Verify NetVM Blacklist Contains IP Via Serial    ${ip}   f2b-sshBlacklist
-    Unban IP Address Via Serial                      ${ip}
     [Teardown]       Account lockout teardown    ${blacklisted_at}
 
 Check OpenSSL3 is Available In Nix Store
@@ -40,38 +39,53 @@ Check OpenSSL3 is Available In Nix Store
 
 Try External Login With Wrong Password
     [Arguments]     ${user}=${LOGIN}   ${pw}=${PASSWORD}   ${timeout}=10
+    Log To Console    Trying to log in with the wrong password
+    ${wrong_password_cmd}   Set Variable
+    ...    nix shell nixpkgs#sshpass -c sh -c 'for i in $(seq 1 ${FAILED_SSH_LOGIN_ATTACK_COUNT}); do sshpass -p wrong ssh -o PreferredAuthentications=password -o PubkeyAuthentication=no -o PasswordAuthentication=yes -o KbdInteractiveAuthentication=no -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${user}@${DEVICE_IP_ADDRESS} true; done'
+    ${result}   Run Process
+    ...    sh
+    ...    -c
+    ...    ${wrong_password_cmd}
+    ...    timeout=120
+    Log    Wrong-password attempt stdout:\n${result.stdout}
+    Log    Wrong-password attempt stderr:\n${result.stderr}
+    Should Not Be Equal As Integers    ${result.rc}    0    Wrong-password login unexpectedly succeeded
+    Should Contain    ${result.stderr}    Permission denied    Wrong-password attempt did not fail as an SSH authentication error
+    Should Not Contain    ${result.stderr}    command not found
+    Should Not Contain    ${result.stderr}    error:
     ${connection}   Open Connection    ${DEVICE_IP_ADDRESS}    port=22    prompt=\$    timeout=${timeout}
-    FOR    ${i}    IN RANGE     ${FAILED_SSH_LOGIN_ATTACK_COUNT}
-        TRY
-            Log To Console    Trying to log in with the wrong password
-            ${status}  ${login_output}   Run Keyword And Ignore Error  Login with timeout  expected_output=${NET_VM}  username=${user}  password=wrong  timeout=${timeout}
-        EXCEPT    Keyword timeout ${timeout} seconds exceeded.
-            BREAK
-        END
-    END
     TRY
         Log To Console    Trying to log in with the correct password
-        Run Keyword And Ignore Error  Login with timeout  expected_output=${NET_VM}  username=${user}  password=${pw}  timeout=${timeout}
+        ${status}  ${login_output}   Run Keyword And Ignore Error
+        ...    Login with timeout
+        ...    expected_output=${NET_VM}
+        ...    username=${user}
+        ...    password=${pw}
+        ...    timeout=${timeout}
+        Should Not Be Equal    ${status}    PASS    Correct-password login unexpectedly succeeded after failed login attempts
     EXCEPT    Keyword timeout ${timeout} seconds exceeded.
         Log   Failed to connect with correct password in ${timeout} seconds.    console=True
+    FINALLY
+        Run Keyword And Ignore Error    Close Connection
     END
-    Close Connection
 
 Account lockout teardown
     [Arguments]     ${blacklisted_at}
     Close All Connections
-    # findtime for fail2ban is 60s; count it from the moment IP was added to blacklist
+    IF    $blacklisted_at == None
+        Log    Skipping lockout wait because the blacklist timestamp was not set.    console=True
+        RETURN
+    END
+    # Wait for the lockout window to pass before verifying SSH access is restored.
     ${now}            Get Time    epoch
     ${elapsed}        Evaluate    int(${now}) - int(${blacklisted_at})
     ${remaining_wait}    Evaluate    max(0, 60 - int(${elapsed}))
     IF    ${remaining_wait} > 0
-        Log To Console    Waiting ${remaining_wait}s before reboot to satisfy fail2ban findtime window
+        Log To Console    Waiting ${remaining_wait}s before verifying SSH access is restored
         Wait    ${remaining_wait}
     END
-    ${soft_reboot_ok}    Run Keyword And Return Status    Soft Reboot Device And Connect
-    IF    not ${soft_reboot_ok}
-        Log    Soft reboot did not recover device access, falling back to hard reboot.    console=True
+    ${connectivity_restored}    Run Keyword And Return Status    Verify External Connectivity Restored    SSH
+    IF    not ${connectivity_restored}
+        Log    SSH access was not restored after waiting, falling back to hard reboot.    console=True
         Hard Reboot Device And Connect   verify_shutdown=False
     END
-    Verify External Connectivity Restored    SSH
-    Login to laptop


### PR DESCRIPTION
Need still more aggressive flooding.

And ssh login test needs fresh connection for each login attempt.

Flood tests on Lenovo-X1
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7298/

`Account lockout after failed SSH login` on Darter-Pro
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7310/