### PR TITLE
Add skip and adapt net-vm timesync test

### DIFF
--- a/Robot-Framework/test-suites/gui-tests/gui_apps.robot
+++ b/Robot-Framework/test-suites/gui-tests/gui_apps.robot
@@ -99,6 +99,7 @@ Ghaf Control Panel shows device information
     Start app via GUI   ${Ghaf Control Panel}
     Navigate To Device Information Page
     Verify Device Information
+    [Teardown]     Run Keyword If Test Failed    SKIP    Known issue: SSRCSP-8770
 
 
 *** Keywords ***

--- a/Robot-Framework/test-suites/security-tests/timesync.robot
+++ b/Robot-Framework/test-suites/security-tests/timesync.robot
@@ -66,12 +66,15 @@ Update system time from internet in ${vm}
     Switch to vm              ${vm}
     Block internet traffic
     Set system time           ${wrong_time}
-    Restart timesync daemon
+    IF    "${vm}" != "${NET_VM}"
+        Restart timesync daemon
+    ELSE
+        Restart timesync daemon    chronyd.service
+    END
     Check time was changed    expected_time=None
     Unblock internet traffic
     Check that time is correct
-    [Teardown]  Run Keyword If  "${KEYWORD STATUS}" == 'FAIL'   Unblock internet traffic
-
+    [Teardown]  Run Keyword If  "${KEYWORD STATUS}" == 'FAIL'   Run Keyword  Unblock internet traffic
 
 Stop timesync daemon
     Run Command            systemctl stop systemd-timesyncd.service  sudo=True
@@ -83,8 +86,9 @@ Start timesync daemon
     Run Command            timedatectl -a
 
 Restart timesync daemon
-    Run Command            systemctl restart systemd-timesyncd.service  sudo=True
-    Verify service status  service=systemd-timesyncd.service  expected_state=active  expected_substate=running
+    [Arguments]            ${service_name}=systemd-timesyncd.service
+    Run Command            systemctl restart ${service_name}  sudo=True
+    Verify service status  service=${service_name}  expected_state=active  expected_substate=running
     Run Command            timedatectl -a
 
 Check that time is correct

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -2,21 +2,22 @@
 
 ## Active SKIPS
 
-| DATE SET   | TEST CASE                                    | TICKET / Additional Data                                                | Error Log Context        |
-| ---------- | -------------------------------------------- | ----------------------------------------------------------------------- | ------------------------ |
-| 20.07.2026 | nvpmodel check test (Orin AGX)               | SSRCSP-8712                                                             | (Fails every time)       |
-| 17.07.2026 | Shutdown from power menu (Lenovo X1)         | SSRCSP-8714                                                             | Slow shutdown            |
-| 06.07.2026 | Open video with COSMIC Media Player          | SSRCSP-8367                                                             | Crash in media-vm        |
-| 01.07.2026 | Account lockout after failed GUI login       | Test under development                                                  | Account lockout          |
-| 25.05.2026 | Reboot from power menu                       | SSRCSP-8490                                                             | Power menu reboot failed |
-| 13.05.2026 | Validate Forward Secure Sealing              | SSRCSP-8425                                                             | FSS test failed          |
-| 30.04.2026 | Open PDF from VM                             | SSRCSP-8367                                                             | Crash in media-vm        |
-| 23.03.2026 | Verify camera block persisted (Lenovo X1)    | SSRCSP-8224                                                             | Camera persistence       |
-| 17.03.2026 | OP-TEE xtest 1006, OP-TEE xtest 1024 (Orins) | SSRCSP-8198                                                             | (Fails every time)       |
-| 11.02.2026 | Check device id (storeDisk)                  | SSRCSP-7997                                                             | (Fails every time)       |
-| 11.02.2026 | Check net-vm hostname (storeDisk)            | SSRCSP-7997                                                             | (Fails every time)       |
-| 16.09.2025 | Check systemctl status in every VM           | [List of skips](/Robot-Framework/test-suites/functional-tests/vm.robot) | Systemctl status         |
-| 21.12.2023 | OP-TEE xtest 1033, OP-TEE xtest 1008 (Orins) | These tests have never passed                                           | (Fails every time)       |
+| DATE SET   | TEST CASE                                    | TICKET / Additional Data                                                                                   | Error Log Context        |
+|------------| -------------------------------------------- |------------------------------------------------------------------------------------------------------------|--------------------------|
+| 05.08.2026 | Ghaf Control Panel shows device information  | SSRCSP-8770 (GUI shows "unknown")                                                                          | (fails most of the time) |
+| 20.07.2026 | nvpmodel check test (Orin AGX)               | SSRCSP-8712                                                                                                | (Fails every time)       |
+| 17.07.2026 | Shutdown from power menu (Lenovo X1)         | SSRCSP-8714                                                                                                | Slow shutdown            |
+| 06.07.2026 | Open video with COSMIC Media Player          | SSRCSP-8367                                                                                                | Crash in media-vm        |
+| 01.07.2026 | Account lockout after failed GUI login       | Test under development                                                                                     | Account lockout          |
+| 25.05.2026 | Reboot from power menu                       | SSRCSP-8490                                                                                                | Power menu reboot failed |
+| 13.05.2026 | Validate Forward Secure Sealing              | SSRCSP-8425                                                                                                | FSS test failed          |
+| 30.04.2026 | Open PDF from VM                             | SSRCSP-8367                                                                                                | Crash in media-vm        |
+| 23.03.2026 | Verify camera block persisted (Lenovo X1)    | SSRCSP-8224                                                                                                | Camera persistence       |
+| 17.03.2026 | OP-TEE xtest 1006, OP-TEE xtest 1024 (Orins) | SSRCSP-8198                                                                                                | (Fails every time)       |
+| 11.02.2026 | Check device id (storeDisk)                  | SSRCSP-7997                                                                                                | (Fails every time)       |
+| 11.02.2026 | Check net-vm hostname (storeDisk)            | SSRCSP-7997                                                                                                | (Fails every time)       |
+| 16.09.2025 | Check systemctl status in every VM           | [List of skips](/Robot-Framework/test-suites/functional-tests/vm.robot)                                    | Systemctl status         |
+| 21.12.2023 | OP-TEE xtest 1033, OP-TEE xtest 1008 (Orins) | These tests have never passed                                                                              | (Fails every time)       |
 
 ## Old Dell 7330 skips
 


### PR DESCRIPTION
Skip for known issue: https://jira.tii.ae/browse/SSRCSP-8770

Net-vm is now fleet time server, using chronyd.service instead of systemd-timesyncd.service. In 'Update system time from internet in VMs' we need to restart chronyd.service in net-vm, other vms syncing via systemd-timesyncd.service.

https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7319/