### PR TITLE
Skip for grafana init check

### DIFF
--- a/Robot-Framework/test-suites/security-tests/logging.robot
+++ b/Robot-Framework/test-suites/security-tests/logging.robot
@@ -33,11 +33,13 @@ User password is not revealed in Grafana
 Check Grafana log forwarding after disconnected state
     [Documentation]  Check that logs are sent to Grafana from time of disconnection during previous boot
     [Tags]           SP-T283  orin-agx  orin-agx-64  orin-nx  lab-only
+    ${initial_check_passed}    Set Variable    ${False}
     Switch to vm      ${ADMIN_VM}
     ${id}             Get Actual Device ID
     Log To Console    Creating log entry and verifying forwarding to grafana
     Run Command       logger --priority=user.info "logtest0_${BUILD_ID}"    sudo=True
     Wait Until Keyword Succeeds  60s  5s  Check VM Log on Grafana  ${id}  ${ADMIN_VM}  2m  ${True}  logtest0_${BUILD_ID}
+    ${initial_check_passed}    Set Variable    ${True}
     Log To Console    Initial check for log forwarding passed
 
     Log To Console    Blocking log forwarding from admin-vm
@@ -61,6 +63,7 @@ Check Grafana log forwarding after disconnected state
     END
     Wait Until Keyword Succeeds  120s  5s  Check VM Log on Grafana     ${id}   ${ADMIN_VM}   5m   ${True}   logtest1_${BUILD_ID}
     Log To Console               Checked that log is forwarded after clearing the iptables rule by reboot
+    [Teardown]  Skip If    not ${initial_check_passed}    Known issue: SSRCSP-7612
 
 *** Keywords ***
 

--- a/list_of_skipped_tests.md
+++ b/list_of_skipped_tests.md
@@ -2,22 +2,23 @@
 
 ## Active SKIPS
 
-| DATE SET   | TEST CASE                                    | TICKET / Additional Data                                                                                   | Error Log Context        |
-|------------| -------------------------------------------- |------------------------------------------------------------------------------------------------------------|--------------------------|
-| 05.08.2026 | Ghaf Control Panel shows device information  | SSRCSP-8770 (GUI shows "unknown")                                                                          | (fails most of the time) |
-| 20.07.2026 | nvpmodel check test (Orin AGX)               | SSRCSP-8712                                                                                                | (Fails every time)       |
-| 17.07.2026 | Shutdown from power menu (Lenovo X1)         | SSRCSP-8714                                                                                                | Slow shutdown            |
-| 06.07.2026 | Open video with COSMIC Media Player          | SSRCSP-8367                                                                                                | Crash in media-vm        |
-| 01.07.2026 | Account lockout after failed GUI login       | Test under development                                                                                     | Account lockout          |
-| 25.05.2026 | Reboot from power menu                       | SSRCSP-8490                                                                                                | Power menu reboot failed |
-| 13.05.2026 | Validate Forward Secure Sealing              | SSRCSP-8425                                                                                                | FSS test failed          |
-| 30.04.2026 | Open PDF from VM                             | SSRCSP-8367                                                                                                | Crash in media-vm        |
-| 23.03.2026 | Verify camera block persisted (Lenovo X1)    | SSRCSP-8224                                                                                                | Camera persistence       |
-| 17.03.2026 | OP-TEE xtest 1006, OP-TEE xtest 1024 (Orins) | SSRCSP-8198                                                                                                | (Fails every time)       |
-| 11.02.2026 | Check device id (storeDisk)                  | SSRCSP-7997                                                                                                | (Fails every time)       |
-| 11.02.2026 | Check net-vm hostname (storeDisk)            | SSRCSP-7997                                                                                                | (Fails every time)       |
-| 16.09.2025 | Check systemctl status in every VM           | [List of skips](/Robot-Framework/test-suites/functional-tests/vm.robot)                                    | Systemctl status         |
-| 21.12.2023 | OP-TEE xtest 1033, OP-TEE xtest 1008 (Orins) | These tests have never passed                                                                              | (Fails every time)       |
+| DATE SET   | TEST CASE                                              | TICKET / Additional Data                                                | Error Log Context        |
+|------------|--------------------------------------------------------|-------------------------------------------------------------------------|--------------------------|
+| 05.08.2026 | Check Grafana log forwarding after disconnected state  | SSRCSP-7612                                                             | (fails often)            |
+| 05.08.2026 | Ghaf Control Panel shows device information            | SSRCSP-8770 (GUI shows "unknown")                                       | (fails most of the time) |
+| 20.07.2026 | nvpmodel check test (Orin AGX)                         | SSRCSP-8712                                                             | (Fails every time)       |
+| 17.07.2026 | Shutdown from power menu (Lenovo X1)                   | SSRCSP-8714                                                             | Slow shutdown            |
+| 06.07.2026 | Open video with COSMIC Media Player                    | SSRCSP-8367                                                             | Crash in media-vm        |
+| 01.07.2026 | Account lockout after failed GUI login                 | Test under development                                                  | Account lockout          |
+| 25.05.2026 | Reboot from power menu                                 | SSRCSP-8490                                                             | Power menu reboot failed |
+| 13.05.2026 | Validate Forward Secure Sealing                        | SSRCSP-8425                                                             | FSS test failed          |
+| 30.04.2026 | Open PDF from VM                                       | SSRCSP-8367                                                             | Crash in media-vm        |
+| 23.03.2026 | Verify camera block persisted (Lenovo X1)              | SSRCSP-8224                                                             | Camera persistence       |
+| 17.03.2026 | OP-TEE xtest 1006, OP-TEE xtest 1024 (Orins)           | SSRCSP-8198                                                             | (Fails every time)       |
+| 11.02.2026 | Check device id (storeDisk)                            | SSRCSP-7997                                                             | (Fails every time)       |
+| 11.02.2026 | Check net-vm hostname (storeDisk)                      | SSRCSP-7997                                                             | (Fails every time)       |
+| 16.09.2025 | Check systemctl status in every VM                     | [List of skips](/Robot-Framework/test-suites/functional-tests/vm.robot) | Systemctl status         |
+| 21.12.2023 | OP-TEE xtest 1033, OP-TEE xtest 1008 (Orins)           | These tests have never passed                                           | (Fails every time)       |
 
 ## Old Dell 7330 skips
 


### PR DESCRIPTION
 'Check Grafana log forwarding after disconnected state' fails very ofter at initial check before the actual test. Skip the test if this happens.

https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7320/
https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7321/